### PR TITLE
Model names suffix

### DIFF
--- a/pynestml/frontend/frontend_configuration.py
+++ b/pynestml/frontend/frontend_configuration.py
@@ -36,6 +36,7 @@ help_logging = 'Indicates which messages shall be logged and printed to the scre
 help_module = 'Indicates the name of the module. Optional. If not indicated, ' \
               'the name of the directory containing the models is used!'
 help_log = 'Indicates whether a log file containing all messages shall be stored. Standard is NO.'
+help_suffix = 'A suffix string that will be appended to the name of all generated models.'
 help_dev = 'Indicates whether the dev mode should be active, i.e., ' \
            'the whole toolchain executed even though errors in models are present.' \
            ' This option is designed for debug purpose only!'
@@ -46,6 +47,7 @@ qualifier_target_arg = '--target'
 qualifier_logging_level_arg = '--logging_level'
 qualifier_module_name_arg = '--module_name'
 qualifier_store_log_arg = '--store_log'
+qualifier_suffix = '--suffix'
 qualifier_dev_arg = '--dev'
 
 
@@ -61,6 +63,7 @@ class FrontendConfiguration(object):
     target_path = None
     module_name = None
     store_log = False
+    suffix = ''
     is_debug = False
 
     @classmethod
@@ -86,6 +89,7 @@ appropriate numeric solver otherwise.
         cls.argument_parser.add_argument(qualifier_logging_level_arg, metavar='[INFO, WARNING/S, ERROR/S, NO]', type=str,help=help_logging)
         cls.argument_parser.add_argument(qualifier_module_name_arg, metavar='NAME', type=str, help=help_module)
         cls.argument_parser.add_argument(qualifier_store_log_arg, action='store_true', help=help_log)
+        cls.argument_parser.add_argument(qualifier_suffix, metavar='SUFFIX', type=str, help=help_suffix, default='')
         cls.argument_parser.add_argument(qualifier_dev_arg, action='store_true', help=help_dev)
         parsed_args = cls.argument_parser.parse_args(args)
         # get the source path
@@ -113,6 +117,7 @@ appropriate numeric solver otherwise.
         else:
             cls.module_name = 'nestmlmodule'
         cls.store_log = parsed_args.store_log
+        cls.suffix = parsed_args.suffix
         cls.is_debug = parsed_args.dev
         return
 

--- a/pynestml/frontend/frontend_configuration.py
+++ b/pynestml/frontend/frontend_configuration.py
@@ -1,4 +1,3 @@
-
 #
 # frontend_configuration.py
 #

--- a/pynestml/frontend/frontend_configuration.py
+++ b/pynestml/frontend/frontend_configuration.py
@@ -1,3 +1,4 @@
+
 #
 # frontend_configuration.py
 #
@@ -47,7 +48,7 @@ qualifier_target_arg = '--target'
 qualifier_logging_level_arg = '--logging_level'
 qualifier_module_name_arg = '--module_name'
 qualifier_store_log_arg = '--store_log'
-qualifier_suffix = '--suffix'
+qualifier_suffix_arg = '--suffix'
 qualifier_dev_arg = '--dev'
 
 
@@ -89,7 +90,7 @@ appropriate numeric solver otherwise.
         cls.argument_parser.add_argument(qualifier_logging_level_arg, metavar='[INFO, WARNING/S, ERROR/S, NO]', type=str,help=help_logging)
         cls.argument_parser.add_argument(qualifier_module_name_arg, metavar='NAME', type=str, help=help_module)
         cls.argument_parser.add_argument(qualifier_store_log_arg, action='store_true', help=help_log)
-        cls.argument_parser.add_argument(qualifier_suffix, metavar='SUFFIX', type=str, help=help_suffix, default='')
+        cls.argument_parser.add_argument(qualifier_suffix_arg, metavar='SUFFIX', type=str, help=help_suffix, default='')
         cls.argument_parser.add_argument(qualifier_dev_arg, action='store_true', help=help_dev)
         parsed_args = cls.argument_parser.parse_args(args)
         # get the source path

