### PR TITLE
Function call argument list

### DIFF
--- a/pynestml/codegeneration/expressions_pretty_printer.py
+++ b/pynestml/codegeneration/expressions_pretty_printer.py
@@ -117,15 +117,6 @@ class ExpressionsPrettyPrinter(object):
             ret.append(self.print_expression(arg))
         return tuple(ret)
 
-    def print_function_call_arguments(self, function_call):
-        # type: (ASTFunctionCall) -> str
-        ret = ''
-        for arg in function_call.get_args():
-            ret += self.print_expression(arg)
-            if function_call.get_args().index(arg) < len(function_call.get_args()) - 1:
-                ret += ', '
-        return ret
-
 
 class TypesPrinter(object):
     """

--- a/pynestml/codegeneration/expressions_pretty_printer.py
+++ b/pynestml/codegeneration/expressions_pretty_printer.py
@@ -106,9 +106,16 @@ class ExpressionsPrettyPrinter(object):
         # type: (ASTFunctionCall) -> str
         function_name = self.reference_converter.convert_function_call(function_call)
         if ASTUtils.needs_arguments(function_call):
-            return function_name % self.print_function_call_arguments(function_call)
+            return function_name % self.print_function_call_argument_list(function_call)
         else:
             return function_name
+
+    def print_function_call_argument_list(self, function_call):
+        # type: (ASTFunctionCall) -> tuple of str
+        ret = []
+        for arg in function_call.get_args():
+            ret.append(self.print_expression(arg))
+        return tuple(ret)
 
     def print_function_call_arguments(self, function_call):
         # type: (ASTFunctionCall) -> str

--- a/pynestml/codegeneration/gsl_reference_converter.py
+++ b/pynestml/codegeneration/gsl_reference_converter.py
@@ -85,7 +85,7 @@ class GSLReferenceConverter(IReferenceConverter):
         if function_name == 'steps':
             return 'nest::Time(nest::Time::ms((double) %s)).get_steps()'
         if function_name == PredefinedFunctions.POW:
-            return 'std::pow(%s)'
+            return 'std::pow(%s, %s)'
         if function_name == PredefinedFunctions.LOG:
             return 'std::log(%s)'
         if function_name == PredefinedFunctions.EXPM1:
@@ -96,9 +96,9 @@ class GSLReferenceConverter(IReferenceConverter):
             else:
                 return 'std::exp(%s)'
         if function_name == PredefinedFunctions.MAX or function_name == PredefinedFunctions.BOUNDED_MAX:
-            return 'std::max(%s)'
+            return 'std::max(%s, %s)'
         if function_name == PredefinedFunctions.MIN or function_name == PredefinedFunctions.BOUNDED_MIN:
-            return 'std::min(%s)'
+            return 'std::min(%s, %s)'
         if function_name == PredefinedFunctions.EMIT_SPIKE:
             return 'set_spiketime(nest::Time::step(origin.get_steps()+lag+1));\n' \
                    'nest::SpikeEvent se;\n' \

--- a/pynestml/codegeneration/idempotent_reference_converter.py
+++ b/pynestml/codegeneration/idempotent_reference_converter.py
@@ -59,7 +59,8 @@ class IdempotentReferenceConverter(IReferenceConverter):
         """
         result = function_call.get_name()
         if ASTUtils.needs_arguments(function_call):
-            result += '(%s)'
+            n_args = len(function_call.get_args())
+            result += '(' + ', '.join(['%s' for _ in range(n_args)]) + ')'
         else:
             result += '()'
         return result

--- a/pynestml/codegeneration/nest_reference_converter.py
+++ b/pynestml/codegeneration/nest_reference_converter.py
@@ -91,11 +91,11 @@ class NESTReferenceConverter(IReferenceConverter):
         elif function_name == 'steps':
             return 'nest::Time(nest::Time::ms((double) %s)).get_steps()'
         elif function_name == PredefinedFunctions.POW:
-            return 'std::pow(%s)'
+            return 'std::pow(%s, %s)'
         elif function_name == PredefinedFunctions.MAX or function_name == PredefinedFunctions.BOUNDED_MAX:
-            return 'std::max(%s)'
+            return 'std::max(%s, %s)'
         elif function_name == PredefinedFunctions.MIN or function_name == PredefinedFunctions.BOUNDED_MIN:
-            return 'std::min(%s)'
+            return 'std::min(%s, %s)'
         elif function_name == PredefinedFunctions.EXP:
             return 'std::exp(%s)'
         elif function_name == PredefinedFunctions.LOG:
@@ -107,7 +107,8 @@ class NESTReferenceConverter(IReferenceConverter):
                    'nest::SpikeEvent se;\n' \
                    'nest::kernel().event_delivery_manager.send(*this, se, lag)'
         elif ASTUtils.needs_arguments(function_call):
-            return function_name + '(%s)'
+            n_args = len(function_call.get_args())
+            return function_name + '(' + ', '.join(['%s' for _ in range(n_args)]) + ')'
         else:
             return function_name + '()'
 


### PR DESCRIPTION
This deprecates the old formatter for function call parameters:

https://github.com/clinssen/nestml/blob/3204d21aeb8ee8cba290812c3891c4068b13a5c2/pynestml/codegeneration/expressions_pretty_printer.py#L113

in favour of a more flexible format:

https://github.com/clinssen/nestml/blob/365ca09d47a9b55356bf2f542aecb9c6de5ffc1c/pynestml/codegeneration/expressions_pretty_printer.py#L113