### PR TITLE
Allow no input or output block in the model

### DIFF
--- a/pynestml/cocos/co_co_each_block_unique_and_defined.py
+++ b/pynestml/cocos/co_co_each_block_unique_and_defined.py
@@ -77,7 +77,7 @@ class CoCoEachBlockUniqueAndDefined(CoCo):
             code, message = Messages.get_block_not_defined_correctly('Equations', False)
             Logger.log_message(code=code, message=message, neuron=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.ERROR)
-        # check that input block is defined exactly once
+        # check that input block is defined at most once
         if isinstance(node.get_input_blocks(), list) and len(node.get_input_blocks()) > 1:
             code, message = Messages.get_block_not_defined_correctly('Input', False)
             Logger.log_message(code=code, message=message, neuron=node, error_position=node.get_source_position(),
@@ -85,12 +85,12 @@ class CoCoEachBlockUniqueAndDefined(CoCo):
         elif isinstance(node.get_input_blocks(), list) and len(node.get_input_blocks()) == 0:
             code, message = Messages.get_block_not_defined_correctly('Input', True)
             Logger.log_message(code=code, message=message, neuron=node, error_position=node.get_source_position(),
-                               log_level=LoggingLevel.ERROR)
+                               log_level=LoggingLevel.WARNING)
         elif node.get_input_blocks() is None:
             code, message = Messages.get_block_not_defined_correctly('Input', True)
             Logger.log_message(code=code, message=message, neuron=node, error_position=node.get_source_position(),
-                               log_level=LoggingLevel.ERROR)
-        # check that output block is defined exactly once
+                               log_level=LoggingLevel.WARNING)
+        # check that output block is defined at most once
         if isinstance(node.get_output_blocks(), list) and len(node.get_output_blocks()) > 1:
             code, message = Messages.get_block_not_defined_correctly('Output', False)
             Logger.log_message(code=code, message=message, neuron=node, error_position=node.get_source_position(),
@@ -98,9 +98,9 @@ class CoCoEachBlockUniqueAndDefined(CoCo):
         elif isinstance(node.get_output_blocks(), list) and len(node.get_output_blocks()) == 0:
             code, message = Messages.get_block_not_defined_correctly('Output', True)
             Logger.log_message(code=code, message=message, neuron=node, error_position=node.get_source_position(),
-                               log_level=LoggingLevel.ERROR)
+                               log_level=LoggingLevel.WARNING)
         elif node.get_output_blocks() is None:
             code, message = Messages.get_block_not_defined_correctly('Output', True)
             Logger.log_message(code=code, message=message, neuron=node, error_position=node.get_source_position(),
-                               log_level=LoggingLevel.ERROR)
+                               log_level=LoggingLevel.WARNING)
         return

--- a/pynestml/utils/messages.py
+++ b/pynestml/utils/messages.py
@@ -478,9 +478,9 @@ class Messages(object):
         assert (missing is not None and isinstance(missing, bool)), \
             '(PyNestML.Utils.Message) Not a bool provided (%s)!' % type(missing)
         if missing:
-            message = block + ' block not defined, model not correct!'
+            message = block + ' block not defined!'
         else:
-            message = block + ' block not unique, model not correct!!'
+            message = block + ' block defined more than once!'
         return MessageCode.BLOCK_NOT_CORRECT, message
 
     @classmethod


### PR DESCRIPTION
Based on discussion at https://github.com/nest/nestml/pull/515/files#r315202498, this allows valid models to be defined without any input or output ports.

An example use case is the Lorentz attractor NESTML model, which does not have any explicit input or output ports, but the state variables of which can be recorded over time.

We could additionally test that if an emit_spike() function is used in the model, a spiking output port was defined.

The reason I am not yet convinced to fully remove the output block, is that it might be a point where we can formally define an interface between the model itself and the outside world, including physical units where necessary. In principle, it would be conceivable for a neuron to emit both spike events as well as real values representing e.g. the release of a slowly decaying modulatory factor.