### PR TITLE
Small updates to the installation and usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cmake -Dwith-nest=<nest_install_dir>/bin/nest-config .
 make all
 make install
 ```
-where `<nest_install_dir>` is the installation directory of NEST (e.g. `/home/nest/work/nest-install`). Subsequently, the module can either be linked into NEST (see [Writing an extension module](https://nest.github.io/nest-simulator/extension_modules)), or loaded dynamically using the `Install` API function. For example, to dynamic load a module with `module_name` = `mymodelsmodule` in PyNEST:
+where `<nest_install_dir>` is the installation directory of NEST (e.g. `/home/nest/work/nest-install`). Subsequently, the module can either be linked into NEST (see [Writing an extension module](https://nest.github.io/nest-simulator/extension_modules)), or loaded dynamically using the `Install` API function. For example, to dynamically load a module with `module_name` = `mymodelsmodule` in PyNEST:
 ```py
 nest.Install("mymodelsmodule")
 ```
@@ -82,7 +82,7 @@ Subsequently, it is possible to call PyNestML from other Python tools and script
 ```py
 to_nest(path, target, dry, logging_level, module_name, store_log, dev)    
 ```
-This operation expects the same set of arguments as in the case of command line invocation. The following default values are used corresponding to the command-line defaults; note that only `path` is mandatory:
+This operation expects the same set of arguments as in the case of command line invocation. The following default values are used, corresponding to the command line defaults. Possible values for `logging_level` are the same as before ('INFO', 'WARNING', 'ERROR', 'NO'). Note that only the `path` argument is mandatory:
 
 | Argument | Type | Default |
 |---       |---   | --- |
@@ -100,7 +100,7 @@ install_nest(models_path, nest_path)
 ```
 Here, `models_path` should be set to the `target` directory of `to_nest()`, and `nest_path` points to the directory where NEST is installed (e.g., `/home/nest/work/nest-install`).
 
-A typical script, therefore, could look like the following. For this example, we assume that the name of the generated module is _mymodelsmodule_.
+A typical script, therefore, could look like the following. For this example, we assume that the name of the generated module is _nestmlmodule_.
 ```py
 from pynestml.frontend.pynestml_frontend import to_nest, install_nest
 
@@ -108,7 +108,7 @@ to_nest(path="/home/nest/work/pynestml/models", target="/home/nest/work/pynestml
 
 install_nest("/home/nest/work/pynestml/target", "/home/nest/work/nest-install")
 
-nest.Install("mymodelsmodule")
+nest.Install("nestmlmodule")
 ...
 nest.Simulate(400.0)
 ```

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ where arguments are:<a name="table_args"></a>
 | -store_log    | (Optional) Stores a log.txt containing all messages in JSON notation. Default is OFF.|
 | -dev          | (Optional) Executes the toolchain in the development mode where errors in models are ignored. Default is OFF.|
 
-Generated artifacts are copied to the selected target directory (default is _target_). In order to install the models into NEST, the following commands have to be executed from within the target directory:
+Generated artifacts are copied to the selected target directory (default is `target`). In order to install the models into NEST, the following commands have to be executed from within the target directory:
 ```
 cmake -Dwith-nest=<nest_install_dir>/bin/nest-config .
 make all
 make install
 ```
