### PR TITLE
Optimize symbol handling: don't add predefined symbols explicitly. 

### DIFF
--- a/src/main/java/org/nest/nestml/_symboltable/NESTMLLanguage.java
+++ b/src/main/java/org/nest/nestml/_symboltable/NESTMLLanguage.java
@@ -38,9 +38,10 @@ public class NESTMLLanguage extends NESTMLLanguageTOP {
     super("NESTML Language", FILE_ENDING);
 
     addResolver(CommonResolvingFilter.create(NeuronSymbol.class, NeuronSymbol.KIND));
-    addResolver(CommonResolvingFilter.create(TypeSymbol.class, TypeSymbol.KIND));
+    addResolver(new PredefinedTypesFilter(TypeSymbol.class, TypeSymbol.KIND));
     addResolver(CommonResolvingFilter.create(MethodSymbol.class, MethodSymbol.KIND));
     addResolver(CommonResolvingFilter.create(VariableSymbol.class, VariableSymbol.KIND));
+    addResolver(new PredefinedVariablesFilter(VariableSymbol.class, VariableSymbol.KIND));
     addResolver(CommonResolvingFilter.create(UsageSymbol.class, UsageSymbol.KIND));
 
     setModelNameCalculator(new CommonModelNameCalculator() {

--- a/src/main/java/org/nest/nestml/_symboltable/NESTMLScopeCreator.java
+++ b/src/main/java/org/nest/nestml/_symboltable/NESTMLScopeCreator.java
@@ -47,9 +47,7 @@ public class NESTMLScopeCreator extends ScopeCreatorBase {
         modelPath,
         nestmlLanguages,
         resolverConfiguration);
-    addPredefinedTypes(globalScope);
     addPredefinedFunctions(globalScope);
-    addPredefinedVariables(globalScope);
     final NESTMLSymbolTableCreator symbolTableCreator = new CommonNESTMLSymbolTableCreator(
         resolverConfiguration,
         globalScope);

--- a/src/main/java/org/nest/nestml/_symboltable/PredefinedTypesFilter.java
+++ b/src/main/java/org/nest/nestml/_symboltable/PredefinedTypesFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c)  RWTH Aachen. All rights reserved.
+ *
+ * http://www.se-rwth.de/
+ */
+package org.nest.nestml._symboltable;
+
+import de.monticore.symboltable.Symbol;
+import de.monticore.symboltable.SymbolKind;
+import de.monticore.symboltable.resolving.CommonResolvingFilter;
+import de.monticore.symboltable.resolving.ResolvingInfo;
+import org.nest.symboltable.predefined.PredefinedTypes;
+import org.nest.symboltable.symbols.TypeSymbol;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * TODO
+ *
+ * @author (last commit) $$Author$$
+ * @version $$Revision$$, $$Date$$
+ * @since TODO
+ */
+public class PredefinedTypesFilter extends CommonResolvingFilter<TypeSymbol> {
+  public PredefinedTypesFilter(
+      final Class<TypeSymbol> symbolClass,
+      final SymbolKind targetKind) {
+    super(symbolClass, targetKind);
+  }
+
+  @Override
+  public Optional<TypeSymbol> filter(
+      final ResolvingInfo resolvingInfo,
+      final String name,
+      final List<Symbol> symbols) {
+
+    return PredefinedTypes.getPredefinedTypeIfExists(name);
+  }
+
+}

--- a/src/main/java/org/nest/nestml/_symboltable/PredefinedVariablesFilter.java
+++ b/src/main/java/org/nest/nestml/_symboltable/PredefinedVariablesFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c)  RWTH Aachen. All rights reserved.
+ *
+ * http://www.se-rwth.de/
+ */
+package org.nest.nestml._symboltable;
+
+import de.monticore.symboltable.Symbol;
+import de.monticore.symboltable.SymbolKind;
+import de.monticore.symboltable.resolving.CommonResolvingFilter;
+import de.monticore.symboltable.resolving.ResolvingInfo;
+import org.nest.symboltable.predefined.PredefinedTypes;
+import org.nest.symboltable.predefined.PredefinedVariables;
+import org.nest.symboltable.symbols.TypeSymbol;
+import org.nest.symboltable.symbols.VariableSymbol;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * TODO
+ *
+ * @author (last commit) $$Author$$
+ * @version $$Revision$$, $$Date$$
+ * @since TODO
+ */
+public class PredefinedVariablesFilter extends CommonResolvingFilter<VariableSymbol> {
+  public PredefinedVariablesFilter(
+      final Class<VariableSymbol> symbolClass,
+      final SymbolKind targetKind) {
+    super(symbolClass, targetKind);
+  }
+
+  @Override
+  public Optional<VariableSymbol> filter(
+      final ResolvingInfo resolvingInfo,
+      final String name,
+      final List<Symbol> symbols) {
+
+    return PredefinedVariables.getVariableIfExists(name);
+  }
+
+}

--- a/src/main/java/org/nest/symboltable/predefined/PredefinedVariables.java
+++ b/src/main/java/org/nest/symboltable/predefined/PredefinedVariables.java
@@ -12,6 +12,7 @@ import org.nest.symboltable.symbols.TypeSymbol;
 import org.nest.symboltable.symbols.VariableSymbol;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -30,7 +31,6 @@ public class PredefinedVariables {
   static  {
     registerVariable(E_CONSTANT, PredefinedTypes.getRealType());
     registerVariable(TIME_CONSTANT, PredefinedTypes.getMS());
-
   }
 
   private static void registerVariable(
@@ -49,5 +49,13 @@ public class PredefinedVariables {
     return ImmutableSet.copyOf(name2VariableSymbol.values());
   }
 
+  public static Optional<VariableSymbol> getVariableIfExists(final String variableName) {
+    if (name2VariableSymbol.containsKey(variableName)) {
+      return Optional.of(name2VariableSymbol.get(variableName));
+    }
+    else {
+      return Optional.empty();
+    }
+  }
 
 }


### PR DESCRIPTION
…solve them via a dedicated resolving filter (thus, they don't clutter the neurons scopes.