### PR TITLE
add friendly error message in case variable is not defined

### DIFF
--- a/pynestml/cocos/co_co_odes_have_consistent_units.py
+++ b/pynestml/cocos/co_co_odes_have_consistent_units.py
@@ -49,6 +49,10 @@ class OdeConsistentUnitsVisitor(ASTVisitor):
         """
         variable_name = node.get_lhs().get_name()
         variable_symbol = node.get_lhs().get_scope().resolve_to_symbol(variable_name, SymbolKind.VARIABLE)
+        if variable_symbol is None:
+            code, message = Messages.get_variable_not_defined(variable_name)
+            Logger.log_message(code=code, message=message, log_level=LoggingLevel.ERROR, error_position=node.get_source_position())
+            return
         variable_type = variable_symbol.type_symbol
         from pynestml.utils.unit_type import UnitType
         from pynestml.symbols.unit_type_symbol import UnitTypeSymbol


### PR DESCRIPTION
Under some conditions, this context condition checker can be called for an ODE in which the left-hand side variable is not defined. Previously, in this case, we try to get an attribute of None in the subsequent line, which leads to a non-helpful exception in the insides of PyNESTML. This PR fixes things by throwing a friendly error message and returning from the function.