--- a/pynestml/frontend/pynestml_frontend.py
+++ b/pynestml/frontend/pynestml_frontend.py
@@ -57,7 +57,7 @@ def to_nest(input_path, target_path = None, logging_level = 'ERROR', module_name
     if store_log:
         args.append(qualifier_store_log_arg)
     if len(suffix) > 0:
-        args.append(qualifier_suffix)
+        args.append(qualifier_suffix_arg)
         args.append(suffix)
     if dev:
         args.append(qualifier_dev_arg)

--- a/pynestml/frontend/pynestml_frontend.py
+++ b/pynestml/frontend/pynestml_frontend.py
@@ -25,7 +25,7 @@ from pynestml.cocos.co_cos_manager import CoCosManager
 from pynestml.codegeneration.codegenerator import CodeGenerator
 from pynestml.frontend.frontend_configuration import FrontendConfiguration, InvalidPathException, \
     qualifier_store_log_arg, qualifier_module_name_arg, qualifier_logging_level_arg, \
-    qualifier_target_arg, qualifier_target_path_arg, qualifier_input_path_arg, qualifier_dev_arg
+    qualifier_target_arg, qualifier_target_path_arg, qualifier_input_path_arg, qualifier_suffix_arg, qualifier_dev_arg
 from pynestml.symbols.predefined_functions import PredefinedFunctions
 from pynestml.symbols.predefined_types import PredefinedTypes
 from pynestml.symbols.predefined_units import PredefinedUnits
@@ -37,7 +37,7 @@ from pynestml.utils.model_installer import install_nest as nest_installer
 
 
 def to_nest(input_path, target_path = None, logging_level = 'ERROR', module_name = None, store_log = False,
-            dev = False):
+            suffix = "", dev = False):
     # if target_path is not None and not os.path.isabs(target_path):
     #    print('PyNestML: Please provide absolute target path!')
     #    return
@@ -56,6 +56,9 @@ def to_nest(input_path, target_path = None, logging_level = 'ERROR', module_name
         args.append(str(module_name))
     if store_log:
         args.append(qualifier_store_log_arg)
+    if len(suffix) > 0:
+        args.append(qualifier_suffix)
+        args.append(suffix)
     if dev:
         args.append(qualifier_dev_arg)
     FrontendConfiguration.parse_config(args)

--- a/pynestml/meta_model/ast_neuron.py
+++ b/pynestml/meta_model/ast_neuron.py
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from pynestml.frontend.frontend_configuration import FrontendConfiguration
 from pynestml.meta_model.ast_node import ASTNode
 from pynestml.meta_model.ast_ode_shape import ASTOdeShape
 from pynestml.meta_model.ast_body import ASTBody
@@ -62,7 +63,7 @@ class ASTNeuron(ASTNode):
         assert (artifact_name is not None and isinstance(artifact_name, str)), \
             '(PyNestML.AST.Neuron) No or wrong type of artifact name provided (%s)!' % type(artifact_name)
         super(ASTNeuron, self).__init__(source_position)
-        self.name = name
+        self.name = name + FrontendConfiguration.suffix
         self.body = body
         self.artifact_name = artifact_name
 

--- a/tests/as_component_test.py
+++ b/tests/as_component_test.py
@@ -36,8 +36,9 @@ class AsComponentTest(unittest.TestCase):
         logging_level = 'NO'
         module_name = 'module'
         store_log = False
+        suffix = ''
         dev = True
-        to_nest(input_path, target_path, logging_level, module_name, store_log, dev)
+        to_nest(input_path, target_path, logging_level, module_name, store_log, suffix, dev)
         self.assertTrue(os.path.isfile(os.path.join(FrontendConfiguration.get_target_path(), 'CMakeLists.txt')))
         self.assertTrue(os.path.isfile(os.path.join(FrontendConfiguration.get_target_path(), 'commentTest.cpp')))
         self.assertTrue(os.path.isfile(os.path.join(FrontendConfiguration.get_target_path(), 'commentTest.h')))
@@ -50,8 +51,9 @@ class AsComponentTest(unittest.TestCase):
         logging_level = 'NO'
         module_name = 'module'
         store_log = False
+        suffix = ''
         dev = True
-        to_nest(input_path, target_path, logging_level, module_name, store_log, dev)
+        to_nest(input_path, target_path, logging_level, module_name, store_log, suffix, dev)
         self.assertTrue(os.path.isfile(os.path.join(FrontendConfiguration.get_target_path(), 'CMakeLists.txt')))
         self.assertTrue(os.path.isfile(os.path.join(FrontendConfiguration.get_target_path(), 'commentTest.cpp')))
         self.assertTrue(os.path.isfile(os.path.join(FrontendConfiguration.get_target_path(), 'commentTest.h')))


### PR DESCRIPTION
This PR adds a 'suffix' parameter to the command-line arguments. A suffix string will be appended to the name of all generated models. This helps to keep the native NEST models namespace separate from the namespace containing all the NESTML generated models. The models coverage checker script, at least in its current implementation, requires this feature.