### PR TITLE
fix refactoring class name from ASTSourcePosition to ASTSourceLocation

### DIFF
--- a/pynestml/meta_model/ast_arithmetic_operator.py
+++ b/pynestml/meta_model/ast_arithmetic_operator.py
@@ -37,7 +37,7 @@ class ASTArithmeticOperator(ASTNode):
     """
 
     def __init__(self, is_times_op, is_div_op, is_modulo_op, is_plus_op, is_minus_op, is_pow_op, source_position):
-        # type:(bool,bool,bool,bool,bool,bool,ASTSourcePosition) -> None
+        # type:(bool,bool,bool,bool,bool,bool,ASTSourceLocation) -> None
         assert ((is_times_op + is_div_op + is_modulo_op + is_plus_op + is_minus_op + is_pow_op) == 1), \
             '(PyNESTML.AST.ArithmeticOperator) Type of arithmetic operator not specified!'
         super(ASTArithmeticOperator, self).__init__(source_position)

--- a/pynestml/meta_model/ast_node.py
+++ b/pynestml/meta_model/ast_node.py
@@ -98,7 +98,7 @@ class ASTNode(object):
         """
         Updates the source position of the element.
         :param new_position: a new source position
-        :type new_position: ASTSourcePosition
+        :type new_position: ASTSourceLocation
         :return: a source position object.
         :rtype: ASTSourceLocation
         """

--- a/pynestml/meta_model/ast_source_location.py
+++ b/pynestml/meta_model/ast_source_location.py
@@ -50,7 +50,7 @@ class ASTSourceLocation(object):
     @classmethod
     def make_ast_source_position(cls, start_line, start_column, end_line, end_column):
         """
-        Factory method of the ASTSourcePosition class.
+        Factory method of the ASTSourceLocation class.
         :param start_line: The start line of the object
         :type start_line: int
         :param start_column: The start column of the object
@@ -59,7 +59,7 @@ class ASTSourceLocation(object):
         :type end_line: int
         :param end_column: The end column of the object
         :type end_column: int
-        :return: a new ASTSourcePosition object
+        :return: a new ASTSourceLocation object
         :rtype: ASTSourceLocation
         """
         return cls(start_line=start_line, start_column=start_column, end_line=end_line, end_column=end_column)

--- a/pynestml/utils/ast_utils.py
+++ b/pynestml/utils/ast_utils.py
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 from pynestml.meta_model.ast_function_call import ASTFunctionCall
+from pynestml.meta_model.ast_source_location import ASTSourceLocation
 from pynestml.symbols.predefined_functions import PredefinedFunctions
 from pynestml.symbols.symbol import SymbolKind
 from pynestml.utils.logger import LoggingLevel, Logger
@@ -373,7 +374,7 @@ class ASTUtils(object):
         from pynestml.meta_model.ast_node_factory import ASTNodeFactory
         if neuron.get_internals_blocks() is None:
             internal = ASTNodeFactory.create_ast_block_with_variables(False, False, True, False, list(),
-                                                                      ASTSourcePosition.get_added_source_position())
+                                                                      ASTSourceLocation.get_added_source_position())
             neuron.get_body().get_body_elements().append(internal)
         return neuron
 
@@ -390,7 +391,7 @@ class ASTUtils(object):
         from pynestml.meta_model.ast_node_factory import ASTNodeFactory
         if neuron.get_internals_blocks() is None:
             state = ASTNodeFactory.create_ast_block_with_variables(True, False, False, False, list(),
-                                                                   ASTSourcePosition.get_added_source_position())
+                                                                   ASTSourceLocation.get_added_source_position())
             neuron.get_body().get_body_elements().append(state)
         return neuron
 
@@ -408,7 +409,7 @@ class ASTUtils(object):
         if neuron.get_initial_blocks() is None:
             initial_values = ASTNodeFactory. \
                 create_ast_block_with_variables(False, False, False, True, list(),
-                                                ASTSourcePosition.get_added_source_position())
+                                                ASTSourceLocation.get_added_source_position())
             neuron.get_body().get_body_elements().append(initial_values)
         return neuron
 


### PR DESCRIPTION
Stray references to a non-existent class `ASTSourcePosition` replaced by `ASTSourceLocation`