### PR TITLE
renaming of get_delay() following changes in nest-simulator

### DIFF
--- a/pynestml/codegeneration/resources_nest/NeuronClass.jinja2
+++ b/pynestml/codegeneration/resources_nest/NeuronClass.jinja2
@@ -308,7 +308,7 @@ void {{neuronName}}::handle(nest::DataLoggingRequest& e){
 
 {% if is_spike_input %}
 void {{neuronName}}::handle(nest::SpikeEvent &e){
-  assert(e.get_delay() > 0);
+  assert(e.get_delay_steps() > 0);
   {% if neuron.is_multisynapse_spikes() -%}
   {%- set spikeBuffer = neuron.get_spike_buffers()[0] -%}
   B_.{{spikeBuffer.get_symbol_name()}}[e.get_rport() - 1].add_value(
@@ -345,7 +345,7 @@ void {{neuronName}}::handle(nest::SpikeEvent &e){
 {% endif -%}
 {% if is_current_input %}
 void {{neuronName}}::handle(nest::CurrentEvent& e){
-  assert(e.get_delay() > 0);
+  assert(e.get_delay_steps() > 0);
 
   const double current=e.get_current();
   const double weight=e.get_weight();


### PR DESCRIPTION
Following the merge of https://github.com/nest/nest-simulator/pull/1037 into nest-simulator/master, NESTML models failed to compile. This PR fixes the issue.

For the associated discussion thread on nest-simulator, see: https://github.com/nest/nest-simulator/issues/1025