### PR TITLE
Generate code for state variables not used in any equations

### DIFF
--- a/pynestml/codegeneration/nest_codegenerator.py
+++ b/pynestml/codegeneration/nest_codegenerator.py
@@ -434,7 +434,10 @@ class NESTCodeGenerator(CodeGenerator):
 
             namespace['propagators'] = self.analytic_solver[neuron.get_name()]["propagators"]
 
-        namespace['non_equations_state_variables'] = self.non_equations_state_variables[neuron.get_name()]
+        # convert variables from ASTVariable instances to strings
+        _names = self.non_equations_state_variables[neuron.get_name()]
+        _names = [to_ode_toolbox_processed_name(var.get_complete_name()) for var in _names]
+        namespace['non_equations_state_variables'] = _names
 
         namespace['uses_numeric_solver'] = neuron.get_name() in self.analytic_solver.keys() \
             and self.numeric_solver[neuron.get_name()] is not None

--- a/pynestml/codegeneration/nest_codegenerator.py
+++ b/pynestml/codegeneration/nest_codegenerator.py
@@ -329,6 +329,11 @@ class NESTCodeGenerator(CodeGenerator):
                     if ode_eq.get_lhs().get_name() == var.get_name():
                         used_in_eq = True
                         break
+                for kern in neuron.get_equations_blocks().get_kernels():
+                    for kern_var in kern.get_variables():
+                        if kern_var.get_name() == var.get_name():
+                            used_in_eq = True
+                            break
 
                 if not used_in_eq:
                     self.non_equations_state_variables[neuron.get_name()].append(var)

--- a/pynestml/codegeneration/nest_codegenerator.py
+++ b/pynestml/codegeneration/nest_codegenerator.py
@@ -413,6 +413,7 @@ class NESTCodeGenerator(CodeGenerator):
 
         namespace['PredefinedUnits'] = pynestml.symbols.predefined_units.PredefinedUnits
         namespace['UnitTypeSymbol'] = pynestml.symbols.unit_type_symbol.UnitTypeSymbol
+        namespace['SymbolKind'] = pynestml.symbols.symbol.SymbolKind
 
         namespace['initial_values'] = {}
         namespace['uses_analytic_solver'] = neuron.get_name() in self.analytic_solver.keys() \

--- a/pynestml/codegeneration/resources_nest/NeuronHeader.jinja2
+++ b/pynestml/codegeneration/resources_nest/NeuronHeader.jinja2
@@ -283,10 +283,13 @@ private:
 {%- else %}
     //! Symbolic indices to the elements of the state vector y
     enum StateVecElems{
-{# N.B. numeric solver contains all state variables, including those that will be solved by analytic solver#}
+{# N.B. numeric solver contains all state variables, including those that will be solved by analytic solver #}
 {%-   if uses_numeric_solver %}
       // numeric solver state variables
 {%-     for variable_name in numeric_state_variables: %}
+      {{variable_name}},
+{%-     endfor %}
+{%-     for variable_name in non_equations_state_variables: %}
       {{variable_name}},
 {%-     endfor %}
 {%-   endif %}

--- a/pynestml/codegeneration/resources_nest/directives/GSLDifferentiationFunction.jinja2
+++ b/pynestml/codegeneration/resources_nest/directives/GSLDifferentiationFunction.jinja2
@@ -32,6 +32,11 @@ extern "C" inline int {{neuronName}}_dynamics(double, const double ode_state[], 
   f[{{names.array_index(variable_sym)}}] = {{printerGSL.print_expression(update_expr, prefix="node.")}};
 {%- endfor %}
 
+{%- for variable_name in non_equations_state_variables: %}
+{%-   set variable_sym = neuron.get_initial_values_blocks().get_scope().resolve_to_symbol(variable_name, SymbolKind.VARIABLE) %}
+  f[{{names.array_index(variable_sym)}}] = 0.;
+{%- endfor %}
+
   return GSL_SUCCESS;
 }
 

--- a/pynestml/utils/ast_utils.py
+++ b/pynestml/utils/ast_utils.py
@@ -19,11 +19,12 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from typing import List, Optional
 
 from pynestml.meta_model.ast_block import ASTBlock
 from pynestml.meta_model.ast_declaration import ASTDeclaration
 from pynestml.meta_model.ast_function_call import ASTFunctionCall
+from pynestml.meta_model.ast_variable import ASTVariable
 from pynestml.utils.ast_source_location import ASTSourceLocation
 from pynestml.symbols.predefined_functions import PredefinedFunctions
 from pynestml.symbols.symbol import SymbolKind
@@ -204,7 +205,6 @@ class ASTUtils(object):
         """
         ret = list()
         from pynestml.visitors.ast_higher_order_visitor import ASTHigherOrderVisitor
-        from pynestml.meta_model.ast_variable import ASTVariable
         res = list()
 
         def loc_get_vars(node):
@@ -279,7 +279,6 @@ class ASTUtils(object):
         :return: the first element with the size parameter
         :rtype: variable_symbol
         """
-        from pynestml.meta_model.ast_variable import ASTVariable
         from pynestml.symbols.symbol import SymbolKind
         variables = (var for var in cls.get_all(ast, ASTVariable) if
                      scope.resolve_to_symbol(var.get_complete_name(), SymbolKind.VARIABLE))
@@ -434,3 +433,13 @@ class ASTUtils(object):
                 if var.get_complete_name() == var_name:
                     return decl
         return None
+
+    @classmethod
+    def all_variables_defined_in_block(cls, block: ASTBlock) -> List[ASTVariable]:
+        if block is None:
+            return []
+        vars = []
+        for decl in block.get_declarations():
+            for var in decl.get_variables():
+                vars.append(var)
+        return vars


### PR DESCRIPTION
This PR fixes an issue with state variables that were declared in the model, but not used in the equations block. This means that they are not processed by ODE-toolbox, which currently results in a missing declaration in the corresponding C++ header file. This PR introduces a separate data structure in the code generator, containing just these variables, so that their declaration is properly generated, next to those variables that do go through ODE-toolbox.