### PR TITLE
Corrections to NESTML models

### DIFF
--- a/models/aeif_cond_alpha.nestml
+++ b/models/aeif_cond_alpha.nestml
@@ -43,11 +43,11 @@ neuron aeif_cond_alpha_neuron:
 
     # Add aliases to simplify the equation definition of V_m
     exp_arg real = (V_m-V_th)/delta_T
-    I_spike pA = delta_T*exp(exp_arg)
+    I_spike pA = g_L*delta_T*exp(exp_arg)
     I_syn_exc pA =   cond_sum(g_ex, spikesExc) * ( V_m - E_ex )
     I_syn_inh pA =   cond_sum(g_in, spikesInh) * ( V_m - E_in )
 
-    V_m' = ( -g_L * ( ( V_m - E_L ) - I_spike ) - I_syn_exc - I_syn_inh - w + I_e + I_stim ) / C_m
+    V_m' = ( -g_L*( V_m - E_L ) + I_spike - I_syn_exc - I_syn_inh - w + I_e + I_stim ) / C_m
     w' = (a*(V_m - E_L) - w)/tau_w
 
   end
@@ -85,11 +85,11 @@ neuron aeif_cond_alpha_neuron:
 
     # Impulse to add to DG_EXC on spike arrival to evoke unit-amplitude
     # conductance excursion.
-    PSConInit_E real = 1.0 * e / tau_syn_ex
+    PSConInit_E nS/ms = 1.0 nS * e / tau_syn_ex
 
     # Impulse to add to DG_INH on spike arrival to evoke unit-amplitude
     # conductance excursion.
-    PSConInit_I real = 1.0 * e / tau_syn_in
+    PSConInit_I nS/ms = 1.0 nS * e / tau_syn_in
 
     # refractory time in steps
     RefractoryCounts integer = steps(t_ref)
@@ -109,12 +109,9 @@ neuron aeif_cond_alpha_neuron:
     integrate_odes()
 
     if r > 0: # refractory
-      r = r - 1
-    end
-
-    if r > 0: # not refractory
-      V_m = V_reset # clamp potential
-    elif V_m >= V_peak:
+      r = r - 1 # decrement refractory ticks count
+      V_m = V_reset
+    elif V_m >= V_peak: # threshold crossing detection
       r = RefractoryCounts
       V_m = V_reset # clamp potential
       w += b

--- a/models/aeif_cond_alpha.nestml
+++ b/models/aeif_cond_alpha.nestml
@@ -38,16 +38,17 @@ neuron aeif_cond_alpha_neuron:
   end
 
   equations:
+    V_bounded mV = min(V_m, V_peak) # prevent exponential divergence
     shape g_in = (e/tau_syn_in) * t * exp(-1/tau_syn_in*t)
     shape g_ex = (e/tau_syn_ex) * t * exp(-1/tau_syn_ex*t)
 
     # Add aliases to simplify the equation definition of V_m
-    exp_arg real = (V_m-V_th)/delta_T
+    exp_arg real = (V_bounded-V_th)/delta_T
     I_spike pA = g_L*delta_T*exp(exp_arg)
-    I_syn_exc pA =   cond_sum(g_ex, spikesExc) * ( V_m - E_ex )
-    I_syn_inh pA =   cond_sum(g_in, spikesInh) * ( V_m - E_in )
+    I_syn_exc pA =   cond_sum(g_ex, spikesExc) * ( V_bounded - E_ex )
+    I_syn_inh pA =   cond_sum(g_in, spikesInh) * ( V_bounded - E_in )
 
-    V_m' = ( -g_L*( V_m - E_L ) + I_spike - I_syn_exc - I_syn_inh - w + I_e + I_stim ) / C_m
+    V_m' = ( -g_L*( V_bounded - E_L ) + I_spike - I_syn_exc - I_syn_inh - w + I_e + I_stim ) / C_m
     w' = (a*(V_m - E_L) - w)/tau_w
 
   end

--- a/models/aeif_cond_alpha_implicit.nestml
+++ b/models/aeif_cond_alpha_implicit.nestml
@@ -52,11 +52,11 @@ neuron aeif_cond_alpha_implicit:
 
     # Add aliases to simplify the equation definition of V_m
     exp_arg real = (V_m-V_th)/delta_T
