### PR TITLE
Rename natural logarithm function to ln() and disambiguate base-10 log function by renaming to log10()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,3 +94,4 @@ jobs:
         - echo $PYNESTKERNEL_LOCATION
         - export PYTHONPATH=$PYTHONPATH:$PYNESTKERNEL_LOCATION
         - python $TRAVIS_BUILD_DIR/extras/nest_integration_test.py
+        - python $TRAVIS_BUILD_DIR/extras/nest_logarithmic_function_test.py

--- a/doc/nestml_language.md
+++ b/doc/nestml_language.md
@@ -209,7 +209,8 @@ The following functions are predefined in NestML and can be used out of the box:
 | max | x, y | Returns the maximum of x and y. Both parameters should be of the same type. The return type is equal to the type of the parameters. |
 | clip | x, y, z | Returns x if it is in [y, z], y if x < y and z if x > z. All parameter types should be the same and equal to the return type. |
 | exp | x | Returns the exponential of x. The type of x and the return type are Real. |
-| log | x | Returns the base 10 logarithm of x. The type of x and the return type are Real. |
+| log10 | x | Returns the base 10 logarithm of x. The type of x and the return type are Real. |
+| ln | x | Returns the base :math:`e` logarithm of x. The type of x and the return type are Real. |
 | expm1 | x | Returns the exponential of x minus 1. The type of x and the return type are Real. |
 | sinh | x | Returns the hyperbolic sine of x. The type of x and the return type are Real. |
 | cosh | x | Returns the hyperbolic cosine of x. The type of x and the return type are Real. |

--- a/models/hill_tononi.nestml
+++ b/models/hill_tononi.nestml
@@ -240,7 +240,7 @@ neuron hill_tononi:
     # section 3.1.2.
     exact_integration_adjustment real = ( ( 1 / Tau_2 ) - ( 1 / Tau_1 ) ) * ms
 
-    t_peak real = ( Tau_2 * Tau_1 ) * log( Tau_2 / Tau_1 ) / ( Tau_2 - Tau_1 ) / ms
+    t_peak real = ( Tau_2 * Tau_1 ) * ln( Tau_2 / Tau_1 ) / ( Tau_2 - Tau_1 ) / ms
     normalisation_factor real = 1 / ( exp( -t_peak / Tau_1 ) - exp( -t_peak / Tau_2 ) )
 
     return g_peak * normalisation_factor * exact_integration_adjustment

--- a/pynestml/codegeneration/nest_reference_converter.py
+++ b/pynestml/codegeneration/nest_reference_converter.py
@@ -119,8 +119,11 @@ class NESTReferenceConverter(IReferenceConverter):
         if function_name == PredefinedFunctions.EXP:
             return 'std::exp({!s})'
 
-        if function_name == PredefinedFunctions.LOG:
+        if function_name == PredefinedFunctions.LN:
             return 'std::log({!s})'
+
+        if function_name == PredefinedFunctions.LOG10:
+            return 'std::log10({!s})'
 
         if function_name == PredefinedFunctions.COSH:
               return 'std::cosh({!s})'

--- a/pynestml/symbols/predefined_functions.py
+++ b/pynestml/symbols/predefined_functions.py
@@ -32,7 +32,8 @@ class PredefinedFunctions(object):
         PRINT                 The callee name of the print function.
         PRINTLN               The callee name of the println function.
         EXP                   The callee name of the exponent function.
-        LOG                   The callee name of the logarithm function.
+        LN                    The callee name of the natural logarithm function, i.e. the logarithm function of base :math:`e`.
+        LOG                   The callee name of the logarithm function of base 10.
         COSH                  The callee name of the hyperbolic cosine.
         SINH                  The callee name of the hyperbolic sine.
         TANH                  The callee name of the hyperbolic tangent.
@@ -57,7 +58,8 @@ class PredefinedFunctions(object):
     PRINT = 'print'
     PRINTLN = 'println'
     EXP = 'exp'
-    LOG = 'log'
+    LN = 'ln'
+    LOG10 = 'log10'
     COSH = 'cosh'
     SINH = 'sinh'
     TANH = 'tanh'
@@ -88,7 +90,8 @@ class PredefinedFunctions(object):
         cls.__register_print_function()
         cls.__register_print_ln_function()
         cls.__register_exponent_function()
-        cls.__register_log_function()
+        cls.__register_ln_function()
+        cls.__register_log10_function()
         cls.__register_cosh_function()
         cls.__register_sinh_function()
         cls.__register_tanh_function()
