### PR TITLE
Correct ODE-toolbox version dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ setuptools
 Jinja2 >= 2.10
 typing
 astropy == 2.0.3
-odetoolbox
+odetoolbox == 1.0


### PR DESCRIPTION
Required while #515 is not yet merged.

Fixes #553.