### PR TITLE
Fix frontend --model_name argument parsing

### DIFF
--- a/pynestml/frontend/frontend_configuration.py
+++ b/pynestml/frontend/frontend_configuration.py
@@ -104,8 +104,8 @@ appropriate numeric solver otherwise.
         cls.handle_target_path(parsed_args.target_path)
         # now adjust the name of the module, if it is a single file, then it is called just module
         if parsed_args.module_name is not None:
-            assert parsed_args.module_name[0].endswith('module'), "Module name (\"" + parsed_args.module_name[0] + "\") should end with \"module\""
-            cls.module_name = parsed_args.module_name[0]
+            assert parsed_args.module_name.endswith('module'), "Module name (\"" + parsed_args.module_name + "\") should end with \"module\""
+            cls.module_name = parsed_args.module_name
         elif os.path.isfile(parsed_args.input_path[0]):
             cls.module_name = 'nestmlmodule'
         elif os.path.isdir(parsed_args.input_path[0]):

--- a/tests/as_component_test.py
+++ b/tests/as_component_test.py
@@ -47,12 +47,11 @@ class AsComponentTest(unittest.TestCase):
     def test_from_objects(self):
         input_path = os.path.join(os.path.dirname(__file__), 'resources', 'CommentTest.nestml')
         target_path = os.path.join('target')
-        target = 'NEST'
         logging_level = 'NO'
         module_name = 'module'
         store_log = False
         dev = True
-        to_nest(input_path, target_path, target, logging_level, module_name, store_log, dev)
+        to_nest(input_path, target_path, logging_level, module_name, store_log, dev)
         self.assertTrue(os.path.isfile(os.path.join(FrontendConfiguration.get_target_path(), 'CMakeLists.txt')))
         self.assertTrue(os.path.isfile(os.path.join(FrontendConfiguration.get_target_path(), 'commentTest.cpp')))
         self.assertTrue(os.path.isfile(os.path.join(FrontendConfiguration.get_target_path(), 'commentTest.h')))


### PR DESCRIPTION
There’s currently an error in `pynestml.frontend` which causes the [components tests](https://github.com/nest/nestml/blob/master/tests/as_component_test.py) to fail. Specifically, this goes back to the `nargs='+'` option of the argument parser [having been removed](https://github.com/nest/nestml/commit/a641d32240af78fab30aea50fa54e667465eefff#diff-1b2112faa67e08f4de9d5b1358e5f68cL87) so that `parsed_args.module_name[0]` [returns the first character of a string](https://github.com/nest/nestml/blob/78fbb789d6e38598f67db4358dad598e39f0c7fc/pynestml/frontend/frontend_configuration.py#L110) rather than the first element of a list. Consequently, the module name "module" does not pass the assertion since only "m" is being evaluated.

This PR fixes the issue.

I strongly suggest revising the use of the argument parser and its options. `nargs` might not be necessary in some cases and the [choices option](https://docs.python.org/2/library/argparse.html#choices) provides useful functionality for the `logging_level` argument.