-    I_spike pA = delta_T*exp(exp_arg)
+    I_spike pA = g_L*delta_T*exp(exp_arg)
     I_syn_exc pA =   cond_sum(g_ex, spikesExc) * ( V_m - E_ex )
     I_syn_inh pA =   cond_sum(g_in, spikesInh) * ( V_m - E_in )
 
-    V_m' = ( -g_L * ( ( V_m - E_L ) - I_spike ) - I_syn_exc - I_syn_inh - w + I_e + I_stim ) / C_m
+    V_m' = ( -g_L*( V_m - E_L ) + I_spike - I_syn_exc - I_syn_inh - w + I_e + I_stim ) / C_m
 
   end
 
@@ -93,11 +93,11 @@ neuron aeif_cond_alpha_implicit:
 
     # Impulse to add to DG_EXC on spike arrival to evoke unit-amplitude
     # conductance excursion.
-    PSConInit_E real = 1.0 * e / tau_syn_ex
+    PSConInit_E nS/ms = 1.0 nS * e / tau_syn_ex
 
     # Impulse to add to DG_INH on spike arrival to evoke unit-amplitude
     # conductance excursion.
-    PSConInit_I real = 1.0 * e / tau_syn_in
+    PSConInit_I nS/ms = 1.0 nS * e / tau_syn_in
 
     # refractory time in steps
     RefractoryCounts integer = steps(t_ref)
@@ -117,12 +117,9 @@ neuron aeif_cond_alpha_implicit:
     integrate_odes()
 
     if r > 0: # refractory
-      r = r - 1
-    end
-
-    if r > 0: # not refractory
+      r -= 1 # decrement refractory ticks count
       V_m = V_reset # clamp potential
-    elif V_m >= V_peak:
+    elif V_m >= V_peak: # threshold crossing detection
       r = RefractoryCounts
       V_m = V_reset # clamp potential
       w += b

--- a/models/aeif_cond_alpha_implicit.nestml
+++ b/models/aeif_cond_alpha_implicit.nestml
@@ -34,12 +34,13 @@ neuron aeif_cond_alpha_implicit:
 
   state:
     V_m mV = E_L      # Membrane potential
-    w pA = 0pA        # Spike-adaptation current
-    g_in nS = 0nS     # Excitatory synaptic conductance
-    g_ex nS = 0nS     # Inhibitory synaptic conductance in nS
+    w pA = 0 pA        # Spike-adaptation current
+    g_in nS = 0 nS     # Excitatory synaptic conductance
+    g_ex nS = 0 nS     # Inhibitory synaptic conductance in nS
   end
 
   equations:
+    V_bounded mV = min(V_m, V_peak) # prevent exponential divergence
     # alpha function for the g_in
     g_in'' = -g_in'/tau_syn_in
     g_in' = g_in' - g_in/tau_syn_in
@@ -48,16 +49,14 @@ neuron aeif_cond_alpha_implicit:
     g_ex'' = -g_ex'/tau_syn_ex
     g_ex' = g_ex' - g_ex/tau_syn_ex
 
-    w' = (a*(V_m - E_L) - w)/tau_w
-
     # Add aliases to simplify the equation definition of V_m
-    exp_arg real = (V_m-V_th)/delta_T
+    exp_arg real = (V_bounded-V_th)/delta_T
     I_spike pA = g_L*delta_T*exp(exp_arg)
-    I_syn_exc pA =   cond_sum(g_ex, spikesExc) * ( V_m - E_ex )
-    I_syn_inh pA =   cond_sum(g_in, spikesInh) * ( V_m - E_in )
+    I_syn_exc pA =   cond_sum(g_ex, spikesExc) * ( V_bounded - E_ex )
+    I_syn_inh pA =   cond_sum(g_in, spikesInh) * ( V_bounded - E_in )
 
-    V_m' = ( -g_L*( V_m - E_L ) + I_spike - I_syn_exc - I_syn_inh - w + I_e + I_stim ) / C_m
-
+    V_m' = ( -g_L*( V_bounded - E_L ) + I_spike - I_syn_exc - I_syn_inh - w + I_e + I_stim ) / C_m
+    w' = (a*(V_bounded - E_L) - w)/tau_w
   end
 
   parameters:

--- a/models/aeif_cond_alpha_implicit.nestml
+++ b/models/aeif_cond_alpha_implicit.nestml
@@ -46,7 +46,7 @@ neuron aeif_cond_alpha_implicit:
 
     # alpha function for the g_ex
     g_ex'' = -g_ex'/tau_syn_ex
-    g_ex' = g_ex'  -g_ex/tau_syn_ex
+    g_ex' = g_ex' - g_ex/tau_syn_ex
 
     w' = (a*(V_m - E_L) - w)/tau_w
 
@@ -62,31 +62,31 @@ neuron aeif_cond_alpha_implicit:
 
   parameters:
     # membrane parameters
-    C_m   pF = 281.0pF       # Membrane Capacitance in pF
-    t_ref ms = 0.0ms         # Refractory period in ms
-    V_reset mV = -60.0mV     # Reset Potential in mV
-    g_L nS = 30.0nS          # Leak Conductance in nS
-    E_L mV = -70.6mV         # Leak reversal Potential (aka resting potential) in mV
-    I_e pA = 0pA             # Constant Current in pA
+    C_m pF = 281.0 pF         # Membrane Capacitance in pF
+    t_ref ms = 0.0 ms         # Refractory period in ms
+    V_reset mV = -60.0 mV     # Reset Potential in mV
+    g_L nS = 30.0 nS          # Leak Conductance in nS
+    E_L mV = -70.6 mV         # Leak reversal Potential (aka resting potential) in mV
+    I_e pA = 0 pA             # Constant Current in pA
 
     # spike adaptation parameters
-    a nS = 4nS               # Subthreshold adaptation
-    b pA = 80.5pA            # pike-triggered adaptation
-    delta_T mV = 2.0mV       # Slope factor
-    tau_w ms = 144.0ms       # Adaptation time constant
-    V_th mV = -50.4mV        # Threshold Potential in mV
-    V_peak mV = 0mV          # Spike detection threshold
+    a nS = 4 nS               # Subthreshold adaptation
+    b pA = 80.5 pA            # pike-triggered adaptation
+    delta_T mV = 2.0 mV       # Slope factor
+    tau_w ms = 144.0 ms       # Adaptation time constant
+    V_th mV = -50.4 mV        # Threshold Potential in mV
+    V_peak mV = 0 mV          # Spike detection threshold
 
     # synaptic parameters
-    E_ex mV = 0mV            # Excitatory reversal Potential in mV
-    tau_syn_ex ms = 0.2ms    # Synaptic Time Constant Excitatory Synapse in ms
-    E_in mV = -85.0mV        # Inhibitory reversal Potential in mV
-    tau_syn_in ms = 2.0ms    # Synaptic Time Constant for Inhibitory Synapse in ms
+    E_ex mV = 0 mV            # Excitatory reversal Potential in mV
+    tau_syn_ex ms = 0.2 ms    # Synaptic Time Constant Excitatory Synapse in ms
+    E_in mV = -85.0 mV        # Inhibitory reversal Potential in mV
+    tau_syn_in ms = 2.0 ms    # Synaptic Time Constant for Inhibitory Synapse in ms
 
     # Input current injected by CurrentEvent.
     # This variable is used to transport the current applied into the
     # _dynamics function computing the derivative of the state vector.
-    I_stim pA = 0pA
+    I_stim pA = 0 pA
   end
 
   internals:

--- a/models/aeif_cond_exp.nestml
+++ b/models/aeif_cond_exp.nestml
@@ -46,11 +46,11 @@ neuron aeif_cond_exp_neuron:
 
     # Add aliases to simplify the equation definition of V_m
     exp_arg real = (V_m-V_th)/delta_T
-    I_spike pA = delta_T*exp(exp_arg)
+    I_spike pA = g_L*delta_T*exp(exp_arg)
     I_syn_exc pA = cond_sum(g_ex, spikeExc) * ( V_m - E_ex )
     I_syn_inh pA = cond_sum(g_in, spikeInh) * ( V_m - E_in )
 
