### PR TITLE
Names corrections + work on Izhikevitch

### DIFF
--- a/models/aeif_cond_alpha.nestml
+++ b/models/aeif_cond_alpha.nestml
@@ -43,8 +43,8 @@ neuron aeif_cond_alpha_neuron:
     shape g_ex = (e/tau_syn_ex) * t * exp(-1/tau_syn_ex*t)
 
     # Add aliases to simplify the equation definition of V_m
-    exp_arg real = (V_bounded-V_th)/delta_T
-    I_spike pA = g_L*delta_T*exp(exp_arg)
+    exp_arg real = (V_bounded-V_th)/Delta_T
+    I_spike pA = g_L*Delta_T*exp(exp_arg)
     I_syn_exc pA =   cond_sum(g_ex, spikesExc) * ( V_bounded - E_ex )
     I_syn_inh pA =   cond_sum(g_in, spikesInh) * ( V_bounded - E_in )
 
@@ -65,7 +65,7 @@ neuron aeif_cond_alpha_neuron:
     # spike adaptation parameters
     a nS = 4nS               # Subthreshold adaptation
     b pA = 80.5pA            # pike-triggered adaptation
-    delta_T mV = 2.0mV       # Slope factor
+    Delta_T mV = 2.0mV       # Slope factor
     tau_w ms = 144.0ms       # Adaptation time constant
     V_th mV = -50.4mV        # Threshold Potential in mV
     V_peak mV = 0mV          # Spike detection threshold

--- a/models/aeif_cond_alpha_implicit.nestml
+++ b/models/aeif_cond_alpha_implicit.nestml
@@ -50,8 +50,8 @@ neuron aeif_cond_alpha_implicit:
     g_ex' = g_ex' - g_ex/tau_syn_ex
 
     # Add aliases to simplify the equation definition of V_m
-    exp_arg real = (V_bounded-V_th)/delta_T
-    I_spike pA = g_L*delta_T*exp(exp_arg)
+    exp_arg real = (V_bounded-V_th)/Delta_T
+    I_spike pA = g_L*Delta_T*exp(exp_arg)
     I_syn_exc pA =   cond_sum(g_ex, spikesExc) * ( V_bounded - E_ex )
     I_syn_inh pA =   cond_sum(g_in, spikesInh) * ( V_bounded - E_in )
 
@@ -71,7 +71,7 @@ neuron aeif_cond_alpha_implicit:
     # spike adaptation parameters
     a nS = 4 nS               # Subthreshold adaptation
     b pA = 80.5 pA            # pike-triggered adaptation
-    delta_T mV = 2.0 mV       # Slope factor
+    Delta_T mV = 2.0 mV       # Slope factor
     tau_w ms = 144.0 ms       # Adaptation time constant
     V_th mV = -50.4 mV        # Threshold Potential in mV
     V_peak mV = 0 mV          # Spike detection threshold

--- a/models/aeif_cond_exp.nestml
+++ b/models/aeif_cond_exp.nestml
@@ -37,7 +37,7 @@ neuron aeif_cond_exp_neuron:
 
   state:
     V_m mV = E_L  # Membrane potential
-    w pA = 0pA    # Spike-adaptation current
+    w pA = 0 pA    # Spike-adaptation current
   end
 
   equations:
@@ -46,8 +46,8 @@ neuron aeif_cond_exp_neuron:
     shape g_ex = exp(-1/tau_syn_ex*t)
 
     # Add aliases to simplify the equation definition of V_m
-    exp_arg real = (V_bounded-V_th)/delta_T
-    I_spike pA = g_L*delta_T*exp(exp_arg)
+    exp_arg real = (V_bounded-V_th)/Delta_T
+    I_spike pA = g_L*Delta_T*exp(exp_arg)
     I_syn_exc pA = cond_sum(g_ex, spikeExc) * ( V_bounded - E_ex )
     I_syn_inh pA = cond_sum(g_in, spikeInh) * ( V_bounded - E_in )
 