@@ -165,16 +168,28 @@ class PredefinedFunctions(object):
         cls.name2function[cls.EXP] = symbol
 
     @classmethod
-    def __register_log_function(cls):
+    def __register_ln_function(cls):
         """
-        Registers the logarithm function (to base 10).
+        Registers the natural logarithm function, i.e. the logarithm function of base :math:`e`.
         """
         params = list()
         params.append(PredefinedTypes.get_real_type())  # the argument
-        symbol = FunctionSymbol(name=cls.LOG, param_types=params,
+        symbol = FunctionSymbol(name=cls.LN, param_types=params,
                                 return_type=PredefinedTypes.get_real_type(),
                                 element_reference=None, is_predefined=True)
-        cls.name2function[cls.LOG] = symbol
+        cls.name2function[cls.LN] = symbol
+
+    @classmethod
+    def __register_log10_function(cls):
+        """
+        Registers the logarithm function of base 10.
+        """
+        params = list()
+        params.append(PredefinedTypes.get_real_type())  # the argument
+        symbol = FunctionSymbol(name=cls.LOG10, param_types=params,
+                                return_type=PredefinedTypes.get_real_type(),
+                                element_reference=None, is_predefined=True)
+        cls.name2function[cls.LOG10] = symbol
 
     @classmethod
     def __register_cosh_function(cls):

--- a/tests/nest_tests/nest_logarithmic_function_test.py
+++ b/tests/nest_tests/nest_logarithmic_function_test.py
@@ -36,6 +36,8 @@ except:
 
 if __name__ == "__main__":
 
+    MAX_SSE = 1E-12
+
     input_path = os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), "resources")))
     nest_path = "/home/travis/nest_install"
     target_path = 'target'
@@ -69,8 +71,8 @@ if __name__ == "__main__":
     ref_ln_state_ts = np.log(timevec - 1)
     ref_log10_state_ts = np.log10(timevec - 1)
 
-    assert np.all(ln_state_ts == ref_ln_state_ts)
-    assert np.all(log10_state_ts == ref_log10_state_ts)
+    assert np.all((ln_state_ts - ref_ln_state_ts)**2 < MAX_SSE)
+    assert np.all((log10_state_ts - ref_log10_state_ts)**2 < MAX_SSE)
 
     # test that expected failure occurs
 
@@ -94,5 +96,5 @@ if __name__ == "__main__":
     ref_ln_state_ts = np.log(timevec - 1)
     ref_log10_state_ts = np.log10(timevec - 1)
 
-    assert not np.all(ln_state_ts == ref_ln_state_ts)
-    assert not np.all(log10_state_ts == ref_log10_state_ts)
+    assert not np.all((ln_state_ts - ref_ln_state_ts)**2 < MAX_SSE)
+    assert not np.all((log10_state_ts - ref_log10_state_ts)**2 < MAX_SSE)

--- a/tests/nest_tests/nest_logarithmic_function_test.py
+++ b/tests/nest_tests/nest_logarithmic_function_test.py
@@ -1,0 +1,98 @@
+#
+# nest_logarithmic_function_test.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Sanity test for the predefined logarithmic functions ln() and log10()"""
+
+import os
+import nest
+import numpy as np
+from pynestml.frontend.pynestml_frontend import to_nest, install_nest
+
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
+    TEST_PLOTS = True
+except:
+    TEST_PLOTS = False
+
+
+
+if __name__ == "__main__":
+
+    input_path = os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), "resources")))
+    nest_path = "/home/travis/nest_install"
+    target_path = 'target'
+    logging_level = 'INFO'
+    module_name = 'nestmlmodule'
+    store_log = False
+    suffix = '_nestml'
+    dev = True
+    to_nest(input_path, target_path, logging_level, module_name, store_log, suffix, dev)
+    install_nest(target_path, nest_path)
+    nest.set_verbosity("M_ALL")
+
+    nest.ResetKernel()
+    nest.Install("nestmlmodule")
+
+    nrn = nest.Create("logarithm_function_test_nestml")
+    mm = nest.Create('multimeter')
+
+    ln_state_specifier = 'ln_state'
+    log10_state_specifier = 'log10_state'
+    nest.SetStatus(mm, {"withtime": True, "record_from": [ln_state_specifier, log10_state_specifier, "x"]})
+
+    nest.Connect(mm, nrn)
+
+    nest.Simulate(100.0)
+
+    dmm = nest.GetStatus(mm)[0]
+    timevec = dmm["events"]["x"]
+    ln_state_ts = dmm["events"][ln_state_specifier]
+    log10_state_ts = dmm["events"][log10_state_specifier]
+    ref_ln_state_ts = np.log(timevec - 1)
+    ref_log10_state_ts = np.log10(timevec - 1)
+
+    assert np.all(ln_state_ts == ref_ln_state_ts)
+    assert np.all(log10_state_ts == ref_log10_state_ts)
+
+    # test that expected failure occurs
+
+    nest.ResetKernel()
+    nrn = nest.Create("logarithm_function_test_invalid_nestml")
+
+    mm = nest.Create('multimeter')
+
+    ln_state_specifier = 'ln_state'
+    log10_state_specifier = 'log10_state'
+    nest.SetStatus(mm, {"withtime": True, "record_from": [ln_state_specifier, log10_state_specifier, "x"]})
+
+    nest.Connect(mm, nrn)
+
+    nest.Simulate(100.0)
+
+    dmm = nest.GetStatus(mm)[0]
+    timevec = dmm["events"]["x"]
+    ln_state_ts = dmm["events"][ln_state_specifier]
+    log10_state_ts = dmm["events"][log10_state_specifier]
+    ref_ln_state_ts = np.log(timevec - 1)
+    ref_log10_state_ts = np.log10(timevec - 1)
+
+    assert not np.all(ln_state_ts == ref_ln_state_ts)
+    assert not np.all(log10_state_ts == ref_log10_state_ts)

