### PR TITLE
Throw exception in to_nest() when error(s) occur during code generation

### DIFF
--- a/pynestml/frontend/pynestml_frontend.py
+++ b/pynestml/frontend/pynestml_frontend.py
@@ -88,7 +88,8 @@ def to_nest(input_path, target_path=None, logging_level='ERROR',
         args.append(qualifier_dev_arg)
 
     FrontendConfiguration.parse_config(args)
-    process()
+    if not process() == 0:
+        raise Exception("Error(s) occurred while processing the model")
 
 
 def install_nest(models_path, nest_path):


### PR DESCRIPTION
If exception is not thrown, user script might happily continue with `install_nest()`, which will either throw confusing follow-on errors, or quietly use previously generated (i.e. out-of-date) code.