@@ -67,7 +67,7 @@ neuron aeif_cond_exp_neuron:
     # spike adaptation parameters
     a nS = 4nS             # Subthreshold adaptation.
     b pA = 80.5pA          # Spike-trigg_exred adaptation.
-    delta_T mV = 2.0mV     # Slope factor
+    Delta_T mV = 2.0mV     # Slope factor
     tau_w ms = 144.0ms     # Adaptation time constant in
     V_th mV = -50.4mV      # Threshold Potential
     V_peak mV = 0mV        # Spike detection threshold in mV.

--- a/models/aeif_cond_exp_implicit.nestml
+++ b/models/aeif_cond_exp_implicit.nestml
@@ -49,8 +49,8 @@ neuron aeif_cond_exp_implicit:
     g_ex' = -g_ex/tau_syn_ex
 
     # Add aliases to simplify the equation definition of V_m
-    exp_arg real = (V_bounded-V_th)/delta_T
-    I_spike pA = g_L*delta_T*exp(exp_arg)
+    exp_arg real = (V_bounded-V_th)/Delta_T
+    I_spike pA = g_L*Delta_T*exp(exp_arg)
     I_syn_exc pA = cond_sum(g_ex, spikeExc) * ( V_bounded - E_ex )
     I_syn_inh pA = cond_sum(g_in, spikeInh) * ( V_bounded - E_in )
 
@@ -70,7 +70,7 @@ neuron aeif_cond_exp_implicit:
     # spike adaptation parameters
     a nS = 4nS             # Subthreshold adaptation.
     b pA = 80.5pA          # Spike-trigg_exred adaptation.
-    delta_T mV = 2.0mV     # Slope factor
+    Delta_T mV = 2.0mV     # Slope factor
     tau_w ms = 144.0ms     # Adaptation time constant in
     V_th mV = -50.4mV      # Threshold Potential
     V_peak mV = 0mV        # Spike detection threshold in mV.

--- a/models/hh_psc_alpha.nestml
+++ b/models/hh_psc_alpha.nestml
@@ -67,7 +67,7 @@ neuron hh_psc_alpha_neuron:
     shape I_ex = 1 pA * (e/tau_syn_ex) * t * exp(-1/tau_syn_ex*t)
 
     I_syn_exc pA = curr_sum(I_ex, spikeExc)
-    I_syn_inh pA = curr_sum(I_in, spikeExc)
+    I_syn_inh pA = curr_sum(I_in, spikeInh)
     I_Na  pA = g_Na * Act_m * Act_m * Act_m * Act_h * ( V_m - E_Na )
     I_K   pA  = g_K * Inact_n * Inact_n * Inact_n * Inact_n * ( V_m - E_K )
     I_L   pA = g_L * ( V_m - E_L )

--- a/models/hh_psc_alpha_implicit.nestml
+++ b/models/hh_psc_alpha_implicit.nestml
@@ -48,8 +48,8 @@ neuron hh_psc_alpha_implicit:
 
   state:
     V_m mV = -65. mV # Membrane potential
-    I_ex pA  # inputs from the exc conductance
-    I_in pA  # inputs from the inh conductance
+    I_syn_ex pA  # inputs from the exc spikes
+    I_syn_in pA  # inputs from the inh spikes
 
     alias alpha_n_init real = ( 0.01 * ( V_m + 55. ) ) / ( 1. - exp( -( V_m + 55. ) / 10. ) )
     alias beta_n_init  real = 0.125 * exp( -( V_m + 65. ) / 80. )
@@ -65,14 +65,14 @@ neuron hh_psc_alpha_implicit:
 
   equations:
     # synapses: alpha functions
-    I_ex'' = -I_ex' / tau_syn_ex
-    I_ex' = I_ex' - ( I_ex / tau_syn_ex )
+    I_syn_ex'' = -I_syn_ex' / tau_syn_ex
+    I_syn_ex' = I_syn_ex' - ( I_syn_ex / tau_syn_ex )
 
