### PR TITLE
Explicitly disable ode-toolbox stiffness testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,15 @@ before_install:
   - export PATH=$PATH:`pwd`
   - pip install --upgrade pip enum34 pytest
   - pip install -r requirements.txt
+ 
+  # gsl library to support ode-toolbox stiffness testing
+  - wget http://ftp.wrz.de/pub/gnu/gsl/gsl-2.5.tar.gz
+  - tar -xvzf gsl-2.5.tar.gz
+  - cd gsl-2.5
+  - ./configure && make && sudo make install
+  - cd ..
+  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
   #- pip install matplotlib
   #- cd ~ && git clone https://github.com/nest/nest-simulator nest_source
   #- mkdir nest_install
@@ -31,6 +40,7 @@ install:
   - export PYTHONPATH=$PYTHONPATH:`pwd`
   - echo $PYTHONPATH
   - python setup.py install
+
   #- python PyNestML.py -path models -target target
   #- cd ../target && mkdir build && cd build
   #- cmake -Dwith-nest=~/nest_install/bin/nest-config .. && make && make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
   - ./configure && make && sudo make install
   - cd ..
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+  - pip install pygsl
 
   #- pip install matplotlib
   #- cd ~ && git clone https://github.com/nest/nest-simulator nest_source

--- a/pynestml/codegeneration/nest_codegenerator.py
+++ b/pynestml/codegeneration/nest_codegenerator.py
@@ -348,7 +348,7 @@ class NESTCodeGenerator(CodeGenerator):
         # type: (ASTEquationsBlock) -> dict[str, list]
         odes_shapes_json = self.transform_ode_and_shapes_to_json(equations_block)
 
-        return analysis(odes_shapes_json)
+        return analysis(odes_shapes_json, enable_stiffness_check=False)
 
 
     def transform_ode_and_shapes_to_json(self, equations_block):
@@ -406,7 +406,7 @@ class NESTCodeGenerator(CodeGenerator):
                                      "definition": shape_name_to_shape_definition[shape_name],
                                      "initial_values": shape_name_to_initial_values[shape_name]})
 
-        result["parameters"] = []  # ode-framework requires this.
+        result["parameters"] = {}  # ode-framework requires this.
         return result
 
 
@@ -414,7 +414,7 @@ class NESTCodeGenerator(CodeGenerator):
         # type: (ASTEquationsBlock) -> dict[str, list]
         shapes_json = self.transform_functional_shapes_to_json(equations_block)
 
-        return analysis(shapes_json)
+        return analysis(shapes_json, enable_stiffness_check=False)
 
 
     def transform_functional_shapes_to_json(self, equations_block):
@@ -432,7 +432,7 @@ class NESTCodeGenerator(CodeGenerator):
                                          "symbol": shape.get_variable().get_complete_name(),
                                          "definition": self._printer.print_expression(shape.get_expression())})
 
-        result["parameters"] = []  # ode-framework requires this.
+        result["parameters"] = {}  # ode-framework requires this.
         return result
 
     def make_functions_self_contained(self, functions):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ typing
 astropy == 2.0.3
 enum34
 git+https://github.com/nest/ode-toolbox.git
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,5 @@ Jinja2 >= 2.10
 typing
 astropy == 2.0.3
 enum34
-pygsl
 git+https://github.com/nest/ode-toolbox.git
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,6 @@ Jinja2 >= 2.10
 typing
 astropy == 2.0.3
 enum34
+pygsl
 git+https://github.com/nest/ode-toolbox.git
+


### PR DESCRIPTION
Adds installation of GSL and PyGSL to the Travis CI environment, enabling the automated stiffness checker from ode-toolbox.

Unfortunately, stiffness checking has to remain disabled because of implementation gaps in the NESTML/ode-toolbox coupling. These will be addressed in a separate PR. For the time being, an extra boolean parameter is passed to `analysis()` to indicate whether or not stiffness checking should be skipped. This first requires that the necessary support is merged in on the side of ode-toolbox, namely PRs https://github.com/jougs/ode-toolbox/pull/5 and https://github.com/nest/ode-toolbox/pull/12/, in that order.

The upshot of this PR is to explicitly disable stiffness checking, instead of depending on the non-presence of GSL/PyGSL in the runtime environment. These two libraries are optional dependencies of NESTML. If indeed installed, they would otherwise cause the end user to run into exceptions thrown from within ode-toolbox during a NESTML code generation run.