-    V_m' = ( -g_L * ( ( V_m - E_L ) - I_spike ) - I_syn_exc - I_syn_inh - w + I_e + I_stim ) / C_m
+    V_m' = ( -g_L*( V_m - E_L ) + I_spike - I_syn_exc - I_syn_inh - w + I_e + I_stim ) / C_m
     w' = (a*(V_m - E_L) - w)/tau_w
   end
 
@@ -102,13 +102,10 @@ neuron aeif_cond_exp_neuron:
     integrate_odes()
 
     if r > 0: # refractory
-      r = r - 1
-    end
-
-    if r > 0: # not refractory
+      r -= 1 # decrement refractory ticks count
       V_m = V_reset # clamp potential
-    elif V_m >= V_peak:
-      r = RefractoryCounts
+    elif V_m >= V_peak: # threshold crossing detection
+      r = RefractoryCounts + 1
       V_m = V_reset # clamp potential
       w += b
       emit_spike()

--- a/models/aeif_cond_exp.nestml
+++ b/models/aeif_cond_exp.nestml
@@ -41,17 +41,18 @@ neuron aeif_cond_exp_neuron:
   end
 
   equations:
+    V_bounded mV = min(V_m, V_peak) # prevent exponential divergence
     shape g_in = exp(-1/tau_syn_in*t)
     shape g_ex = exp(-1/tau_syn_ex*t)
 
     # Add aliases to simplify the equation definition of V_m
-    exp_arg real = (V_m-V_th)/delta_T
+    exp_arg real = (V_bounded-V_th)/delta_T
     I_spike pA = g_L*delta_T*exp(exp_arg)
-    I_syn_exc pA = cond_sum(g_ex, spikeExc) * ( V_m - E_ex )
-    I_syn_inh pA = cond_sum(g_in, spikeInh) * ( V_m - E_in )
+    I_syn_exc pA = cond_sum(g_ex, spikeExc) * ( V_bounded - E_ex )
+    I_syn_inh pA = cond_sum(g_in, spikeInh) * ( V_bounded - E_in )
 
-    V_m' = ( -g_L*( V_m - E_L ) + I_spike - I_syn_exc - I_syn_inh - w + I_e + I_stim ) / C_m
-    w' = (a*(V_m - E_L) - w)/tau_w
+    V_m' = ( -g_L*( V_bounded - E_L ) + I_spike - I_syn_exc - I_syn_inh - w + I_e + I_stim ) / C_m
+    w' = (a*(V_bounded - E_L) - w)/tau_w
   end
 
   parameters:

--- a/models/aeif_cond_exp_implicit.nestml
+++ b/models/aeif_cond_exp_implicit.nestml
@@ -51,11 +51,11 @@ neuron aeif_cond_exp_implicit:
 
     # Add aliases to simplify the equation definition of V_m
     exp_arg real = (V_m-V_th)/delta_T
-    I_spike pA = delta_T*exp(exp_arg)
+    I_spike pA = g_L*delta_T*exp(exp_arg)
     I_syn_exc pA = cond_sum(g_ex, spikeExc) * ( V_m - E_ex )
     I_syn_inh pA = cond_sum(g_in, spikeInh) * ( V_m - E_in )
 
-    V_m' = ( -g_L * ( ( V_m - E_L ) - I_spike ) - I_syn_exc - I_syn_inh - w + I_e + I_stim ) / C_m
+    V_m' = ( -g_L*( V_m - E_L ) + I_spike - I_syn_exc - I_syn_inh - w + I_e + I_stim ) / C_m
   end
 
   parameters:
@@ -106,12 +106,9 @@ neuron aeif_cond_exp_implicit:
     integrate_odes()
 
     if r > 0: # refractory
-      r = r - 1
-    end
-
-    if r > 0: # not refractory
-      V_m = V_reset # clamp potential
-    elif V_m >= V_peak:
+      r -= 1 # decrement refractory ticks count
+      V_m = V_reset
+    elif V_m >= V_peak: # threshold crossing detection
       r = RefractoryCounts
       V_m = V_reset # clamp potential
       w += b

--- a/models/aeif_cond_exp_implicit.nestml
+++ b/models/aeif_cond_exp_implicit.nestml
@@ -43,19 +43,19 @@ neuron aeif_cond_exp_implicit:
   end
 
   equations:
+    V_bounded mV = min(V_m, V_peak) # prevent exponential divergence
     # exp function for the g_in, g_ex
     g_in' = -g_in/tau_syn_in
     g_ex' = -g_ex/tau_syn_ex
 
-    w' = (a*(V_m - E_L) - w)/tau_w
-
     # Add aliases to simplify the equation definition of V_m
-    exp_arg real = (V_m-V_th)/delta_T
+    exp_arg real = (V_bounded-V_th)/delta_T
     I_spike pA = g_L*delta_T*exp(exp_arg)
-    I_syn_exc pA = cond_sum(g_ex, spikeExc) * ( V_m - E_ex )
-    I_syn_inh pA = cond_sum(g_in, spikeInh) * ( V_m - E_in )
+    I_syn_exc pA = cond_sum(g_ex, spikeExc) * ( V_bounded - E_ex )
+    I_syn_inh pA = cond_sum(g_in, spikeInh) * ( V_bounded - E_in )
 
-    V_m' = ( -g_L*( V_m - E_L ) + I_spike - I_syn_exc - I_syn_inh - w + I_e + I_stim ) / C_m
+    V_m' = ( -g_L*( V_bounded - E_L ) + I_spike - I_syn_exc - I_syn_inh - w + I_e + I_stim ) / C_m
+    w' = (a*(V_bounded - E_L) - w)/tau_w
   end
 
   parameters:

--- a/models/hh_psc_alpha.nestml
+++ b/models/hh_psc_alpha.nestml
@@ -63,11 +63,11 @@ neuron hh_psc_alpha_neuron:
 
   equations:
     # synapses: alpha functions
-    shape g_in = (e/tau_syn_in) * t * exp(-1/tau_syn_in*t)
-    shape g_ex = (e/tau_syn_ex) * t * exp(-1/tau_syn_ex*t)
+    shape I_in = 1 pA * (e/tau_syn_in) * t * exp(-1/tau_syn_in*t)
+    shape I_ex = 1 pA * (e/tau_syn_ex) * t * exp(-1/tau_syn_ex*t)
 
-    I_syn_exc pA = curr_sum(g_ex, spikeExc)
-    I_syn_inh pA = curr_sum(g_in, spikeExc)
+    I_syn_exc pA = curr_sum(I_ex, spikeExc)
+    I_syn_inh pA = curr_sum(I_in, spikeExc)
     I_Na  pA = g_Na * Act_m * Act_m * Act_m * Act_h * ( V_m - E_Na )
     I_K   pA  = g_K * Inact_n * Inact_n * Inact_n * Inact_n * ( V_m - E_K )
     I_L   pA = g_L * ( V_m - E_L )
@@ -106,11 +106,11 @@ neuron hh_psc_alpha_neuron:
   internals:
     # Impulse to add to DG_EXC on spike arrival to evoke unit-amplitude
     # conductance excursion.
-    PSConInit_E real = 1.0 * e / tau_syn_ex
+    PSConInit_E pA/ms = 1.0 pA * e / tau_syn_ex
 
     # Impulse to add to DG_INH on spike arrival to evoke unit-amplitude
     # conductance excursion.
-    PSConInit_I real = 1.0 * e / tau_syn_in
+    PSConInit_I pA/ms = 1.0 pA * e / tau_syn_in
 
 
     RefractoryCounts integer = steps(t_ref) # refractory time in steps

--- a/models/hh_psc_alpha_implicit.nestml
+++ b/models/hh_psc_alpha_implicit.nestml
@@ -146,7 +146,7 @@ neuron hh_psc_alpha_implicit:
       emit_spike()
     end
 
-    I_stim = currents.get_sum()
+    I_stim = currents
 
     I_ex' += spikeExc.get_sum() * PSConInit_E
     I_in' += spikeInh.get_sum() * PSConInit_I

--- a/models/hh_psc_alpha_implicit.nestml
+++ b/models/hh_psc_alpha_implicit.nestml
@@ -48,8 +48,8 @@ neuron hh_psc_alpha_implicit:
 
   state:
     V_m mV = -65. mV # Membrane potential
