### PR TITLE
add prefix to function calls to permit proper resolution in C++

### DIFF
--- a/pynestml/codegeneration/expressions_pretty_printer.py
+++ b/pynestml/codegeneration/expressions_pretty_printer.py
@@ -47,7 +47,20 @@ class ExpressionsPrettyPrinter(object):
             self.types_printer = TypesPrinter()
 
     def print_expression(self, node, prefix=''):
-        # type: (ASTExpressionNode) -> str
+        """Print an expression.
+
+        Parameters
+        ----------
+        node : ASTExpressionNode
+            The expression node to print.
+        prefix : str
+            *See documentation for the function print_function_call().*
+
+        Returns
+        -------
+        s : str
+            The expression string.
+        """
         if node.get_implicit_conversion_factor() is not None:
             return str(node.get_implicit_conversion_factor()) + ' * (' + self.__do_print(node) + ')'
         else:
@@ -103,7 +116,22 @@ class ExpressionsPrettyPrinter(object):
             raise RuntimeError('Unsupported rhs in rhs pretty printer!')
 
     def print_function_call(self, function_call, prefix=''):
-        # type: (ASTFunctionCall) -> str
+        """Print a function call, including bracketed arguments list.
+
+        Parameters
+        ----------
+        node : ASTFunctionCall
+            The function call node to print.
+        prefix : str
+            Optional string that will be prefixed to the function call. For example, to refer to a function call in the class "node", use a prefix equal to "node." or "node->".
+
+            Predefined functions will not be prefixed.
+
+        Returns
+        -------
+        s : str
+            The function call string.
+        """
         function_name = self.reference_converter.convert_function_call(function_call)
         function_is_predefined = PredefinedFunctions.get_function(function_call.get_name())  # check if function is "predefined" purely based on the name, as we don't have access to the function symbol here
 

--- a/pynestml/codegeneration/expressions_pretty_printer.py
+++ b/pynestml/codegeneration/expressions_pretty_printer.py
@@ -46,14 +46,14 @@ class ExpressionsPrettyPrinter(object):
         else:
             self.types_printer = TypesPrinter()
 
-    def print_expression(self, node):
+    def print_expression(self, node, prefix=""):
         # type: (ASTExpressionNode) -> str
         if node.get_implicit_conversion_factor() is not None:
             return str(node.get_implicit_conversion_factor()) + ' * (' + self.__do_print(node) + ')'
         else:
-            return self.__do_print(node)
+            return self.__do_print(node, prefix=prefix)
 
-    def __do_print(self, node):
+    def __do_print(self, node, prefix=""):
         # type: (ASTExpressionNode) -> str
         if isinstance(node, ASTSimpleExpression):
             if node.has_unit():
@@ -73,48 +73,48 @@ class ExpressionsPrettyPrinter(object):
             elif node.is_variable():
                 return self.reference_converter.convert_name_reference(node.get_variable())
             elif node.is_function_call():
-                return self.print_function_call(node.get_function_call())
+                return self.print_function_call(node.get_function_call(), prefix=prefix)
         elif isinstance(node, ASTExpression):
             # a unary operator
             if node.is_unary_operator():
                 op = self.reference_converter.convert_unary_op(node.get_unary_operator())
-                rhs = self.print_expression(node.get_expression())
+                rhs = self.print_expression(node.get_expression(), prefix=prefix)
                 return op % rhs
             # encapsulated in brackets
             elif node.is_encapsulated:
-                return self.reference_converter.convert_encapsulated() % self.print_expression(node.get_expression())
+                return self.reference_converter.convert_encapsulated() % self.print_expression(node.get_expression(), prefix=prefix)
             # logical not
             elif node.is_logical_not:
                 op = self.reference_converter.convert_logical_not()
-                rhs = self.print_expression(node.get_expression())
+                rhs = self.print_expression(node.get_expression(), prefix=prefix)
                 return op % rhs
             # compound rhs with lhs + rhs
             elif node.is_compound_expression():
-                lhs = self.print_expression(node.get_lhs())
+                lhs = self.print_expression(node.get_lhs(), prefix=prefix)
                 op = self.reference_converter.convert_binary_op(node.get_binary_operator())
