### PR TITLE
updated the versioning scheme

### DIFF
--- a/pynestml/__init__.py
+++ b/pynestml/__init__.py
@@ -17,3 +17,5 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+__version__ = "3.0-post-dev"

--- a/pynestml/frontend/frontend_configuration.py
+++ b/pynestml/frontend/frontend_configuration.py
@@ -20,6 +20,7 @@
 import argparse  # used for parsing of input arguments
 import os
 
+import pynestml
 from pynestml.exceptions.invalid_path_exception import InvalidPathException
 from pynestml.utils.logger import Logger
 
@@ -72,7 +73,7 @@ class FrontendConfiguration(object):
                             'built-in '
                             ' procedural language. The equations are analyzed by NESTML to compute an exact solution'
                             ' if possible or use an appropriate numeric solver otherwise.'
-                            ' Version 0.0.6, beta.')
+                            ' Version '  + str(pynestml.__version__))
 
         cls.argument_parser.add_argument(qualifier_path_arg, type=str, nargs='+',
                                          help=help_path)

--- a/pynestml/frontend/frontend_configuration.py
+++ b/pynestml/frontend/frontend_configuration.py
@@ -67,13 +67,14 @@ class FrontendConfiguration(object):
         :type args: list(str)
         """
         cls.argument_parser = argparse.ArgumentParser(
-                description='NESTML is a domain specific language that supports the specification of neuron models in a'
-                            ' precise and concise syntax, based on the syntax of Python. Model equations can either be '
-                            ' given as a simple string of mathematical notation or as an algorithm written in the '
-                            'built-in '
-                            ' procedural language. The equations are analyzed by NESTML to compute an exact solution'
-                            ' if possible or use an appropriate numeric solver otherwise.'
-                            ' Version '  + str(pynestml.__version__))
+                description='''NESTML is a domain specific language that supports the specification of neuron
+models in a precise and concise syntax, based on the syntax of Python. Model
+equations can either be given as a simple string of mathematical notation or
+as an algorithm written in the built-in procedural language. The equations are
+analyzed by NESTML to compute an exact solution if possible or use an
+appropriate numeric solver otherwise.
+
+ Version ''' + str(pynestml.__version__), formatter_class=argparse.RawDescriptionHelpFormatter)
 
         cls.argument_parser.add_argument(qualifier_path_arg, type=str, nargs='+',
                                          help=help_path)


### PR DESCRIPTION
Versioning according to PEP 440 (https://www.python.org/dev/peps/pep-0440/).

This fixes issue #429.

PEP 440 defines a lexicographical ordering on version number strings. There are rather a few special cases (such as "dev" and "post") that affect this order. To obtain a version that sits lexicographically _after_ the 3.0 release, but _before_ identifying the version number of the next release, because we don't know yet what that is going to be (3.1? 3.0.1?), we have to use the _post_ keyword:

    >>> from pkg_resources import parse_version as V
    >>> V("3.0") < V("3.0-post")
    >>> True

To make it abundantly clear to the user that they are dealing with a development branch, I've also added "-dev" after the "-post". Technically, this means that this is a pre-release (3.0-post-dev) of the post-release (3.0-post):

    >>> V("3.0") < V("3.0-post-dev") < V("3.0-post")
    >>> True

Versioning upon a release will follow the plan as set out in #429 and treat "-post-dev" as a single keyword.