-    g_ex pA  # inputs from the exc conductance
-    g_in pA  # inputs from the inh conductance
+    I_ex pA  # inputs from the exc conductance
+    I_in pA  # inputs from the inh conductance
 
     alias alpha_n_init real = ( 0.01 * ( V_m + 55. ) ) / ( 1. - exp( -( V_m + 55. ) / 10. ) )
     alias beta_n_init  real = 0.125 * exp( -( V_m + 65. ) / 80. )
@@ -65,14 +65,14 @@ neuron hh_psc_alpha_implicit:
 
   equations:
     # synapses: alpha functions
-    g_ex'' = -g_ex' / tau_syn_ex
-    g_ex' = g_ex' - ( g_ex / tau_syn_ex )
+    I_ex'' = -I_ex' / tau_syn_ex
+    I_ex' = I_ex' - ( I_ex / tau_syn_ex )
 
-    g_in'' = -g_in' / tau_syn_in
-    g_in' = g_in' - ( g_in / tau_syn_in )
+    I_in'' = -I_in' / tau_syn_in
+    I_in' = I_in' - ( I_in / tau_syn_in )
 
-    I_syn_exc pA = curr_sum(g_ex, spikeExc)
-    I_syn_inh pA = curr_sum(g_in, spikeExc)
+    I_syn_exc pA = curr_sum(I_ex, spikeExc)
+    I_syn_inh pA = curr_sum(I_in, spikeExc)
     I_Na  pA = g_Na * Act_m * Act_m * Act_m * Act_h * ( V_m - E_Na )
     I_K   pA  = g_K * Inact_n * Inact_n * Inact_n * Inact_n * ( V_m - E_K )
     I_L   pA = g_L * ( V_m - E_L )
@@ -111,11 +111,11 @@ neuron hh_psc_alpha_implicit:
   internals:
     # Impulse to add to DG_EXC on spike arrival to evoke unit-amplitude
     # conductance excursion.
-    PSConInit_E real = 1.0 * e / tau_syn_ex
+    PSConInit_E pA/ms = 1.0 pA * e / tau_syn_ex
 
     # Impulse to add to DG_INH on spike arrival to evoke unit-amplitude
     # conductance excursion.
-    PSConInit_I real = 1.0 * e / tau_syn_in
+    PSConInit_I pA/ms = 1.0 pA * e / tau_syn_in
 
 
     RefractoryCounts integer = steps(t_ref) # refractory time in steps
@@ -124,7 +124,7 @@ neuron hh_psc_alpha_implicit:
    # Input current injected by CurrentEvent.
    # This variable is used to transport the current applied into the
    # _dynamics function computing the derivative of the state vector.
-   I_stim pA = 0pA
+   I_stim pA = 0 pA
   end
 
   input:
@@ -148,8 +148,8 @@ neuron hh_psc_alpha_implicit:
 
     I_stim = currents.get_sum()
 
-    g_ex' += spikeExc.get_sum() * PSConInit_E
-    g_in' += spikeInh.get_sum() * PSConInit_I
+    I_ex' += spikeExc.get_sum() * PSConInit_E
+    I_in' += spikeInh.get_sum() * PSConInit_I
   end
 
 end

--- a/models/iaf_cond_alpha.nestml
+++ b/models/iaf_cond_alpha.nestml
@@ -90,7 +90,7 @@ neuron iaf_cond_alpha_neuron:
       emit_spike()
     end
     # set new input current
-    I_stim = currents.get_sum()
+    I_stim = currents
   end
 
 end

--- a/models/iaf_cond_alpha.nestml
+++ b/models/iaf_cond_alpha.nestml
@@ -90,7 +90,7 @@ neuron iaf_cond_alpha_neuron:
       emit_spike()
     end
     # set new input current
-    I_stim = currents
+    I_stim = currents.get_sum()
   end
 
 end

--- a/models/iaf_cond_beta.nestml
+++ b/models/iaf_cond_beta.nestml
@@ -23,8 +23,8 @@ SeeAlso: iaf_cond_exp, iaf_cond_beta_mc, iaf_cond_alpha */
 neuron iaf_cond_beta_neuron:
   state:
     V_m mV = E_L # membrane potential