--- a/tests/nest_tests/resources/LogarithmicFunctionTest.nestml
+++ b/tests/nest_tests/resources/LogarithmicFunctionTest.nestml
@@ -1,0 +1,33 @@
+neuron logarithm_function_test:
+  state:
+  end
+
+  initial_values:
+    x real = 0.
+    ln_state real = 0.
+    log10_state real = 0.
+  end
+
+  equations:
+  end
+
+  parameters:
+  end
+
+  internals:
+  end
+
+  input:
+      spikeInh nS  <- inhibitory spike
+      spikeExc nS  <- excitatory spike
+      currents <- current
+  end
+
+  output: spike
+
+  update:
+    ln_state = ln(x)
+    log10_state = log10(x)
+    x = x + 1.
+  end
+end

--- a/tests/nest_tests/resources/LogarithmicFunctionTest_invalid.nestml
+++ b/tests/nest_tests/resources/LogarithmicFunctionTest_invalid.nestml
@@ -1,0 +1,33 @@
+neuron logarithm_function_test_invalid:
+  state:
+  end
+
+  initial_values:
+    x real = 0.
+    ln_state real = 0.
+    log10_state real = 0.
+  end
+
+  equations:
+  end
+
+  parameters:
+  end
+
+  internals:
+  end
+
+  input:
+      spikeInh nS  <- inhibitory spike
+      spikeExc nS  <- excitatory spike
+      currents <- current
+  end
+
+  output: spike
+
+  update:
+    ln_state = log10(x)
+    log10_state = ln(x)
+    x = x + 1.
+  end
+end

--- a/tests/resources/ExpressionCollection.nestml
+++ b/tests/resources/ExpressionCollection.nestml
@@ -459,7 +459,8 @@ neuron ExpressionCollection:
         r_potassium = PotassiumRefractoryCounts
         emit_spike()
         exact_integration_adjustment real = ( ( 1 / Tau_2 ) - ( 1 / Tau_1 ) ) * ms
-        t_peak real = ( Tau_2 * Tau_1 ) * log( Tau_2 / Tau_1 ) / ( Tau_2 - Tau_1 ) / ms
+        t_peak real = ( Tau_2 * Tau_1 ) * log10( Tau_2 / Tau_1 ) / ( Tau_2 - Tau_1 ) / ms
+        t_peak123 real = ( Tau_2 * Tau_1 ) * ln( Tau_2 / Tau_1 ) / ( Tau_2 - Tau_1 ) / ms
         normalisation_factor real = 1 / ( exp( -t_peak / Tau_1 ) - exp( -t_peak / Tau_2 ) )
         test = g_peak * normalisation_factor * exact_integration_adjustment
         # clip and hyperbolic functions


### PR DESCRIPTION
Includes an integration test, i.e. target code is generated for the NESTML functions `ln()` and `log10()`, which is then built on the target platform, and numerically compared to a reference timeseries. Includes an expected-to-fail integration test.