-where _nest\_install\_dir_ points to the installation directory of NEST (e.g. _/home/nest/work/nest-install_). Subsequently, the module can either be linked into NEST (see [Writing an extension module](https://nest.github.io/nest-simulator/extension_modules)), or loaded dynamically using the _Install_ API function. For example, dynamic loading in PyNEST of a module with _module\_name=mymodelsmodule_:
+where `<nest_install_dir>` is the installation directory of NEST (e.g. `/home/nest/work/nest-install`). Subsequently, the module can either be linked into NEST (see [Writing an extension module](https://nest.github.io/nest-simulator/extension_modules)), or loaded dynamically using the `Install` API function. For example, dynamic loading in PyNEST of a module with `module_name=mymodelsmodule`:
 ```py
 nest.Install("mymodels")    
 ...
@@ -81,7 +81,7 @@ Subsequently, it is possible to call PyNestML from other Python tools and script
 ```py
 to_nest(path, target, dry, logging_level, module_name, store_log, dev)    
 ```
-This operation expects the same set of arguments as in the case of the shell/CMD call, with the following default values being used, where only the _path_ is mandatory:
+This operation expects the same set of arguments as in the case of the shell/CMD call, with the following default values being used, where only the `path` is mandatory:
 
 | Argument | Type | Default |
 |---       |---   | --- |
@@ -97,7 +97,7 @@ No values provided indicates the same behavior as listed for default values in t
 ```py
 install_nest(models_path, nest_path)
 ```  
-where the _models\_path_ has to point as previously selected for the _target_ argument, while _nest\_path_ has to point to the directory where NEST is installed (e.g., "/home/nest/work/nest-install"). The second argument is hereby equivalent to the _nest\_install\_dir_ argument from the manual installation of models (see above).
+where `models_path` is equal to the `target` argument in the call to `to_nest()`, and `nest_path` points to the directory where NEST is installed (e.g., `/home/nest/work/nest-install`).
 
 A typical script, therefore, could look like the following. The name of the generated module is here _mymodelsmodule_.
 ```py

--- a/README.md
+++ b/README.md
@@ -2,105 +2,86 @@
 
 # PyNestML - The NEST Modelling Language @Python
 
-NestML is a domain specific language that supports the specification of neuron models
-in a precise and concise syntax, based on the syntax of Python. Model equations
-can either be given as a simple string of mathematical notation or as an algorithm written
-in the built-in procedural language. The equations are analyzed by NESTML to compute
-an exact solution if possible or use an appropriate numeric solver otherwise.
+NestML is a domain specific language that supports the specification of neuron models in a precise and concise syntax, based on the syntax of Python. Model equations can either be given as a simple string of mathematical notation or as an algorithm written in the built-in procedural language. The equations are analyzed by NESTML to compute an exact solution if possible or use an appropriate numeric solver otherwise.
 
 ## Directory structure
 
 `models` - Example neuron models in NestML format.
-
 `pynestml` - The source code of PyNestML.
-
 `tests` - A collection of tests for testing of the toolchains behavior.
-
 `doc` - The documentation of the modeling language NestML as well as processing toolchain PyNestML.
 
-## Installing and running NESTML
+## Installing NESTML
 
 In order to execute the language tool-chain, Python in version 2 or 3 is required. A setup file is provided and can be installed by 
-
 ```
 python2 setup.py install --user
 ```
-
 For Python in version 3, respectively:
-
 ```
 python3 setup.py install --user
 ```
-
 Correct installation can be tested by 
-
 ```
 python2 setup.py test
 \# respectively python3 setup.py test 
 ```
-
 In order to ensure correct installation and resolving of dependencies, Python's package manager [pip](https://pip.pypa.io/en/stable/installing/), the distribution tool [setuptools](https://packaging.python.org/tutorials/installing-packages/) as well as the python-dev package are required and should be installed in advance. The setup file additionally installs the following components:
 
 * [SymPy in the version >= 1.1.1](http://www.sympy.org/en/index.html)
-
 * [NumPy in the version >=1.8.2](http://www.numpy.org/)
-
 * [Antlr4 runtime environment in the version >= 4.7](https://github.com/antlr/antlr4/blob/master/doc/python-target.md)
 
 In the case that no 'enum' package is found, additionally, enum34 has to be updated by
-
 ```
 pip install --upgrade pip enum34
 ```
-
 All requirements are stored in the requirements.txt and can be installed in one step by pip
-
 ```
 pip install -r requirements.txt
 ```
 
+## Running NESTML
+
 After the installation, the toolchain can be executed by the following command.
-
 ```
-python PyNestML.py -ARGUMENTS
+python PyNestML.py ARGUMENTS
 ```
-
 where arguments are:<a name="table_args"></a>
 
 | Command       | Description |
 |---            |---          |
 | -h or --help  | Print help message.|
 | -path         | Path to the source file or directory containing the model.|
-| -target       | (Optional) Path to target directory where models will be generated to. Default is /target .| 
+| -target       | (Optional) Path to target directory where models will be generated to. Default is `target`.| 
 | -dry          | (Optional) Executes the analysis of the model without generating target code. Default is OFF.|
 | -logging_level| (Optional) Sets the logging level, i.e., which level of messages should be printed. Default is ERROR, available are [INFO, WARNING, ERROR, NO] |
-| -module_name  | (Optional) Sets the name of the module which shall be generated. Default is the name of the directory containing the models. |
+| -module_name  | (Optional) Sets the name of the module which shall be generated. Default is the name of the directory containing the models. The name has to end in "module". Default is `nestmlmodule`. |
 | -store_log    | (Optional) Stores a log.txt containing all messages in JSON notation. Default is OFF.|
 | -dev          | (Optional) Executes the toolchain in the development mode where errors in models are ignored. Default is OFF.|
 
-
-Generated artifacts are copied to the selected target directory (default is /target). In order to install 
-the models into NEST, the following commands have to be executed:
+Generated artifacts are copied to the selected target directory (default is _target_). In order to install the models into NEST, the following commands have to be executed:
 ```
 cmake -Dwith-nest=<nest_install_dir>/bin/nest-config .
 make all
 make install
 ```
-where _nest\_install\_dir_ points to the installation directory of NEST (e.g. work/nest-install). Subsequently, PyNEST can be used to set up and execute a simulation.
-
-PyNestML is also available as a component and can therefore be used from within 
-other Python tools and scripts. After the PyNestML has been installed,
-the following modules have to be imported:
+where _nest\_install\_dir_ points to the installation directory of NEST (e.g. work/nest-install). Subsequently, the module can either be linked into NEST (see [Writing an extension module](https://nest.github.io/nest-simulator/extension_modules), or loaded dynamically using the _Install_ API function. For example, dynamic loading in PyNEST of a module with _module\_name=mymodelsmodule_:
+```py
+nest.Install("mymodels")    
+...
+nest.Simulate(400.0)
 ```
-from pynestml.frontend.pynestml_frontend import to_nest,install_nest
+
+PyNestML is also available as a component and can therefore be used from within other Python tools and scripts. After PyNestML has been installed, the following modules have to be imported:
+```py
+from pynestml.frontend.pynestml_frontend import to_nest, install_nest
 ```
 Subsequently, it is possible to call PyNestML from other Python tools and scripts via:
-
-```
+```py
 to_nest(path, target, dry, logging_level, module_name, store_log, dev)    
 ```
-This operation expects the same set of arguments as in the case of the shell/CMD call,
-with the following default values being used, where only the __path__ is mandatory:
+This operation expects the same set of arguments as in the case of the shell/CMD call, with the following default values being used, where only the __path__ is mandatory:
 
 | Argument | Type | Default |
 |---       |---   | --- |
@@ -112,27 +93,21 @@ with the following default values being used, where only the __path__ is mandato
 | store_log | boolean | False |
 | dev | boolean | False |
 
-where no values provided indicates the same behavior as listed for default values 
-in arguments [table](#table_args).
-If no errors occur, the output will be generated to the specified target directory. In order 
-to avoid an execution of all required module-installation routines by hand, PyNestML
-features a function for an installation of NEST models directly into NEST:
-```
-install_nest(models_path,nest_path)
+where no values provided indicates the same behavior as listed for default values in arguments [table](#table_args). If no errors occur, the output will be generated to the specified target directory. In order to avoid an execution of all required module-installation routines by hand, PyNestML features a function for an installation of NEST models directly into NEST:
+```py
+install_nest(models_path, nest_path)
 ```  
-where the _models\_path_ has to point as previously selected for the _target_
-argument, while _nest\_path_ has to point to the directory where NEST is installed (e.g., 
-"/home/nest/work/nest-install"). The second argument is hereby equivalent to the
-_nest\_install\_dir_ argument from the manual installation of models (see above).
-The simulation can then be started. A typical script, therefore, can look like the following:
-```
-from pynestml.frontend.pynestml_frontend import to_nest,install_nest
+where the _models\_path_ has to point as previously selected for the _target_ argument, while _nest\_path_ has to point to the directory where NEST is installed (e.g., "/home/nest/work/nest-install"). The second argument is hereby equivalent to the _nest\_install\_dir_ argument from the manual installation of models (see above).
 
-to_nest(path="/home/nest/work/pynestml/models", target="/home/nest/work/pynestml/target",dev=True)
+A typical script, therefore, could look like the following. The name of the generated module is here _mymodelsmodule_.
+```py
+from pynestml.frontend.pynestml_frontend import to_nest, install_nest
+
+to_nest(path="/home/nest/work/pynestml/models", target="/home/nest/work/pynestml/target", dev=True)
 
 install_nest("/home/nest/work/pynestml/target", "/home/nest/work/nest-install")
 
-nest.install(<the module name>)    
+nest.Install("mymodels")
 ...
 nest.Simulate(400.0)
 ```

--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@ NestML is a domain specific language that supports the specification of neuron m
 ## Directory structure
 
 `models` - Example neuron models in NestML format.
+
 `pynestml` - The source code of PyNestML.
+
 `tests` - A collection of tests for testing of the toolchains behavior.
+
 `doc` - The documentation of the modeling language NestML as well as processing toolchain PyNestML.
 
 ## Installing NESTML
@@ -66,11 +69,9 @@ cmake -Dwith-nest=<nest_install_dir>/bin/nest-config .
 make all
 make install
 ```
-where `<nest_install_dir>` is the installation directory of NEST (e.g. `/home/nest/work/nest-install`). Subsequently, the module can either be linked into NEST (see [Writing an extension module](https://nest.github.io/nest-simulator/extension_modules)), or loaded dynamically using the `Install` API function. For example, dynamic loading in PyNEST of a module with `module_name=mymodelsmodule`:
+where `<nest_install_dir>` is the installation directory of NEST (e.g. `/home/nest/work/nest-install`). Subsequently, the module can either be linked into NEST (see [Writing an extension module](https://nest.github.io/nest-simulator/extension_modules)), or loaded dynamically using the `Install` API function. For example, to dynamic load a module with `module_name` = `mymodelsmodule` in PyNEST:
 ```py
 nest.Install("mymodels")    
-...
-nest.Simulate(400.0)
 ```
 
 PyNestML is also available as a component and can therefore be used from within other Python tools and scripts. After PyNestML has been installed, the following modules have to be imported:
@@ -81,7 +82,7 @@ Subsequently, it is possible to call PyNestML from other Python tools and script
 ```py
 to_nest(path, target, dry, logging_level, module_name, store_log, dev)    
 ```
-This operation expects the same set of arguments as in the case of the shell/CMD call, with the following default values being used, where only the `path` is mandatory:
+This operation expects the same set of arguments as in the case of command line invocation. The following default values being used; note that only the `path` is mandatory:
 
 | Argument | Type | Default |
 |---       |---   | --- |

--- a/README.md
+++ b/README.md
@@ -82,22 +82,22 @@ Subsequently, it is possible to call PyNestML from other Python tools and script
 ```py
 to_nest(path, target, dry, logging_level, module_name, store_log, dev)    
 ```
-This operation expects the same set of arguments as in the case of command line invocation. The following default values being used; note that only the `path` is mandatory:
+This operation expects the same set of arguments as in the case of command line invocation. The following default values are used corresponding to the command-line defaults; note that only `path` is mandatory:
 
 | Argument | Type | Default |
 |---       |---   | --- |
-| path     | string | -no default- |  
+| path     | string | _no default_ |
 | target   | string | None |
 | dry      | boolean | False |
 | logging_level | string | 'ERROR' |
-| module_name | string | None |
+| module_name | string | `nestmlmodule` |
 | store_log | boolean | False |
 | dev | boolean | False |
 
-No values provided indicates the same behavior as listed for default values in the [command-line arguments table](#table_args). If no errors occur, the output will be generated to the specified target directory. In order to avoid an execution of all required module-installation routines by hand, PyNestML features a function for an installation of NEST models directly into NEST:
+If no errors occur, the output will be generated into the specified target directory. In order to avoid an execution of all required module-installation routines by hand, PyNestML features a function for an installation of NEST models directly into NEST:
 ```py
 install_nest(models_path, nest_path)
-```  
+```
 where `models_path` is equal to the `target` argument in the call to `to_nest()`, and `nest_path` points to the directory where NEST is installed (e.g., `/home/nest/work/nest-install`).
 
 A typical script, therefore, could look like the following. The name of the generated module is here _mymodelsmodule_.

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ cmake -Dwith-nest=<nest_install_dir>/bin/nest-config .
 make all
 make install
 ```
-where `<nest_install_dir>` is the installation directory of NEST (e.g. `/home/nest/work/nest-install`). Subsequently, the module can either be linked into NEST (see [Writing an extension module](https://nest.github.io/nest-simulator/extension_modules)), or loaded dynamically using the `Install` API function. For example, to dynamically load a module with `module_name` = `mymodelsmodule` in PyNEST:
+where `<nest_install_dir>` is the installation directory of NEST (e.g. `/home/nest/work/nest-install`). Subsequently, the module can either be linked into NEST (see [Writing an extension module](https://nest.github.io/nest-simulator/extension_modules)), or loaded dynamically using the `Install` API function. For example, to dynamically load a module with `module_name` = `nestmlmodule` in PyNEST:
 ```py
-nest.Install("mymodelsmodule")
+nest.Install("nestmlmodule")
 ```
 
 PyNestML is also available as a component and can therefore be used from within other Python tools and scripts. After PyNestML has been installed, the following modules have to be imported:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ make install
 ```
 where `<nest_install_dir>` is the installation directory of NEST (e.g. `/home/nest/work/nest-install`). Subsequently, the module can either be linked into NEST (see [Writing an extension module](https://nest.github.io/nest-simulator/extension_modules)), or loaded dynamically using the `Install` API function. For example, to dynamic load a module with `module_name` = `mymodelsmodule` in PyNEST:
 ```py
-nest.Install("mymodels")    
+nest.Install("mymodelsmodule")
 ```
 
 PyNestML is also available as a component and can therefore be used from within other Python tools and scripts. After PyNestML has been installed, the following modules have to be imported:
@@ -100,7 +100,7 @@ install_nest(models_path, nest_path)
 ```
 Here, `models_path` should be set to the `target` directory of `to_nest()`, and `nest_path` points to the directory where NEST is installed (e.g., `/home/nest/work/nest-install`).
 
-A typical script, therefore, could look like the following. The name of the generated module is here _mymodelsmodule_.
+A typical script, therefore, could look like the following. For this example, we assume that the name of the generated module is _mymodelsmodule_.
 ```py
 from pynestml.frontend.pynestml_frontend import to_nest, install_nest
 
@@ -108,7 +108,7 @@ to_nest(path="/home/nest/work/pynestml/models", target="/home/nest/work/pynestml
 
 install_nest("/home/nest/work/pynestml/target", "/home/nest/work/nest-install")
 
-nest.Install("mymodels")
+nest.Install("mymodelsmodule")
 ...
 nest.Simulate(400.0)
 ```

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ where arguments are:<a name="table_args"></a>
 | -store_log    | (Optional) Stores a log.txt containing all messages in JSON notation. Default is OFF.|
 | -dev          | (Optional) Executes the toolchain in the development mode where errors in models are ignored. Default is OFF.|
 
-Generated artifacts are copied to the selected target directory (default is _target_). In order to install the models into NEST, the following commands have to be executed:
+Generated artifacts are copied to the selected target directory (default is _target_). In order to install the models into NEST, the following commands have to be executed from within the target directory:
 ```
 cmake -Dwith-nest=<nest_install_dir>/bin/nest-config .
 make all
 make install
 ```
-where _nest\_install\_dir_ points to the installation directory of NEST (e.g. work/nest-install). Subsequently, the module can either be linked into NEST (see [Writing an extension module](https://nest.github.io/nest-simulator/extension_modules), or loaded dynamically using the _Install_ API function. For example, dynamic loading in PyNEST of a module with _module\_name=mymodelsmodule_:
+where _nest\_install\_dir_ points to the installation directory of NEST. Subsequently, the module can either be linked into NEST (see [Writing an extension module](https://nest.github.io/nest-simulator/extension_modules)), or loaded dynamically using the _Install_ API function. For example, dynamic loading in PyNEST of a module with _module\_name=mymodelsmodule_:
 ```py
 nest.Install("mymodels")    
 ...

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cmake -Dwith-nest=<nest_install_dir>/bin/nest-config .
 make all
 make install
 ```
-where _nest\_install\_dir_ points to the installation directory of NEST. Subsequently, the module can either be linked into NEST (see [Writing an extension module](https://nest.github.io/nest-simulator/extension_modules)), or loaded dynamically using the _Install_ API function. For example, dynamic loading in PyNEST of a module with _module\_name=mymodelsmodule_:
+where _nest\_install\_dir_ points to the installation directory of NEST (e.g. _/home/nest/work/nest-install_). Subsequently, the module can either be linked into NEST (see [Writing an extension module](https://nest.github.io/nest-simulator/extension_modules)), or loaded dynamically using the _Install_ API function. For example, dynamic loading in PyNEST of a module with _module\_name=mymodelsmodule_:
 ```py
 nest.Install("mymodels")    
 ...
@@ -81,7 +81,7 @@ Subsequently, it is possible to call PyNestML from other Python tools and script
 ```py
 to_nest(path, target, dry, logging_level, module_name, store_log, dev)    
 ```
-This operation expects the same set of arguments as in the case of the shell/CMD call, with the following default values being used, where only the __path__ is mandatory:
+This operation expects the same set of arguments as in the case of the shell/CMD call, with the following default values being used, where only the _path_ is mandatory:
 
 | Argument | Type | Default |
 |---       |---   | --- |
@@ -93,7 +93,7 @@ This operation expects the same set of arguments as in the case of the shell/CMD
 | store_log | boolean | False |
 | dev | boolean | False |
 
-where no values provided indicates the same behavior as listed for default values in arguments [table](#table_args). If no errors occur, the output will be generated to the specified target directory. In order to avoid an execution of all required module-installation routines by hand, PyNestML features a function for an installation of NEST models directly into NEST:
+No values provided indicates the same behavior as listed for default values in the [command-line arguments table](#table_args). If no errors occur, the output will be generated to the specified target directory. In order to avoid an execution of all required module-installation routines by hand, PyNestML features a function for an installation of NEST models directly into NEST:
 ```py
 install_nest(models_path, nest_path)
 ```  

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If no errors occur, the output will be generated into the specified target direc
 ```py
 install_nest(models_path, nest_path)
 ```
-where `models_path` is equal to the `target` argument in the call to `to_nest()`, and `nest_path` points to the directory where NEST is installed (e.g., `/home/nest/work/nest-install`).
+Here, `models_path` should be set to the `target` directory of `to_nest()`, and `nest_path` points to the directory where NEST is installed (e.g., `/home/nest/work/nest-install`).
 
 A typical script, therefore, could look like the following. The name of the generated module is here _mymodelsmodule_.
 ```py

--- a/pynestml/frontend/frontend_configuration.py
+++ b/pynestml/frontend/frontend_configuration.py
@@ -105,13 +105,14 @@ class FrontendConfiguration(object):
         cls.handle_target_path(parsed_args.target)
         # now adjust the name of the module, if it is a single file, then it is called just module
         if parsed_args.module_name is not None:
+            assert parsed_args.module_name.endswith('module')
             cls.module_name = parsed_args.module_name[0]
         elif os.path.isfile(parsed_args.path[0]):
-            cls.module_name = 'module'
+            cls.module_name = 'nestmlmodule'
         elif os.path.isdir(parsed_args.path[0]):
             cls.module_name = os.path.basename(os.path.normpath(parsed_args.path[0]))
         else:
-            cls.module_name = 'module'
+            cls.module_name = 'nestmlmodule'
         cls.store_log = parsed_args.store_log
         cls.is_debug = parsed_args.dev
         return

--- a/pynestml/frontend/frontend_configuration.py
+++ b/pynestml/frontend/frontend_configuration.py
@@ -105,7 +105,7 @@ class FrontendConfiguration(object):
         cls.handle_target_path(parsed_args.target)
         # now adjust the name of the module, if it is a single file, then it is called just module
         if parsed_args.module_name is not None:
-            assert parsed_args.module_name.endswith('module')
+            assert parsed_args.module_name[0].endswith('module')
             cls.module_name = parsed_args.module_name[0]
         elif os.path.isfile(parsed_args.path[0]):
             cls.module_name = 'nestmlmodule'

--- a/pynestml/frontend/frontend_configuration.py
+++ b/pynestml/frontend/frontend_configuration.py
@@ -105,7 +105,7 @@ class FrontendConfiguration(object):
         cls.handle_target_path(parsed_args.target)
         # now adjust the name of the module, if it is a single file, then it is called just module
         if parsed_args.module_name is not None:
-            assert parsed_args.module_name[0].endswith('module')
+            assert parsed_args.module_name[0].endswith('module'), "Module name (\"" + parsed_args.module_name[0] + "\") should end with \"module\""
             cls.module_name = parsed_args.module_name[0]
         elif os.path.isfile(parsed_args.path[0]):
             cls.module_name = 'nestmlmodule'


### PR DESCRIPTION
* Small fixes like nest.install() -> nest.Install()

* addressed the fact that module names have to end in "module" if NEST is expected to pick them up for linking (see https://nest.github.io/nest-simulator/extension_modules). This also means that we cannot have a module that's just called "module", so I (confusingly) called it "nestmlmodule" by default; other suggestions welcome!