-    GI nS = 0 # inputs from the inh conductance
-    GE nS = 0 # inputs from the exc conductance
+    GI nS = 0 nS # inputs from the inh conductance
+    GE nS = 0 nS # inputs from the exc conductance
 
   end
 

--- a/models/iaf_cond_exp.nestml
+++ b/models/iaf_cond_exp.nestml
@@ -42,9 +42,9 @@ neuron iaf_cond_exp_neuron:
   parameters:
     V_th mV = -55.0mV    # Threshold Potential in mV
     V_reset mV = -60.0mV # Reset Potential in mV
-    t_ref ms = 2.0mV     # Refractory period in ms
+    t_ref ms = 2.0 ms     # Refractory period in ms
     g_L nS = 16.6667nS   # Leak Conductance in nS
-    C_m pF = 250.0       # Membrane Capacitance in pF
+    C_m pF = 250.0 pF      # Membrane Capacitance in pF
     E_ex mV = 0mV        # Excitatory reversal Potential in mV
     E_in mV = -85.0mV    # Inhibitory reversal Potential in mV
     E_L mV = -70.0mV     # Leak reversal Potential (aka resting potential) in mV
@@ -57,14 +57,6 @@ neuron iaf_cond_exp_neuron:
   end
 
   internals:
-    # Impulse to add to g_ex' on spike arrival to evoke unit-amplitude
-    # conductance excursion.
-    PSConInit_E real = 1.0 * e / tau_syn_ex
-
-    # Impulse to add to g_in' on spike arrival to evoke unit-amplitude
-    # conductance excursion.
-    PSConInit_I real = 1.0 * e / tau_syn_in
-
     RefractoryCounts integer = steps(t_ref) # refractory time in steps
     r integer                               # counts number of tick during the refractory period
   end

--- a/models/iaf_psc_alpha.nestml
+++ b/models/iaf_psc_alpha.nestml
@@ -80,8 +80,8 @@ neuron iaf_psc_alpha_neuron:
   end
 
   equations:
-    shape I_shape_in = (e/tau_syn_in) * t * exp(-1/tau_syn_in*t)
-    shape I_shape_ex = (e/tau_syn_ex) * t * exp(-1/tau_syn_ex*t)
+    shape I_shape_in = 1 pA * (e/tau_syn_in) * t * exp(-1/tau_syn_in*t)
+    shape I_shape_ex = 1 pA * (e/tau_syn_ex) * t * exp(-1/tau_syn_ex*t)
 
     V_abs' = -1/Tau * V_abs + 1/C_m * (curr_sum(I_shape_in, in_spikes) + curr_sum(I_shape_ex, ex_spikes) + I_e + currents)
   end

--- a/models/iaf_psc_alpha_multisynapse.nestml
+++ b/models/iaf_psc_alpha_multisynapse.nestml
@@ -36,7 +36,7 @@ neuron iaf_psc_alpha_multisynapse_neuron:
   end
 
   equations:
-      shape I_shape = (e/tau_syn) * t * exp(-1/tau_syn*t)
+      shape I_shape = 1 pA * (e/tau_syn) * t * exp(-1/tau_syn*t)
       V_abs' = -1/tau_m * V_abs + 1/C_m * (curr_sum(I_shape, spikes) + I_e + currents)
   end
 

--- a/models/izhikevich.nestml
+++ b/models/izhikevich.nestml
@@ -69,7 +69,6 @@ neuron izhikevich_neuron:
   output: spike
 
   update:
-    I = currents.get_sum()
     integrate_odes()
     # Add synaptic current
     V_m += spikes.get_sum()
@@ -84,6 +83,7 @@ neuron izhikevich_neuron:
       emit_spike()
     end
 
+    I = currents.get_sum()
   end
 
 end

--- a/models/izhikevich.nestml
+++ b/models/izhikevich.nestml
@@ -83,7 +83,7 @@ neuron izhikevich_neuron:
       emit_spike()
     end
 
-    I = currents.get_sum()
+    I = currents
   end
 
 end


### PR DESCRIPTION
Corrections to NESTML models

* All *_alpha models:
    - corrected the unit of the spike normalization constant
* AEIF models:
    - corrected the I_spike to an actual current
* hh_psc_alpha(_implicit):
    - corrected ``g_ex/in`` to ``I_ex/in``