-                rhs = self.print_expression(node.get_rhs())
+                rhs = self.print_expression(node.get_rhs(), prefix=prefix)
                 return op % (lhs, rhs)
             elif node.is_ternary_operator():
-                condition = self.print_expression(node.get_condition())
-                if_true = self.print_expression(node.get_if_true())
-                if_not = self.print_expression(node.if_not)
+                condition = self.print_expression(node.get_condition(), prefix=prefix)
+                if_true = self.print_expression(node.get_if_true(), prefix=prefix)
+                if_not = self.print_expression(node.if_not, prefix=prefix)
                 return self.reference_converter.convert_ternary_operator() % (condition, if_true, if_not)
         else:
             raise RuntimeError('Unsupported rhs in rhs pretty printer!')
 
-    def print_function_call(self, function_call):
+    def print_function_call(self, function_call, prefix=""):
         # type: (ASTFunctionCall) -> str
         function_name = self.reference_converter.convert_function_call(function_call)
         if ASTUtils.needs_arguments(function_call):
-            return function_name % self.print_function_call_argument_list(function_call)
+            return prefix + function_name % self.print_function_call_argument_list(function_call, prefix=prefix)
         else:
-            return function_name
+            return prefix + function_name
 
-    def print_function_call_argument_list(self, function_call):
+    def print_function_call_argument_list(self, function_call, prefix=""):
         # type: (ASTFunctionCall) -> tuple of str
         ret = []
         for arg in function_call.get_args():
-            ret.append(self.print_expression(arg))
+            ret.append(self.print_expression(arg, prefix=prefix))
         return tuple(ret)
 
 

--- a/pynestml/codegeneration/expressions_pretty_printer.py
+++ b/pynestml/codegeneration/expressions_pretty_printer.py
@@ -23,8 +23,8 @@ from pynestml.meta_model.ast_expression import ASTExpression
 from pynestml.meta_model.ast_expression_node import ASTExpressionNode
 from pynestml.meta_model.ast_function_call import ASTFunctionCall
 from pynestml.meta_model.ast_simple_expression import ASTSimpleExpression
+from pynestml.symbols.predefined_functions import PredefinedFunctions
 from pynestml.utils.ast_utils import ASTUtils
-
 
 class ExpressionsPrettyPrinter(object):
     """
@@ -46,14 +46,14 @@ class ExpressionsPrettyPrinter(object):
         else:
             self.types_printer = TypesPrinter()
 
-    def print_expression(self, node, prefix=""):
+    def print_expression(self, node, prefix=''):
         # type: (ASTExpressionNode) -> str
         if node.get_implicit_conversion_factor() is not None:
             return str(node.get_implicit_conversion_factor()) + ' * (' + self.__do_print(node) + ')'
         else:
             return self.__do_print(node, prefix=prefix)
 
-    def __do_print(self, node, prefix=""):
+    def __do_print(self, node, prefix=''):
         # type: (ASTExpressionNode) -> str
         if isinstance(node, ASTSimpleExpression):
             if node.has_unit():
@@ -102,15 +102,20 @@ class ExpressionsPrettyPrinter(object):
         else:
             raise RuntimeError('Unsupported rhs in rhs pretty printer!')
 
-    def print_function_call(self, function_call, prefix=""):
+    def print_function_call(self, function_call, prefix=''):
         # type: (ASTFunctionCall) -> str
         function_name = self.reference_converter.convert_function_call(function_call)
+        function_is_predefined = PredefinedFunctions.get_function(function_call.get_name())  # check if function is "predefined" purely based on the name, as we don't have access to the function symbol here
+
+        if function_is_predefined:
+            prefix = ''
+
         if ASTUtils.needs_arguments(function_call):
             return prefix + function_name % self.print_function_call_argument_list(function_call, prefix=prefix)
         else:
             return prefix + function_name
 
-    def print_function_call_argument_list(self, function_call, prefix=""):
+    def print_function_call_argument_list(self, function_call, prefix=''):
         # type: (ASTFunctionCall) -> tuple of str
         ret = []
         for arg in function_call.get_args():

--- a/pynestml/codegeneration/gsl_reference_converter.py
+++ b/pynestml/codegeneration/gsl_reference_converter.py
@@ -28,6 +28,7 @@ from pynestml.symbols.predefined_functions import PredefinedFunctions
 from pynestml.symbols.predefined_units import PredefinedUnits
 from pynestml.symbols.predefined_variables import PredefinedVariables
 from pynestml.symbols.symbol import SymbolKind
+from pynestml.utils.ast_utils import ASTUtils
 
 
 class GSLReferenceConverter(IReferenceConverter):
@@ -103,7 +104,12 @@ class GSLReferenceConverter(IReferenceConverter):
             return 'set_spiketime(nest::Time::step(origin.get_steps()+lag+1));\n' \
                    'nest::SpikeEvent se;\n' \
                    'nest::kernel().event_delivery_manager.send(*this, se, lag)'
-        raise RuntimeError('Cannot map the function: "' + function_name + '".')
+        elif ASTUtils.needs_arguments(function_call):
+            n_args = len(function_call.get_args())
+            return function_name + '(' + ', '.join(['%s' for _ in range(n_args)]) + ')'
+        else:
+            return function_name + '()'
+#        raise RuntimeError('Cannot map the function: "' + function_name + '".')
 
     def convert_constant(self, constant_name):
         """

