### PR TITLE
Corrected error message in install_nest

### DIFF
--- a/pynestml/utils/model_installer.py
+++ b/pynestml/utils/model_installer.py
@@ -32,7 +32,7 @@ def install_nest(models_path, nest_path):
         print('PyNestML: Models path not a directory (%s)! abort installation...' % models_path)
         return
     if not os.path.isdir(nest_path):
-        print('PyNestML: NEST path not a directory (%s)! abort installation...' % models_path)
+        print('PyNestML: NEST path not a directory (%s)! abort installation...' % nest_path)
         return
 
     cmake_cmd = ['cmake', '-Dwith-nest=' + str(nest_path) + '/bin/nest-config', '.']


### PR DESCRIPTION
There is a copy-paste mistake in the error message of the ``install_nest`` function, which this PR corrects.