### PR TITLE
Change egg to wheel distribution type

### DIFF
--- a/extras/nestml-release-checklist.md
+++ b/extras/nestml-release-checklist.md
@@ -40,7 +40,7 @@ Follow this checklist to successfully perform a NESTML release. Let's say that 3
 - Perform a corresponding release on PyPi. From the `release-v3.1` branch:
 
   ```bash
-  python setup.py sdist
+  python setup.py bdist_wheel
   twine upload dist/*
   ```
 


### PR DESCRIPTION
"Eggs" are deprecated and have been replaced by "wheels". This is causing NESTML v3.1 to not be correctly detected by some pip clients. I already rebuilt the distribution package for v3.1 and uploaded it to PyPi.