-    I_in'' = -I_in' / tau_syn_in
-    I_in' = I_in' - ( I_in / tau_syn_in )
+    I_syn_in'' = -I_syn_in' / tau_syn_in
+    I_syn_in' = I_syn_in' - ( I_syn_in / tau_syn_in )
 
-    I_syn_exc pA = curr_sum(I_ex, spikeExc)
-    I_syn_inh pA = curr_sum(I_in, spikeExc)
+    I_syn_exc pA = curr_sum(I_syn_ex, spikeExc)
+    I_syn_inh pA = curr_sum(I_syn_in, spikeInh)
     I_Na  pA = g_Na * Act_m * Act_m * Act_m * Act_h * ( V_m - E_Na )
     I_K   pA  = g_K * Inact_n * Inact_n * Inact_n * Inact_n * ( V_m - E_K )
     I_L   pA = g_L * ( V_m - E_L )
@@ -128,8 +128,8 @@ neuron hh_psc_alpha_implicit:
   end
 
   input:
-      spikeInh   <- inhibitory spike
-      spikeExc   <- excitatory spike
+      spikeInh <- inhibitory spike
+      spikeExc <- excitatory spike
       currents <- current
   end
 
@@ -148,8 +148,8 @@ neuron hh_psc_alpha_implicit:
 
     I_stim = currents
 
-    I_ex' += spikeExc.get_sum() * PSConInit_E
-    I_in' += spikeInh.get_sum() * PSConInit_I
+    I_syn_ex' += spikeExc.get_sum() * PSConInit_E
+    I_syn_in' += spikeInh.get_sum() * PSConInit_I
   end
 
 end

--- a/models/izhikevich.nestml
+++ b/models/izhikevich.nestml
@@ -44,7 +44,7 @@ neuron izhikevich_neuron:
   state:
     V_m mV = -65mV # Membrane potential in mV
     U_m real = 0   # Membrane potential recovery variable
-    I mA = 0mA     # input current
+    I pA = 0. pA   # input current
   end
 
   equations:
@@ -57,7 +57,7 @@ neuron izhikevich_neuron:
     b real = 0.2    # sensitivity of recovery variable
     c mV = -65      # after-spike reset value of V_m
     d real = 8.0    # after-spike reset value of U_m
-    I_e mA = 0mA    # Constant input current in pA. (R=1)
+    I_e pA = 0 pA   # Constant input current in pA. (R=1)
     V_min mV = -inf # Absolute lower value for the membrane potential.
   end
 

