### PR TITLE
fix sympy version check

### DIFF
--- a/src/main/resources/checks/sympyChecker.py
+++ b/src/main/resources/checks/sympyChecker.py
@@ -2,4 +2,4 @@ import sympy
 from distutils.version import LooseVersion, StrictVersion
 
 output = open('sympyVersion.tmp', 'w')
-output.write(str(LooseVersion(sympy.__version__) >= LooseVersion("1.0.0")))
+output.write(str(LooseVersion(sympy.__version__) >= LooseVersion("1.0")))


### PR DESCRIPTION
LooseVersion(sympy.\__version__) evaluates to LooseVersion("1.0") rather than LooseVersion("1.0.0") causing sympy check to fail when it should not.