### PR TITLE
Hide "Edit on GitHub" link on ReadTheDocs pages

### DIFF
--- a/doc/sphinx-apidoc/_static/css/custom.css
+++ b/doc/sphinx-apidoc/_static/css/custom.css
@@ -1,3 +1,7 @@
+.wy-breadcrumbs-aside {
+   display: none !important;
+}
+
 .keep-us-sustainable {
    background-color: #272525;
 }


### PR DESCRIPTION
Because of automated documentation generation and other pre-processing that happens in ``conf.py``, these backlinks, which are by default automatically generated by a Sphinx extension running on ReadTheDocs, often result in a 404 error. Fixing this is not trivial as there is no mechanism to specify individually the "correct" link for each page. This PR hides all links for now to avoid having a lot of broken links in the documentation. We will follow further developments and discussion in https://github.com/nest/nest-simulator/issues/1655.

