### PR TITLE
Clarify requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ NestML is a domain specific language that supports the specification of neuron m
 
 ## Installing NESTML
 
+### Requirements
+
 In order to execute the language tool-chain, Python in version 2 or 3 is required.
 To ensure correct installation and resolving of dependencies, Python's package manager [pip](https://pip.pypa.io/en/stable/installing/), the distribution tool [setuptools](https://packaging.python.org/tutorials/installing-packages/) as well as the python headers (``python-dev`` on Ubuntu/Debian, ``python-devel`` on most other linux platforms) package are required and should be installed in advance. The setup file additionally installs the following components:
 
@@ -36,6 +38,8 @@ Requirements are stored in ``requirements.txt`` and can be installed in one step
 pip install -r requirements.txt
 ```
 
+### Installation
+
 Once all requirements are installed, a setup file is provided and can be run on Python 2 via 
 ```
 python2 setup.py install --user
@@ -44,6 +48,8 @@ Or for Python 3:
 ```
 python3 setup.py install --user
 ```
+
+### Testing
 
 Correct installation can then be tested by 
 ```

--- a/README.md
+++ b/README.md
@@ -18,20 +18,8 @@ NestML is a domain specific language that supports the specification of neuron m
 
 ## Installing NESTML
 
-In order to execute the language tool-chain, Python in version 2 or 3 is required. A setup file is provided and can be installed by 
-```
-python2 setup.py install --user
-```
-For Python in version 3, respectively:
-```
-python3 setup.py install --user
-```
-Correct installation can be tested by 
-```
-python2 setup.py test
-\# respectively python3 setup.py test 
-```
-In order to ensure correct installation and resolving of dependencies, Python's package manager [pip](https://pip.pypa.io/en/stable/installing/), the distribution tool [setuptools](https://packaging.python.org/tutorials/installing-packages/) as well as the python-dev package are required and should be installed in advance. The setup file additionally installs the following components:
+In order to execute the language tool-chain, Python in version 2 or 3 is required.
+To ensure correct installation and resolving of dependencies, Python's package manager [pip](https://pip.pypa.io/en/stable/installing/), the distribution tool [setuptools](https://packaging.python.org/tutorials/installing-packages/) as well as the python headers (``python-dev`` on Ubuntu/Debian, ``python-devel`` on most other linux platforms) package are required and should be installed in advance. The setup file additionally installs the following components:
 
 * [SymPy in the version >= 1.1.1](http://www.sympy.org/en/index.html)
 * [NumPy in the version >=1.8.2](http://www.numpy.org/)
@@ -41,9 +29,26 @@ In the case that no 'enum' package is found, additionally, enum34 has to be upda
 ```
 pip install --upgrade pip enum34
 ```
-All requirements are stored in the requirements.txt and can be installed in one step by pip
+
+First of all, you should make sure that all required packages are installed.
+Requirements are stored in ``requirements.txt`` and can be installed in one step through pip by running
 ```
 pip install -r requirements.txt
+```
+
+Once all requirements are installed, a setup file is provided and can be run on Python 2 via 
+```
+python2 setup.py install --user
+```
+Or for Python 3:
+```
+python3 setup.py install --user
+```
+
+Correct installation can then be tested by 
+```
+python2 setup.py test
+\# respectively python3 setup.py test 
 ```
 
 ## Running NESTML


### PR DESCRIPTION
Trying to install NESTML, I was troubled by the fact that the requirements come after the installation instructions and apparently I was not alone (see #424)
Furthermore, I was not lucky enough to get the nice error message from #424 so figuring what was wrong took me some time.

Therefore, I propose a simple change to the Readme which makes the requirements come first and should hopefully prevent this problem for other users.