--- a/pynestml/codegeneration/nest_printer.py
+++ b/pynestml/codegeneration/nest_printer.py
@@ -186,7 +186,7 @@ class NestPrinter(object):
                 if function_symbol.get_parameter_types().index(typeSym) < len(
                         function_symbol.get_parameter_types()) - 1:
                     declaration += ', '
-            declaration += ')\n'
+            declaration += ') const\n'
             return declaration
         else:
             raise RuntimeError('Cannot resolve the method ' + ast_function.get_name())
@@ -226,7 +226,7 @@ class NestPrinter(object):
                 if function_symbol.get_parameter_types().index(typeSym) < \
                         len(function_symbol.get_parameter_types()) - 1:
                     declaration += ', '
-            declaration += ')\n'
+            declaration += ') const\n'
             return declaration
         else:
             raise RuntimeError('Cannot resolve the method ' + ast_function.get_name())

--- a/pynestml/codegeneration/resources_nest/directives/GSLDifferentiationFunction.jinja2
+++ b/pynestml/codegeneration/resources_nest/directives/GSLDifferentiationFunction.jinja2
@@ -13,19 +13,19 @@ extern "C" inline int {{neuronName}}_dynamics(double, const double ode_state[], 
     {%- for function in utils.get_alias_symbols(ode) -%}
       {%- if not function.is_equation() -%}
         {% set declaringExpression = function.get_declaring_expression() -%}
-  double {{names.name(function)}} = {{printerGSL.print_expression(declaringExpression)}};
+  double {{names.name(function)}} = {{printerGSL.print_expression(declaringExpression, prefix="node.")}};
       {% endif -%}
     {% endfor -%}
   {% endfor %}
   {# todo by kp: this part is no longer required since we make all functions self contained
   {% for function in neuron.get_ode_aliases() -%}
     {% set declaringExpression = function.get_declaring_expression() -%}
-  double {{names.name(function)}} = {{printerGSL.print_expression(declaringExpression)}};
+  double {{names.name(function)}} = {{printerGSL.print_expression(declaringExpression, prefix="node.")}};
   {% endfor -%}
   #}
   {%- for odeVariable in neuron.get_non_function_initial_values_symbols() -%}
   {%- if odeVariable.is_ode_defined() %}
-  f[{{names.array_index(odeVariable)}}] = {{printerGSL.print_expression(odeVariable.get_ode_definition())}};
+  f[{{names.array_index(odeVariable)}}] = {{printerGSL.print_expression(odeVariable.get_ode_definition(), prefix="node.")}};
   {%- endif -%}
   {%- endfor %}
   return GSL_SUCCESS;


### PR DESCRIPTION
When using NESTML functions that are called from within the ODE stepping function, the calls could not be resolved because the stepping function is declared as an `extern "C"` and the functions are generated as part of the neuron class. This PR adds the necessary `node.` prefix.

This PR also declares each of these functions are "const", i.e. they should not modify the state of the neuron. I'm not sure if this is warranted, but otherwise we get complaints about violating const correctness elsewhere.