### PR TITLE
cleanup of error handling: input file not found and lexer/parser errors

### DIFF
--- a/pynestml/frontend/frontend_configuration.py
+++ b/pynestml/frontend/frontend_configuration.py
@@ -77,7 +77,7 @@ appropriate numeric solver otherwise.
  Version ''' + str(pynestml.__version__), formatter_class=argparse.RawDescriptionHelpFormatter)
 
         cls.argument_parser.add_argument(qualifier_path_arg, type=str, nargs='+',
-                                         help=help_path)
+                                         help=help_path, required=True)
         cls.argument_parser.add_argument(qualifier_target_arg, metavar='Target', type=str, nargs='?',
                                          help=help_target)
         cls.argument_parser.add_argument(qualifier_dry_arg, action='store_true',

--- a/pynestml/frontend/pynestml_frontend.py
+++ b/pynestml/frontend/pynestml_frontend.py
@@ -91,31 +91,35 @@ def process():
     init_predefined()
     # now proceed to parse all models
     compilation_units = list()
-    for m_file in FrontendConfiguration.get_files():
-        parsed_unit = ModelParser.parse_model(m_file)
+    nestml_files = FrontendConfiguration.get_files()
+    if not type(nestml_files) is list:
+        nestml_files = [nestml_files]
+    for nestml_file in nestml_files:
+        parsed_unit = ModelParser.parse_model(nestml_file)
         if parsed_unit is not None:
             compilation_units.append(parsed_unit)
-    # generate a list of all neurons
-    neurons = list()
-    for compilationUnit in compilation_units:
-        neurons.extend(compilationUnit.get_neuron_list())
-    # check if across two files two neurons with same name have been defined
-    CoCosManager.check_not_two_neurons_across_units(compilation_units)
-    # now exclude those which are broken, i.e. have errors.
-    if not FrontendConfiguration.is_dev():
-        for neuron in neurons:
-            if Logger.has_errors(neuron):
-                code, message = Messages.get_neuron_contains_errors(neuron.get_name())
-                Logger.log_message(neuron=neuron, code=code, message=message,
-                                   error_position=neuron.get_source_position(),
-                                   log_level=LoggingLevel.INFO)
-                neurons.remove(neuron)
-    if not FrontendConfiguration.is_dry_run():
-        analyse_and_generate_neurons(neurons)
-        generate_nest_module_code(neurons)
-    else:
-        code, message = Messages.get_dry_run()
-        Logger.log_message(neuron=None, code=code, message=message, log_level=LoggingLevel.INFO)
+    if len(compilation_units) > 0:
+        # generate a list of all neurons
+        neurons = list()
+        for compilationUnit in compilation_units:
+            neurons.extend(compilationUnit.get_neuron_list())
+        # check if across two files two neurons with same name have been defined
+        CoCosManager.check_not_two_neurons_across_units(compilation_units)
+        # now exclude those which are broken, i.e. have errors.
+        if not FrontendConfiguration.is_dev():
+            for neuron in neurons:
+                if Logger.has_errors(neuron):
+                    code, message = Messages.get_neuron_contains_errors(neuron.get_name())
+                    Logger.log_message(neuron=neuron, code=code, message=message,
+                                       error_position=neuron.get_source_position(),
+                                       log_level=LoggingLevel.INFO)
+                    neurons.remove(neuron)
+        if not FrontendConfiguration.is_dry_run():
+            analyse_and_generate_neurons(neurons)
+            generate_nest_module_code(neurons)
+        else:
+            code, message = Messages.get_dry_run()
+            Logger.log_message(neuron=None, code=code, message=message, log_level=LoggingLevel.INFO)
     if FrontendConfiguration.store_log:
         store_log_to_file()
     return

--- a/pynestml/utils/__init__.py
+++ b/pynestml/utils/__init__.py
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-__all__ = ['ast_utils', 'logger', 'stack', 'either', 'error_strings', 'logging_helper', 'messages',
-           'model_parser',
-           'ode_transformer', 'type_caster', 'type_dictionary', 'unit_type', 'ast_nestml_printer']
+__all__ = ['ast_utils', 'logger', 'stack', 'either', 'error_listener',
+           'error_strings', 'logging_helper', 'messages', 'model_parser',
+           'ode_transformer', 'type_caster', 'type_dictionary', 'unit_type',
+           'ast_nestml_printer']

--- a/pynestml/utils/error_listener.py
+++ b/pynestml/utils/error_listener.py
@@ -1,0 +1,38 @@
+#
+# error_listener.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+This class contains several method used to parse handed over models and returns them as one or more AST trees.
+"""
+from antlr4.error.ErrorListener import ConsoleErrorListener, ErrorListener
+
+class NestMLErrorListener(ErrorListener):
+    """helper class to listen for parser errors and record whether an error has occurred"""
+
+    def __init__(self):
+        super(NestMLErrorListener, self).__init__()
+        self._error_occurred = False
+
+    @property
+    def error_occurred(self):
+        return self._error_occurred
+
+    def syntaxError(self, recognizer, offendingSymbol, line, column, msg, e):
+        self._error_occurred = True

--- a/pynestml/utils/messages.py
+++ b/pynestml/utils/messages.py
@@ -51,6 +51,21 @@ class Messages(object):
         return MessageCode.TYPE_REGISTERED, message
 
     @classmethod
+    def get_input_path_not_found(cls, path):
+        message = 'Input path ("%s") not found!' % (path)
+        return MessageCode.INPUT_PATH_NOT_FOUND, message
+
+    @classmethod
+    def get_lexer_error(cls):
+        message = 'Error occurred during lexing: abort'
+        return MessageCode.LEXER_ERROR, message
+
+    @classmethod
+    def get_parser_error(cls):
+        message = 'Error occurred during parsing: abort'
+        return MessageCode.PARSER_ERROR, message
+
+    @classmethod
     def get_binary_operation_not_defined(cls, lhs, operator, rhs):
         message = 'Operation %s %s %s is not defined!' % (lhs, operator, rhs)
         return MessageCode.OPERATION_NOT_DEFINED, message
@@ -962,3 +977,6 @@ class MessageCode(Enum):
     INTERNAL_WARNING = 56
     OPERATION_NOT_DEFINED = 57
     CONVOLVE_NEEDS_BUFFER_PARAMETER = 58
+    INPUT_PATH_NOT_FOUND = 59
+    LEXER_ERROR = 60
+    PARSER_ERROR = 61


### PR DESCRIPTION
More sensible and consistent error handling, in the case of not found path (argument to `-path`) or lexer or parser errors.

Overall in NESTML, there is still a mix of two error strategies: returning None and raising exceptions (such as RunTimeException). For new code, we could consider creating our own hierarchy of Exception subclasses instead of relying on return values. The disadvantage of this is that error messages will be repeated: once when logging the message in the logger, and a second time when the exception is thrown.