### PR TITLE
improve documentation of dev command-line parameter; connect to exising template debug boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ where arguments are:<a name="table_args"></a>
 | --logging_level| (Optional) Sets the logging level, i.e., which level of messages should be printed. Default is ERROR, available are [INFO, WARNING, ERROR, NO] |
 | --module_name  | (Optional) Sets the name of the module which shall be generated. Default is the name of the directory containing the models. The name has to end in "module". Default is `nestmlmodule`. |
 | --store_log    | (Optional) Stores a log.txt containing all messages in JSON notation. Default is OFF.|
-| --dev          | (Optional) Executes the toolchain in the development mode where errors in models are ignored. Default is OFF.|
+| --dev          | (Optional) Enable development mode: code generation is attempted even for models that contain errors, and extra information is rendered in the generated code. Default is OFF.|
 
 Generated artifacts are copied to the selected target directory (default is `target`). In order to install the models into NEST, the following commands have to be executed from within the target directory:
 ```
@@ -116,7 +116,7 @@ A typical script, therefore, could look like the following. For this example, we
 ```py
 from pynestml.frontend.pynestml_frontend import to_nest, install_nest
 
-to_nest(input_path="/home/nest/work/pynestml/models", target_path="/home/nest/work/pynestml/target", dev=True)
+to_nest(input_path="/home/nest/work/pynestml/models", target_path="/home/nest/work/pynestml/target")
 
 install_nest("/home/nest/work/pynestml/target", "/home/nest/work/nest-install")
 

--- a/pynestml/codegeneration/nest_codegenerator.py
+++ b/pynestml/codegeneration/nest_codegenerator.py
@@ -228,6 +228,7 @@ class NESTCodeGenerator(CodeGenerator):
         namespace['odeTransformer'] = OdeTransformer()
         namespace['printerGSL'] = gsl_printer
         namespace['now'] = datetime.datetime.utcnow()
+        namespace['tracing'] = FrontendConfiguration.is_dev
 
         self.define_solver_type(neuron, namespace)
         return namespace

--- a/pynestml/frontend/frontend_configuration.py
+++ b/pynestml/frontend/frontend_configuration.py
@@ -31,15 +31,11 @@ from pynestml.utils.messages import Messages
 help_input_path = 'Path to a single file or a directory containing the source models.'
 help_target_path = 'Path to a target directory where models should be generated to. Standard is "target".'
 help_target = 'Name of the target platform to build code for. Default is NEST.'
-help_logging = 'Indicates which messages shall be logged and printed to the screen. ' \
-               'Standard is ERRORS.'
-help_module = 'Indicates the name of the module. Optional. If not indicated, ' \
-              'the name of the directory containing the models is used!'
+help_logging = 'Indicates which messages shall be logged and printed to the screen. Standard is ERROR.'
+help_module = 'Indicates the name of the module. Optional. If not indicated, the name of the directory containing the models is used!'
 help_log = 'Indicates whether a log file containing all messages shall be stored. Standard is NO.'
 help_suffix = 'A suffix string that will be appended to the name of all generated models.'
-help_dev = 'Indicates whether the dev mode should be active, i.e., ' \
-           'the whole toolchain executed even though errors in models are present.' \
-           ' This option is designed for debug purpose only!'
+help_dev = 'Enable development mode: code generation is attempted even for models that contain errors, and extra information is rendered in the generated code.'
 
 qualifier_input_path_arg = '--input_path'
 qualifier_target_path_arg = '--target_path'
@@ -64,7 +60,7 @@ class FrontendConfiguration(object):
     module_name = None
     store_log = False
     suffix = ''
-    is_debug = False
+    is_dev = False
 
     @classmethod
     def parse_config(cls, args):
@@ -118,7 +114,7 @@ appropriate numeric solver otherwise.
             cls.module_name = 'nestmlmodule'
         cls.store_log = parsed_args.store_log
         cls.suffix = parsed_args.suffix
-        cls.is_debug = parsed_args.dev
+        cls.is_dev = parsed_args.dev
         return
 
     @classmethod
@@ -178,11 +174,11 @@ appropriate numeric solver otherwise.
     @classmethod
     def is_dev(cls):
         """
-        Returns whether the dev mode have benn set as active.
-        :return: True if dev mode is active, otherwise False.
+        Returns whether the development mode has been enabled.
+        :return: True if development mode is enabled, otherwise False.
         :rtype: bool
         """
-        return cls.is_debug
+        return cls.is_dev
 
     @classmethod
     def handle_target(cls, target):

--- a/pynestml/frontend/pynestml_frontend.py
+++ b/pynestml/frontend/pynestml_frontend.py
@@ -38,29 +38,24 @@ from pynestml.utils.model_installer import install_nest as nest_installer
 
 def to_nest(input_path, target_path=None, logging_level='ERROR',
             module_name=None, store_log=False, suffix="", dev=False):
-    '''
-    Translate NESTML files into their equivalent C++ code for the NEST
-    simulator.
+    '''Translate NESTML files into their equivalent C++ code for the NEST simulator.
 
     Parameters
     ----------
     input_path : str
-        Path to the NESTML file or to a folder containing NESTML files to
-        convert to NEST code.
+        Path to the NESTML file or to a folder containing NESTML files to convert to NEST code.
     target_path : str, optional (default: append "target" to `input_path`)
         Path to the generated C++ code and install files.
     logging_level : str, optional (default: 'ERROR')
-        Sets which level of information should be displayed duing code
-        generation (among 'ERROR', 'WARNING', 'INFO', or 'NO').
+        Sets which level of information should be displayed duing code generation (among 'ERROR', 'WARNING', 'INFO', or 'NO').
     module_name : str, optional (default: "nestmlmodule")
-        Name of the module, which will be used to import the model in NEST via
-        ``nest.Install(module_name)``.
+        Name of the module, which will be used to import the model in NEST via `nest.Install(module_name)`.
     store_log : bool, optional (default: False)
         Whether the log should be saved to file.
     suffix : str, optional (default: "")
-        Suffix which will be appended to the model's name (internal use to
-        avoid naming conflicts with existing NEST models).
+        Suffix which will be appended to the model's name (internal use to avoid naming conflicts with existing NEST models).
     dev : bool, optional (default: False)
+        Enable development mode: code generation is attempted even for models that contain errors, and extra information is rendered in the generated code.
     '''
     # if target_path is not None and not os.path.isabs(target_path):
     #    print('PyNestML: Please provide absolute target path!')
@@ -151,7 +146,7 @@ def process():
         # check if across two files two neurons with same name have been defined
         CoCosManager.check_not_two_neurons_across_units(compilation_units)
         # now exclude those which are broken, i.e. have errors.
-        if not FrontendConfiguration.is_dev():
+        if not FrontendConfiguration.is_dev:
             for neuron in neurons:
                 if Logger.has_errors(neuron):
                     code, message = Messages.get_neuron_contains_errors(neuron.get_name())


### PR DESCRIPTION
This fixes #476.

Minor cleanup of the `--dev` command-line parameter, as well as connecting this flag to the Jinja2 templates debugging flag `tracing`, which enables the printing of some debug information as comments in the generated code.