### PR TITLE
Improve coco for undefined variables

### DIFF
--- a/src/main/java/org/nest/nestml/_cocos/VariableDoesNotExist.java
+++ b/src/main/java/org/nest/nestml/_cocos/VariableDoesNotExist.java
@@ -48,7 +48,7 @@ public class VariableDoesNotExist implements ODEASTOdeDeclarationCoCo {
         ode-> {
           checkVariableByName(ode.getLhs());
           ASTUtils.getAll(ode.getRhs(), ASTVariable.class)
-                  .forEach(variable -> checkVariableByName(variable.getName().toString(), node)); // it can be a D'' variable
+                  .forEach(variable -> checkVariableByName(variable.toString(), node)); // it can be a D'' variable
         }
 
     );

--- a/src/test/java/org/nest/integration/ODEProcessorTest.java
+++ b/src/test/java/org/nest/integration/ODEProcessorTest.java
@@ -61,13 +61,11 @@ public class ODEProcessorTest extends ModelbasedTest {
 
   /**
    * Parses model, builds symboltable, cleanups output folder by deleting tmp file and processes ODEs from model.i
-   * @param pathToModel
-   * @return
    */
   private Scope processModel(final String pathToModel) {
     final ASTNESTMLCompilationUnit modelRoot = parseNESTMLModel(pathToModel);
     scopeCreator.runSymbolTableCreator(modelRoot);
-    final Path outputBase = Paths.get(OUTPUT_FOLDER.toString(), Names.getPathFromQualifiedName(pathToModel.toString()));
+    final Path outputBase = Paths.get(OUTPUT_FOLDER.toString(), Names.getPathFromQualifiedName(pathToModel));
     FilesHelper.deleteFilesInFolder(outputBase);
 
     testant.solveODE(modelRoot.getNeurons().get(0), outputBase);

--- a/src/test/java/org/nest/nestml/_cocos/NESTMLCoCosTest.java
+++ b/src/test/java/org/nest/nestml/_cocos/NESTMLCoCosTest.java
@@ -600,8 +600,8 @@ public class NESTMLCoCosTest  {
         pathToInvalidModel,
         nestmlCoCoChecker,
         "NESTML_",
-        4); // TODO should be 4
-
+        5);
+    
   }
 
   @Test

--- a/src/test/resources/org/nest/nestml/_cocos/equations/invalidEquations.nestml
+++ b/src/test/resources/org/nest/nestml/_cocos/equations/invalidEquations.nestml
@@ -1,8 +1,10 @@
 neuron IAF:
   state:
     V_m mV
+    U mV
   end
   equations:
+    U' = U'
     V_m'' = t # Is that OK?
     G1 = G2 # 2 Errors: LHS is undefined, RHS is undefined
     V1' = V2 # 2 Errors: LHS is undefined, RHS is undefined


### PR DESCRIPTION
-forbid expressions like: V_m' = V_m', where there is no equations for V_m''