--- a/models/izhikevich_psc_alpha.nestml
+++ b/models/izhikevich_psc_alpha.nestml
@@ -1,0 +1,115 @@
+/*
+Name: izhikevich_psc_alpha - Detailed Izhikevich neuron model with alpha-shaped
+                             post-synaptic current.
+
+Description:
+Implementation of the simple spiking neuron model introduced by Izhikevich
+[1]. The dynamics are given by:
+   C_m dV_m/dt = k (V-V_t)(V-V_t) - u + I + I_syn_ex + I_syn_in
+   dU_m/dt = a*(b*(V_m-E_L) - U_m)
+
+   if v >= V_th:
+     V_m is set to c
+     U_m is incremented by d
+
+   On each spike arrival, the membrane potential feels an alpha-shaped current
+   of the form:
+     I_syn = I_0 * t * exp(-t/tau_syn) / tau_syn.
+
+References:
+[1] Izhikevich, Simple Model of Spiking Neurons,
+IEEE Transactions on Neural Networks (2003) 14:1569-1572
+
+Sends: SpikeEvent
+
+Receives: SpikeEvent, CurrentEvent, DataLoggingRequest
+FirstVersion: 2009
+Author: Hanuschkin, Morrison, Kunkel
+SeeAlso: izhikevitch, iaf_psc_alpha, mat2_psc_alpha
+*/
+
+neuron izhikevich_psc_alpha:
+
+  state:
+    V_m mV = -65 mV # Membrane potential in mV
+    U_m pA = 0 pA   # Membrane potential recovery variable
+    I_syn_ex pA = 0. pA # inputs from the exc conductance
+    I_syn_in pA = 0. pA # inputs from the inh conductance
+  end
+
+  equations:
+    # synapses: alpha functions
+    I_syn_ex'' = -I_syn_ex' / tau_syn_ex
+    I_syn_ex' = I_syn_ex' - ( I_syn_ex / tau_syn_ex )
+    I_syn_in'' = -I_syn_in' / tau_syn_in
+    I_syn_in' = I_syn_in' - ( I_syn_in / tau_syn_in )
+    
+    I_syn_exc pA = curr_sum(I_syn_ex, spikesExc)
+    I_syn_inh pA = curr_sum(I_syn_in, spikesInh)
+    
+    V_m' = ( k * (V_m - V_r) * (V_m - V_t) - U_m + I_e + I_syn_inh + I_syn_exc ) / C_m
+    U_m' = a * ( b*(V_m - V_r) - U_m )
+  end
+
+  parameters:
+    C_m pF = 200. pF           # Membrane capacitance
+    k pF/mV/ms = 8. [pF/mV/ms] # Spiking slope
+    V_r mV = -65. mV           # resting potential
+    V_t mV = -45. mV           # threshold potential
+    a 1/ms = 0.01 [1/ms]       # describes time scale of recovery variable
+    b nS = 9. nS               # sensitivity of recovery variable
+    c mV = -65 mV              # after-spike reset value of V_m
+    d pA = 60. pA              # after-spike reset value of U_m
+    I_e pA = 0. pA             # Constant input current in pA. (R=1)
+    V_peak mV = 0. mV          # Spike detection threashold (reset condition)
+    tau_syn_ex ms = 0.2 ms     # Synaptic Time Constant Excitatory Synapse in ms
+    tau_syn_in ms = 2.0 ms     # Synaptic Time Constant for Inhibitory Synapse in ms
+    t_ref ms = 2.0 ms      # Refractory period
+  end
+
+  internals:
+    # Impulse to add to DG_EXC on spike arrival to evoke unit-amplitude
+    # conductance excursion.
+    PSConInit_E pA/ms = 1.0 pA * e / tau_syn_ex
+
+    # Impulse to add to DG_INH on spike arrival to evoke unit-amplitude
+    # conductance excursion.
+    PSConInit_I pA/ms = 1.0 pA * e / tau_syn_in
+
+
+    RefractoryCounts integer = steps(t_ref) # refractory time in steps
+    r integer # number of steps in the current refractory phase
+
+   # Input current injected by CurrentEvent.
+   # This variable is used to transport the current applied into the
+   # _dynamics function computing the derivative of the state vector.
+   I_stim pA = 0. pA
+  end
+
+  input:
+    spikesInh <- inhibitory spike
+    spikesExc <- excitatory spike
+    currents  <- current
+  end
+
+  output: spike
+
+  update:
+    integrate_odes()
+
+    # refractoriness and threshold crossing
+    if r > 0: # is refractory?
+      r -= 1
+    elif V_m >= V_peak:
+      V_m = c
+      U_m += d
+      emit_spike()
+      r = RefractoryCounts
+    end
+
+    I_syn_ex += spikesExc
+    I_syn_in += spikesInh
+    I_stim = currents
+  end
+
+end

--- a/models/izhikevich_psc_alpha.nestml
+++ b/models/izhikevich_psc_alpha.nestml
@@ -107,8 +107,8 @@ neuron izhikevich_psc_alpha:
       r = RefractoryCounts
     end
 
-    I_syn_ex += spikesExc
-    I_syn_in += spikesInh
+    I_syn_ex' += spikesExc * PSConInit_E
+    I_syn_in' += spikesInh * PSConInit_I
     I_stim = currents
   end
 


### PR DESCRIPTION
* Normalized variables names to match ``nest::names`` (``Delta_T`` and ``I_syn_ex/in``)
* Corrected one spike buffer in ``hh_psc_alpha_neuron``
* Changed the Izhikevitch current units to ``pA``
* Added detailed and dimensionned ``izhikevitch_psc_alpha`` model.