### PR TITLE
Minor logger refactoring

### DIFF
--- a/pynestml/cocos/co_co_all_variables_defined.py
+++ b/pynestml/cocos/co_co_all_variables_defined.py
@@ -62,7 +62,7 @@ class CoCoAllVariablesDefined(CoCo):
                     if symbol is None:
                         # symbol has not been defined; neither as a variable name nor as a type symbol
                         code, message = Messages.get_variable_not_defined(var.get_name())
-                        Logger.log_message(neuron=node, code=code, message=message, log_level=LoggingLevel.ERROR,
+                        Logger.log_message(node=node, code=code, message=message, log_level=LoggingLevel.ERROR,
                                            error_position=var.get_source_position())
                 # first check if it is part of an invariant
                 # if it is the case, there is no "recursive" declaration
@@ -80,7 +80,7 @@ class CoCoAllVariablesDefined(CoCo):
                     if ((not symbol.get_referenced_object().get_source_position().before(var.get_source_position()))
                             and (not symbol.block_type in [BlockType.PARAMETERS, BlockType.INTERNALS])):
                         code, message = Messages.get_variable_used_before_declaration(var.get_name())
-                        Logger.log_message(neuron=node, message=message, error_position=var.get_source_position(),
+                        Logger.log_message(node=node, message=message, error_position=var.get_source_position(),
                                            code=code, log_level=LoggingLevel.ERROR)
                         # now check that they are now defined recursively, e.g. V_m mV = V_m + 1
                     # todo: we should not check this for invariants
@@ -88,7 +88,7 @@ class CoCoAllVariablesDefined(CoCo):
                             and not symbol.get_referenced_object().get_source_position().is_added_source_position()):
                         code, message = Messages.get_variable_defined_recursively(var.get_name())
                         Logger.log_message(code=code, message=message, error_position=symbol.get_referenced_object().
-                                           get_source_position(), log_level=LoggingLevel.ERROR, neuron=node)
+                                           get_source_position(), log_level=LoggingLevel.ERROR, node=node)
 
         # now check for each assignment whether the left hand side variable is defined
         vis = ASTAssignedVariableDefinedVisitor(node)
@@ -107,7 +107,7 @@ class ASTAssignedVariableDefinedVisitor(ASTVisitor):
         if symbol is None:
             code, message = Messages.get_variable_not_defined(node.get_variable().get_complete_name())
             Logger.log_message(code=code, message=message, error_position=node.get_source_position(),
-                               log_level=LoggingLevel.ERROR, neuron=self.neuron)
+                               log_level=LoggingLevel.ERROR, node=self.neuron)
 
 
 class ASTExpressionCollectorVisitor(ASTVisitor):

--- a/pynestml/cocos/co_co_each_block_unique_and_defined.py
+++ b/pynestml/cocos/co_co_each_block_unique_and_defined.py
@@ -48,51 +48,51 @@ class CoCoEachBlockUniqueAndDefined(CoCo):
             '(PyNestML.CoCo.BlocksUniques) No or wrong type of neuron provided (%s)!' % type(node)
         if isinstance(node.get_state_blocks(), list) and len(node.get_state_blocks()) > 1:
             code, message = Messages.get_block_not_defined_correctly('State', False)
-            Logger.log_message(code=code, message=message, neuron=node, error_position=node.get_source_position(),
+            Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.ERROR)
         # check that update block is defined at most once
         if isinstance(node.get_update_blocks(), list) and len(node.get_update_blocks()) > 1:
             code, message = Messages.get_block_not_defined_correctly('Update', False)
-            Logger.log_message(code=code, message=message, neuron=node, error_position=node.get_source_position(),
+            Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.ERROR)
         # check that parameters block is defined at most once
         if isinstance(node.get_parameter_blocks(), list) and len(node.get_parameter_blocks()) > 1:
             code, message = Messages.get_block_not_defined_correctly('Parameters', False)
-            Logger.log_message(code=code, message=message, neuron=node, error_position=node.get_source_position(),
+            Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.ERROR)
         # check that internals block is defined at most once
         if isinstance(node.get_internals_blocks(), list) and len(node.get_internals_blocks()) > 1:
             code, message = Messages.get_block_not_defined_correctly('Internals', False)
-            Logger.log_message(code=code, message=message, neuron=node, error_position=node.get_source_position(),
+            Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.ERROR)
         # check that equations block is defined at most once
         if isinstance(node.get_equations_blocks(), list) and len(node.get_equations_blocks()) > 1:
             code, message = Messages.get_block_not_defined_correctly('Equations', False)
-            Logger.log_message(code=code, message=message, neuron=node, error_position=node.get_source_position(),
+            Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.ERROR)
         # check that input block is defined at most once
         if isinstance(node.get_input_blocks(), list) and len(node.get_input_blocks()) > 1:
             code, message = Messages.get_block_not_defined_correctly('Input', False)
-            Logger.log_message(code=code, message=message, neuron=node, error_position=node.get_source_position(),
+            Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.ERROR)
         elif isinstance(node.get_input_blocks(), list) and len(node.get_input_blocks()) == 0:
             code, message = Messages.get_block_not_defined_correctly('Input', True)
-            Logger.log_message(code=code, message=message, neuron=node, error_position=node.get_source_position(),
+            Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.WARNING)
         elif node.get_input_blocks() is None:
             code, message = Messages.get_block_not_defined_correctly('Input', True)
-            Logger.log_message(code=code, message=message, neuron=node, error_position=node.get_source_position(),
+            Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.WARNING)
         # check that output block is defined at most once
         if isinstance(node.get_output_blocks(), list) and len(node.get_output_blocks()) > 1:
             code, message = Messages.get_block_not_defined_correctly('Output', False)
-            Logger.log_message(code=code, message=message, neuron=node, error_position=node.get_source_position(),
+            Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.ERROR)
         elif isinstance(node.get_output_blocks(), list) and len(node.get_output_blocks()) == 0:
             code, message = Messages.get_block_not_defined_correctly('Output', True)
-            Logger.log_message(code=code, message=message, neuron=node, error_position=node.get_source_position(),
+            Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.WARNING)
         elif node.get_output_blocks() is None:
             code, message = Messages.get_block_not_defined_correctly('Output', True)
-            Logger.log_message(code=code, message=message, neuron=node, error_position=node.get_source_position(),
+            Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.WARNING)

--- a/pynestml/cocos/co_co_kernel_type.py
+++ b/pynestml/cocos/co_co_kernel_type.py
@@ -84,7 +84,7 @@ class KernelTypeVisitor(ASTVisitor):
                 decl = ASTUtils.get_declaration_by_name(self._neuron.get_initial_blocks(), iv_name)
                 if decl is None:
                     code, message = Messages.get_variable_not_defined(iv_name)
-                    Logger.log_message(neuron=self._neuron, code=code, message=message, log_level=LoggingLevel.ERROR,
+                    Logger.log_message(node=self._neuron, code=code, message=message, log_level=LoggingLevel.ERROR,
                                        error_position=node.get_source_position())
                     continue
                 assert len(self._neuron.get_initial_blocks().get_declarations()[0].get_variables(

--- a/pynestml/cocos/co_co_user_defined_function_correctly_defined.py
+++ b/pynestml/cocos/co_co_user_defined_function_correctly_defined.py
@@ -71,7 +71,7 @@ class CoCoUserDefinedFunctionCorrectlyDefined(CoCo):
             elif symbol is not None and userDefinedFunction.has_return_type() and \
                     not symbol.get_return_type().equals(PredefinedTypes.get_void_type()):
                 code, message = Messages.get_no_return()
-                Logger.log_message(neuron=_neuron, code=code, message=message,
+                Logger.log_message(node=_neuron, code=code, message=message,
                                    error_position=userDefinedFunction.get_source_position(),
                                    log_level=LoggingLevel.ERROR)
         return

--- a/pynestml/cocos/co_co_variable_once_per_scope.py
+++ b/pynestml/cocos/co_co_variable_once_per_scope.py
@@ -60,17 +60,17 @@ class CoCoVariableOncePerScope(CoCo):
                     if sym2.get_symbol_kind() == SymbolKind.TYPE:
                         code, message = Messages.get_variable_with_same_name_as_type(sym1.get_symbol_name())
                         Logger.log_message(error_position=sym1.get_referenced_object().get_source_position(),
-                                           neuron=neuron, log_level=LoggingLevel.WARNING, code=code, message=message)
+                                           node=neuron, log_level=LoggingLevel.WARNING, code=code, message=message)
                     elif sym1.get_symbol_kind() == sym2.get_symbol_kind():
                         if sym2.is_predefined:
                             code, message = Messages.get_variable_redeclared(sym1.get_symbol_name(), True)
                             Logger.log_message(error_position=sym1.get_referenced_object().get_source_position(),
-                                               neuron=neuron, log_level=LoggingLevel.ERROR, code=code, message=message)
+                                               node=neuron, log_level=LoggingLevel.ERROR, code=code, message=message)
                         elif sym1.get_referenced_object().get_source_position().before(
                                 sym2.get_referenced_object().get_source_position()):
                             code, message = Messages.get_variable_redeclared(sym1.get_symbol_name(), False)
                             Logger.log_message(error_position=sym2.get_referenced_object().get_source_position(),
-                                               neuron=neuron, log_level=LoggingLevel.ERROR, code=code, message=message)
+                                               node=neuron, log_level=LoggingLevel.ERROR, code=code, message=message)
             checked.append(sym1)
         for scope in scope.get_scopes():
             cls.__check_scope(neuron, scope)

--- a/pynestml/frontend/frontend_configuration.py
+++ b/pynestml/frontend/frontend_configuration.py
@@ -23,7 +23,6 @@ import os
 import re
 
 import pynestml
-from pynestml.codegeneration.codegenerator import CodeGenerator
 from pynestml.exceptions.invalid_path_exception import InvalidPathException
 from pynestml.exceptions.invalid_target_exception import InvalidTargetException
 from pynestml.utils.logger import Logger
@@ -198,6 +197,8 @@ appropriate numeric solver otherwise.
     def handle_target(cls, target):
         if target is None or target.upper() == 'NONE':
             target = ''     # make sure `target` is always a string
+
+        from pynestml.codegeneration.codegenerator import CodeGenerator
 
         if target.upper() not in CodeGenerator.get_known_targets():
             code, message = Messages.get_unknown_target(target)

--- a/pynestml/frontend/pynestml_frontend.py
+++ b/pynestml/frontend/pynestml_frontend.py
@@ -164,7 +164,7 @@ def process():
             for neuron in neurons:
                 if Logger.has_errors(neuron):
                     code, message = Messages.get_neuron_contains_errors(neuron.get_name())
-                    Logger.log_message(neuron=neuron, code=code, message=message,
+                    Logger.log_message(node=neuron, code=code, message=message,
                                        error_position=neuron.get_source_position(),
                                        log_level=LoggingLevel.INFO)
                     neurons.remove(neuron)

--- a/pynestml/meta_model/ast_neuron.py
+++ b/pynestml/meta_model/ast_neuron.py
@@ -21,7 +21,6 @@
 
 from typing import Optional, Union, List, Dict
 
-from pynestml.frontend.frontend_configuration import FrontendConfiguration
 from pynestml.meta_model.ast_input_block import ASTInputBlock
 from pynestml.meta_model.ast_node import ASTNode
 from pynestml.meta_model.ast_kernel import ASTKernel

--- a/pynestml/symbols/variable_symbol.py
+++ b/pynestml/symbols/variable_symbol.py
@@ -328,7 +328,7 @@ class VariableSymbol(Symbol):
         if is_cond_based == is_curr_based:
             code, message = Messages.get_could_not_determine_cond_based(
                 type_str=self.type_symbol.print_nestml_type(), name=self.name)
-            Logger.log_message(neuron=None, code=code, message=message, log_level=LoggingLevel.WARNING,
+            Logger.log_message(node=None, code=code, message=message, log_level=LoggingLevel.WARNING,
                                error_position=ASTSourceLocation.get_added_source_position())
             return False
 

--- a/pynestml/utils/logger.py
+++ b/pynestml/utils/logger.py
@@ -18,13 +18,27 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
-import json
+
+from typing import List, Mapping, Tuple
+
 from collections import OrderedDict
-
 from enum import Enum
+import json
+from pynestml.meta_model.ast_node import ASTNode
+from pynestml.utils.ast_source_location import ASTSourceLocation
+from pynestml.utils.messages import MessageCode
 
 
-class Logger(object):
+class LoggingLevel(Enum):
+    """
+    Different types of logging levels, this part can be extended.
+    """
+    INFO = 0
+    WARNING = 1
+    ERROR = 2
+    NO = 3
+
+class Logger:
     """
     This class represents a logger which can be used to print messages to the screen depending on the logging
     level.
@@ -37,35 +51,39 @@ class Logger(object):
     level is set to WARNING, only warnings and errors are printed. Only if level is set to ALL, all messages
     are printed.
     Attributes:
-        log       Stores all messages as received during the execution. Map from id (int) to neuron,type,message
+        log       Stores all messages as received during the execution. Map from id (int) to node,type,message
         curr_message A counter indicating the current message, this enables a sorting by the number of message
         logging_level Indicates messages of which level shall be printed to the screen.
-        current_neuron The currently processed model. This enables to retrieve all messages belonging to a certain model
+        current_node The currently processed model. This enables to retrieve all messages belonging to a certain model
     """
     log = {}
     curr_message = None
     logging_level = None
-    current_neuron = None
+    current_node = None
     no_print = False
 
     @classmethod
-    def init_logger(cls, logging_level):
+    def init_logger(cls, logging_level: LoggingLevel):
         """
         Initializes the logger.
         :param logging_level: the logging level as required
-        :type logging_level: LoggingLevel
         """
         cls.logging_level = logging_level
         cls.curr_message = 0
         cls.log = {}
-        return
+        cls.log_frozen = False
+
+    def freeze_log(cls, do_freeze: bool = True):
+        """
+        Freeze the log: while log is frozen, all logging requests will be ignored.
+        """
+        cls.log_frozen = do_freeze
 
     @classmethod
-    def get_log(cls):
+    def get_log(cls) -> Mapping[int, Tuple[ASTNode, LoggingLevel, str]]:
         """
-        Returns the overall log of messages. The structure of the log is: (NEURON,LEVEL,MESSAGE)
-        :return: dict from id to neuron+message+type.
-        :rtype: dict(int->neuron,level,str)
+        Returns the overall log of messages. The structure of the log is: (NODE, LEVEL, MESSAGE)
+        :return: mapping from id to ASTNode, log level and message.
         """
         return cls.log
 
@@ -80,42 +98,40 @@ class Logger(object):
         cls.curr_message = counter
 
     @classmethod
-    def log_message(cls, neuron=None, code=None, message=None, error_position=None, log_level=None):
+    def log_message(cls, node: ASTNode = None, code: MessageCode = None, message: str = None, error_position: ASTSourceLocation = None, log_level: LoggingLevel = None):
         """
         Logs the handed over message on the handed over. If the current logging is appropriate, the
         message is also printed.
-        :param neuron: the neuron in which the error occurred
-        :type neuron: ast_neuron
+        :param node: the node in which the error occurred
         :param code: a single error code
-        :type code: ErrorCode
         :param error_position: the position on which the error occurred.
-        :type error_position: SourcePosition
         :param message: a message.
-        :type message: str
         :param log_level: the corresponding log level.
-        :type log_level: LoggingLevel
         """
+        if cls.log_frozen:
+            return
         if cls.curr_message is None:
             cls.init_logger(LoggingLevel.INFO)
-        from pynestml.meta_model.ast_neuron import ASTNeuron
+        from pynestml.meta_model.ast_node import ASTNode
         from pynestml.utils.ast_source_location import ASTSourceLocation
-        assert (neuron is None or isinstance(neuron, ASTNeuron)), \
-            '(PyNestML.Logger) Wrong type of neuron provided (%s)!' % type(neuron)
+        assert (node is None or isinstance(node, ASTNode)), \
+            '(PyNestML.Logger) Wrong type of node provided (%s)!' % type(node)
         assert (error_position is None or isinstance(error_position, ASTSourceLocation)), \
             '(PyNestML.Logger) Wrong type of error position provided (%s)!' % type(error_position)
-        if isinstance(neuron, ASTNeuron):
+        from pynestml.meta_model.ast_neuron import ASTNeuron
+        if isinstance(node, ASTNeuron):
             cls.log[cls.curr_message] = (
-                neuron.get_artifact_name(), neuron, log_level, code, error_position, message)
-        elif cls.current_neuron is not None:
-            cls.log[cls.curr_message] = (cls.current_neuron.get_artifact_name(), cls.current_neuron,
+                node.get_artifact_name(), node, log_level, code, error_position, message)
+        elif cls.current_node is not None:
+            cls.log[cls.curr_message] = (cls.current_node.get_artifact_name(), cls.current_node,
                                          log_level, code, error_position, message)
         cls.curr_message += 1
         if cls.no_print:
             return
         if cls.logging_level.value <= log_level.value:
             to_print = '[' + str(cls.curr_message) + ','
-            to_print = (to_print + (neuron.get_name() + ', ' if neuron is not None else
-                                    cls.current_neuron.get_name() + ', ' if cls.current_neuron is not None else 'GLOBAL, '))
+            to_print = (to_print + (node.get_name() + ', ' if node is not None else
+                                    cls.current_node.get_name() + ', ' if cls.current_node is not None else 'GLOBAL, '))
             to_print = to_print + str(log_level.name)
             to_print = to_print + (', ' + str(error_position) if error_position is not None else '') + ']: '
             to_print = to_print + str(message)
@@ -123,13 +139,11 @@ class Logger(object):
         return
 
     @classmethod
-    def string_to_level(cls, string):
+    def string_to_level(cls, string: str) -> LoggingLevel:
         """
         Returns the logging level corresponding to the handed over string. If no such exits, returns None.
         :param string: a single string representing the level.
-        :type string: str
         :return: a single logging level.
-        :rtype: LoggingLevel
         """
         if type(string) != str:
             return LoggingLevel.ERROR
@@ -145,108 +159,98 @@ class Logger(object):
             return LoggingLevel.ERROR
 
     @classmethod
-    def set_logging_level(cls, level):
+    def set_logging_level(cls, level: LoggingLevel) -> None:
         """
         Updates the logging level to the handed over one.
         :param level: a new logging level.
-        :type level: LoggingLevel
         """
+        if cls.log_frozen:
+            return
         cls.logging_level = level
 
     @classmethod
-    def set_current_neuron(cls, neuron):
+    def set_current_node(cls, node: ASTNode) -> None:
         """
-        Sets the handed over neuron as the currently processed one. This enables a retrieval of messages for a
-        specific neuron.
-        :param neuron:  a single neuron instance
-        :type neuron: ast_neuron
+        Sets the handed over node as the currently processed one. This enables a retrieval of messages for a
+        specific node.
+        :param node:  a single node instance
         """
-        cls.current_neuron = neuron
+        cls.current_node = node
 
     @classmethod
-    def get_all_messages_of_level_and_or_neuron(cls, neuron, level):
+    def get_all_messages_of_level_and_or_node(cls, node: ASTNode, level: LoggingLevel) -> List[Tuple[ASTNode, LoggingLevel, str]]:
         """
-        Returns all messages which have a certain logging level, or have been reported for a certain neuron, or
+        Returns all messages which have a certain logging level, or have been reported for a certain node, or
         both.
-        :param neuron: a single neuron instance
-        :type neuron: ASTNeron
+        :param node: a single node instance
         :param level: a logging level
-        :type level: LoggingLevel
         :return: a list of messages with their levels.
-        :rtype: list((str,Logging_Level)
         """
-        if level is None and neuron is None:
+        if level is None and node is None:
             return cls.get_log()
         ret = list()
-        for (artifactName, neuron_i, logLevel, code, errorPosition, message) in cls.log.values():
+        for (artifactName, node_i, logLevel, code, errorPosition, message) in cls.log.values():
             if (level == logLevel if level is not None else True) and (
-                    neuron if neuron is not None else True) and (
-                    neuron.get_artifact_name() == artifactName if neuron is not None else True):
-                ret.append((neuron, logLevel, message))
+                    node if node is not None else True) and (
+                    node.get_artifact_name() == artifactName if node is not None else True):
+                ret.append((node, logLevel, message))
         return ret
 
     @classmethod
-    def get_all_messages_of_level(cls, level):
+    def get_all_messages_of_level(cls, level: LoggingLevel) -> List[Tuple[ASTNode, LoggingLevel, str]]:
         """
         Returns all messages which have a certain logging level.
         :param level: a logging level
-        :type level: LoggingLevel
         :return: a list of messages with their levels.
-        :rtype: list((str,Logging_Level)
         """
         if level is None:
             return cls.get_log()
         ret = list()
-        for (artifactName, neuron, logLevel, code, errorPosition, message) in cls.log.values():
+        for (artifactName, node, logLevel, code, errorPosition, message) in cls.log.values():
             if level == logLevel:
-                ret.append((neuron, logLevel, message))
+                ret.append((node, logLevel, message))
         return ret
 
     @classmethod
-    def get_all_messages_of_neuron(cls, neuron):
+    def get_all_messages_of_node(cls, node: ASTNode) -> List[Tuple[ASTNode, LoggingLevel, str]]:
         """
-        Returns all messages which have been reported for a certain neuron.
-        :param neuron: a single neuron instance
-        :type neuron: ASTNeron
+        Returns all messages which have been reported for a certain node.
+        :param node: a single node instance
         :return: a list of messages with their levels.
-        :rtype: list((str,Logging_Level)
         """
-        if neuron is None:
+        if node is None:
             return cls.get_log()
         ret = list()
-        for (artifactName, neuron_i, logLevel, code, errorPosition, message) in cls.log.values():
-            if (neuron_i == neuron if neuron is not None else True) and \
-                    (neuron.get_artifact_name() == artifactName if neuron is not None else True):
-                ret.append((neuron, logLevel, message))
+        for (artifactName, node_i, logLevel, code, errorPosition, message) in cls.log.values():
+            if (node_i == node if node is not None else True) and \
+                    (node.get_artifact_name() == artifactName if node is not None else True):
+                ret.append((node, logLevel, message))
         return ret
 
     @classmethod
-    def has_errors(cls, neuron):
+    def has_errors(cls, node: ASTNode) -> bool:
         """
-        Indicates whether the handed over neuron, thus the corresponding model, has errors.
-        :param neuron: a single neuron instance.
-        :type neuron: ast_neuron
+        Indicates whether the handed over node, thus the corresponding model, has errors.
+        :param node: a single node instance.
         :return: True if errors detected, otherwise False
-        :rtype: bool
         """
-        return len(cls.get_all_messages_of_level_and_or_neuron(neuron, LoggingLevel.ERROR)) > 0
+        return len(cls.cls.get_all_messages_of_level_and_or_node(node, LoggingLevel.ERROR)) > 0
 
     @classmethod
-    def get_json_format(cls):
+    def get_json_format(cls) -> str:
         """
         Returns the log in a format which can be used to be stored to a file.
-        :return: a str containing the log
-        :rtype: str
+        :return: a string containing the log
         """
         ret = '['
         for messageNr in cls.log.keys():
-            (artifactName, neuron, logLevel, code, errorPosition, message) = cls.log[messageNr]
+            (artifactName, node, logLevel, code, errorPosition, message) = cls.log[messageNr]
             ret += '{' + \
                    '"filename":"' + \
                    artifactName + \
                    '", ' + \
-                   '"neuronName":"' + \
-                   (neuron.get_name() if neuron is not None else 'GLOBAL') + '", ' + \
+                   '"nodeName":"' + \
+                   (node.get_name() if node is not None else 'GLOBAL') + '", ' + \
                    '"severity":"' \
                    + str(logLevel.name) + '", '
             if code is not None:
@@ -268,13 +272,3 @@ class Logger(object):
             ret += ']'
             parsed = json.loads(ret, object_pairs_hook=OrderedDict)
         return json.dumps(parsed, indent=2, sort_keys=False)
-
-
-class LoggingLevel(Enum):
-    """
-    Different types of logging levels, this part can be extended.
-    """
-    INFO = 0
-    WARNING = 1
-    ERROR = 2
-    NO = 3

--- a/pynestml/utils/logger.py
+++ b/pynestml/utils/logger.py
@@ -38,6 +38,7 @@ class LoggingLevel(Enum):
     ERROR = 2
     NO = 3
 
+
 class Logger:
     """
     This class represents a logger which can be used to print messages to the screen depending on the logging
@@ -234,7 +235,7 @@ class Logger:
         :param node: a single node instance.
         :return: True if errors detected, otherwise False
         """
-        return len(cls.cls.get_all_messages_of_level_and_or_node(node, LoggingLevel.ERROR)) > 0
+        return len(cls.get_all_messages_of_level_and_or_node(node, LoggingLevel.ERROR)) > 0
 
     @classmethod
     def get_json_format(cls) -> str:

--- a/pynestml/utils/model_parser.py
+++ b/pynestml/utils/model_parser.py
@@ -90,11 +90,11 @@ class ModelParser(object):
             input_file = FileStream(file_path)
         except IOError:
             code, message = Messages.get_input_path_not_found(path=file_path)
-            Logger.log_message(neuron=None, code=None, message=message,
+            Logger.log_message(node=None, code=None, message=message,
                                error_position=None, log_level=LoggingLevel.ERROR)
             return
         code, message = Messages.get_start_processing_file(file_path)
-        Logger.log_message(neuron=None, code=code, message=message, error_position=None, log_level=LoggingLevel.INFO)
+        Logger.log_message(node=None, code=code, message=message, error_position=None, log_level=LoggingLevel.INFO)
 
         # create a lexer and hand over the input
         lexer = PyNestMLLexer()
@@ -110,7 +110,7 @@ class ModelParser(object):
         stream.fill()
         if lexerErrorListener._error_occurred:
             code, message = Messages.get_lexer_error()
-            Logger.log_message(neuron=None, code=None, message=message,
+            Logger.log_message(node=None, code=None, message=message,
                                error_position=None, log_level=LoggingLevel.ERROR)
             return
         # parse the file
@@ -125,7 +125,7 @@ class ModelParser(object):
         compilation_unit = parser.nestMLCompilationUnit()
         if parserErrorListener._error_occurred:
             code, message = Messages.get_parser_error()
-            Logger.log_message(neuron=None, code=None, message=message,
+            Logger.log_message(node=None, code=None, message=message,
                                error_position=None, log_level=LoggingLevel.ERROR)
             return
 

--- a/pynestml/visitors/ast_builder_visitor.py
+++ b/pynestml/visitors/ast_builder_visitor.py
@@ -450,9 +450,9 @@ class ASTBuilderVisitor(PyNestMLParserVisitor):
         # update the comments
         update_node_comments(neuron, self.__comments.visit(ctx))
         # in order to enable the logger to print correct messages set as the source the corresponding neuron
-        Logger.set_current_neuron(neuron)
+        Logger.set_current_node(neuron)
         CoCoEachBlockUniqueAndDefined.check_co_co(node=neuron)
-        Logger.set_current_neuron(neuron)
+        Logger.set_current_node(neuron)
         # now the meta_model seems to be correct, return it
         return neuron
 

--- a/pynestml/visitors/ast_symbol_table_visitor.py
+++ b/pynestml/visitors/ast_symbol_table_visitor.py
@@ -55,9 +55,9 @@ class ASTSymbolTableVisitor(ASTVisitor):
         :rtype: ast_neuron
         """
         # set current processed neuron
-        Logger.set_current_neuron(node)
+        Logger.set_current_node(node)
         code, message = Messages.get_start_building_symbol_table()
-        Logger.log_message(neuron=node, code=code, error_position=node.get_source_position(),
+        Logger.log_message(node=node, code=code, error_position=node.get_source_position(),
                            message=message, log_level=LoggingLevel.INFO)
         scope = Scope(scope_type=ScopeType.GLOBAL, source_position=node.get_source_position())
         node.update_scope(scope)
@@ -94,7 +94,7 @@ class ASTSymbolTableVisitor(ASTVisitor):
             assign_ode_to_variables(equation_block)
         if not self.after_ast_rewrite_:
             CoCosManager.post_ode_specification_checks(node)
-        Logger.set_current_neuron(None)
+        Logger.set_current_node(None)
         return
 
     def visit_body(self, node):

--- a/tests/cocos_test.py
+++ b/tests/cocos_test.py
@@ -81,7 +81,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoVariableNotDefined.nestml'))
         self.assertEqual(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
-                                                                            LoggingLevel.ERROR)), 5)
+                                                                          LoggingLevel.ERROR)), 5)
 
     def test_valid_element_not_defined_in_scope(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -217,7 +217,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoUnitNumeratorNotOne.nestml'))
         self.assertEqual(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
-                                                                            LoggingLevel.ERROR)), 2)
+                                                                          LoggingLevel.ERROR)), 2)
 
     def test_valid_numerator_of_unit_one(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -391,7 +391,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoConvolveNotCorrectlyProvided.nestml'))
         self.assertEqual(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
-                                                                            LoggingLevel.ERROR)), 3)
+                                                                          LoggingLevel.ERROR)), 3)
 
     def test_valid_convolve_correctly_defined(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -431,7 +431,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoConvolveNotCorrectlyParametrized.nestml'))
         self.assertEqual(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
-                                                                            LoggingLevel.ERROR)), 0)
+                                                                          LoggingLevel.ERROR)), 0)
 
     def test_invalid_invariant_correctly_typed(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -455,7 +455,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoIllegalExpression.nestml'))
         self.assertEqual(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
-                                                                            LoggingLevel.ERROR)), 6)
+                                                                          LoggingLevel.ERROR)), 6)
 
     def test_valid_expression_correctly_typed(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -471,7 +471,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoOdeIncorrectlyTyped.nestml'))
         self.assertTrue(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
-                                                                           LoggingLevel.ERROR)) > 0)
+                                                                         LoggingLevel.ERROR)) > 0)
 
     def test_valid_ode_correctly_typed(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -488,7 +488,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoOutputPortDefinedIfEmitCall.nestml'))
         self.assertTrue(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
-                                                                           LoggingLevel.ERROR)) > 0)
+                                                                         LoggingLevel.ERROR)) > 0)
 
     def test_invalid_output_port_defined_if_emit_call(self):
         """test that an error is raised when the emit_spike() function is called by the neuron, but a spiking output port is not defined"""
@@ -497,7 +497,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoOutputPortDefinedIfEmitCall-2.nestml'))
         self.assertTrue(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
-                                                                           LoggingLevel.ERROR)) > 0)
+                                                                         LoggingLevel.ERROR)) > 0)
 
     def test_valid_output_port_defined_if_emit_call(self):
         """test that no error is raised when the output block is missing, but not emit_spike() functions are called"""

--- a/tests/cocos_test.py
+++ b/tests/cocos_test.py
@@ -49,7 +49,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoVariableDefinedAfterUsage.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 2)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 2)
 
     def test_valid_element_defined_after_usage(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -57,7 +57,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoVariableDefinedAfterUsage.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_element_in_same_line(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -65,7 +65,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoElementInSameLine.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
 
     def test_valid_element_in_same_line(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -73,14 +73,14 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoElementInSameLine.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_element_not_defined_in_scope(self):
         Logger.set_logging_level(LoggingLevel.INFO)
         model = ModelParser.parse_model(
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoVariableNotDefined.nestml'))
-        self.assertEqual(len(Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0],
+        self.assertEqual(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
                                                                             LoggingLevel.ERROR)), 5)
 
     def test_valid_element_not_defined_in_scope(self):
@@ -89,7 +89,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoVariableNotDefined.nestml'))
         self.assertEqual(
-            len(Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)),
+            len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)),
             0)
 
     def test_variable_with_same_name_as_unit(self):
@@ -98,7 +98,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoVariableWithSameNameAsUnit.nestml'))
         self.assertEqual(
-            len(Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.WARNING)),
+            len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.WARNING)),
             3)
 
     def test_invalid_variable_redeclaration(self):
@@ -107,7 +107,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoVariableRedeclared.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
 
     def test_valid_variable_redeclaration(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -115,7 +115,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoVariableRedeclared.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_each_block_unique(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -123,7 +123,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoEachBlockUnique.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 2)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 2)
 
     def test_valid_each_block_unique(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -131,7 +131,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoEachBlockUnique.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_function_unique_and_defined(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -139,7 +139,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoFunctionNotUnique.nestml'))
         self.assertEqual(
-            len(Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 4)
+            len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 4)
 
     def test_valid_function_unique_and_defined(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -147,7 +147,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoFunctionNotUnique.nestml'))
         self.assertEqual(
-            len(Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_inline_expressions_have_rhs(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -162,7 +162,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoInlineExpressionHasNoRhs.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_inline_expression_has_several_lhs(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -177,7 +177,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoInlineExpressionWithSeveralLhs.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_no_values_assigned_to_buffers(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -185,7 +185,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoValueAssignedToBuffer.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 2)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 2)
 
     def test_valid_no_values_assigned_to_buffers(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -193,7 +193,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoValueAssignedToBuffer.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_order_of_equations_correct(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -201,7 +201,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoNoOrderOfEquations.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 2)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 2)
 
     def test_valid_order_of_equations_correct(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -209,14 +209,14 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoNoOrderOfEquations.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_numerator_of_unit_one(self):
         Logger.set_logging_level(LoggingLevel.INFO)
         model = ModelParser.parse_model(
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoUnitNumeratorNotOne.nestml'))
-        self.assertEqual(len(Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0],
+        self.assertEqual(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
                                                                             LoggingLevel.ERROR)), 2)
 
     def test_valid_numerator_of_unit_one(self):
@@ -225,21 +225,21 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoUnitNumeratorNotOne.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_names_of_neurons_unique(self):
         Logger.init_logger(LoggingLevel.INFO)
         ModelParser.parse_model(
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoMultipleNeuronsWithEqualName.nestml'))
-        self.assertEqual(len(Logger.get_all_messages_of_level_and_or_neuron(None, LoggingLevel.ERROR)), 1)
+        self.assertEqual(len(Logger.get_all_messages_of_level_and_or_node(None, LoggingLevel.ERROR)), 1)
 
     def test_valid_names_of_neurons_unique(self):
         Logger.init_logger(LoggingLevel.INFO)
         ModelParser.parse_model(
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoMultipleNeuronsWithEqualName.nestml'))
-        self.assertEqual(len(Logger.get_all_messages_of_level_and_or_neuron(None, LoggingLevel.ERROR)), 0)
+        self.assertEqual(len(Logger.get_all_messages_of_level_and_or_node(None, LoggingLevel.ERROR)), 0)
 
     def test_invalid_no_nest_collision(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -247,7 +247,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoNestNamespaceCollision.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
 
     def test_valid_no_nest_collision(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -255,7 +255,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoNestNamespaceCollision.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_redundant_buffer_keywords_detected(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -263,7 +263,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoBufferWithRedundantTypes.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
 
     def test_valid_redundant_buffer_keywords_detected(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -271,7 +271,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoBufferWithRedundantTypes.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_parameters_assigned_only_in_parameters_block(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -279,7 +279,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoParameterAssignedOutsideBlock.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
 
     def test_valid_parameters_assigned_only_in_parameters_block(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -287,7 +287,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoParameterAssignedOutsideBlock.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_current_buffers_not_specified_with_keywords(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -295,7 +295,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoCurrentBufferQualifierSpecified.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
 
     def test_valid_current_buffers_not_specified(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -303,7 +303,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoCurrentBufferQualifierSpecified.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_spike_buffer_without_datatype(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -311,7 +311,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoSpikeBufferWithoutType.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 2)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 2)
 
     def test_valid_spike_buffer_without_datatype(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -319,7 +319,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoSpikeBufferWithoutType.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_function_with_wrong_arg_number_detected(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -327,7 +327,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoFunctionCallNotConsistentWrongArgNumber.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
 
     def test_valid_function_with_wrong_arg_number_detected(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -335,7 +335,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoFunctionCallNotConsistentWrongArgNumber.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_init_values_have_rhs_and_ode(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -343,7 +343,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoInitValuesWithoutOde.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.WARNING)), 3)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.WARNING)), 3)
 
     def test_valid_init_values_have_rhs_and_ode(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -351,7 +351,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoInitValuesWithoutOde.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.WARNING)), 2)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.WARNING)), 2)
 
     def test_invalid_incorrect_return_stmt_detected(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -359,7 +359,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoIncorrectReturnStatement.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 4)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 4)
 
     def test_valid_incorrect_return_stmt_detected(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -367,7 +367,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoIncorrectReturnStatement.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_ode_vars_outside_init_block_detected(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -375,7 +375,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoOdeVarNotInInitialValues.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
 
     def test_valid_ode_vars_outside_init_block_detected(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -383,14 +383,14 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoOdeVarNotInInitialValues.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_convolve_correctly_defined(self):
         Logger.set_logging_level(LoggingLevel.INFO)
         model = ModelParser.parse_model(
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoConvolveNotCorrectlyProvided.nestml'))
-        self.assertEqual(len(Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0],
+        self.assertEqual(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
                                                                             LoggingLevel.ERROR)), 3)
 
     def test_valid_convolve_correctly_defined(self):
@@ -399,7 +399,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoConvolveNotCorrectlyProvided.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_vector_in_non_vector_declaration_detected(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -407,7 +407,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoVectorInNonVectorDeclaration.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
 
     def test_valid_vector_in_non_vector_declaration_detected(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -415,7 +415,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoVectorInNonVectorDeclaration.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_convolve_correctly_parameterized(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -423,14 +423,14 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoConvolveNotCorrectlyParametrized.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
 
     def test_valid_convolve_correctly_parameterized(self):
         Logger.set_logging_level(LoggingLevel.INFO)
         model = ModelParser.parse_model(
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoConvolveNotCorrectlyParametrized.nestml'))
-        self.assertEqual(len(Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0],
+        self.assertEqual(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
                                                                             LoggingLevel.ERROR)), 0)
 
     def test_invalid_invariant_correctly_typed(self):
@@ -439,7 +439,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoInvariantNotBool.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
 
     def test_valid_invariant_correctly_typed(self):
         Logger.set_logging_level(LoggingLevel.INFO)
@@ -447,14 +447,14 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoInvariantNotBool.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_expression_correctly_typed(self):
         Logger.set_logging_level(LoggingLevel.INFO)
         model = ModelParser.parse_model(
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoIllegalExpression.nestml'))
-        self.assertEqual(len(Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0],
+        self.assertEqual(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
                                                                             LoggingLevel.ERROR)), 6)
 
     def test_valid_expression_correctly_typed(self):
@@ -463,14 +463,14 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoIllegalExpression.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_ode_correctly_typed(self):
         Logger.set_logging_level(LoggingLevel.INFO)
         model = ModelParser.parse_model(
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoOdeIncorrectlyTyped.nestml'))
-        self.assertTrue(len(Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0],
+        self.assertTrue(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
                                                                            LoggingLevel.ERROR)) > 0)
 
     def test_valid_ode_correctly_typed(self):
@@ -479,7 +479,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoOdeCorrectlyTyped.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_output_block_defined_if_emit_call(self):
         """test that an error is raised when the emit_spike() function is called by the neuron, but an output block is not defined"""
@@ -487,7 +487,7 @@ class CoCosTest(unittest.TestCase):
         model = ModelParser.parse_model(
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoOutputPortDefinedIfEmitCall.nestml'))
-        self.assertTrue(len(Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0],
+        self.assertTrue(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
                                                                            LoggingLevel.ERROR)) > 0)
 
     def test_invalid_output_port_defined_if_emit_call(self):
@@ -496,7 +496,7 @@ class CoCosTest(unittest.TestCase):
         model = ModelParser.parse_model(
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoOutputPortDefinedIfEmitCall-2.nestml'))
-        self.assertTrue(len(Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0],
+        self.assertTrue(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
                                                                            LoggingLevel.ERROR)) > 0)
 
     def test_valid_output_port_defined_if_emit_call(self):
@@ -506,7 +506,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoOutputPortDefinedIfEmitCall.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_valid_coco_kernel_type(self):
         """
@@ -517,7 +517,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'valid')),
                          'CoCoKernelType.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
 
     def test_invalid_coco_kernel_type(self):
         """
@@ -528,7 +528,7 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoKernelType.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 1)
 
     def test_invalid_coco_kernel_type_initial_values(self):
         """
@@ -539,4 +539,4 @@ class CoCosTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'invalid')),
                          'CoCoKernelTypeInitialValues.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 4)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 4)

--- a/tests/expression_type_calculation_test.py
+++ b/tests/expression_type_calculation_test.py
@@ -91,7 +91,7 @@ class ExpressionTypeCalculationTest(unittest.TestCase):
         # ExpressionTestVisitor().handle(model)
         Logger.set_current_node(None)
         self.assertEqual(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
-                                                                            LoggingLevel.ERROR)), 2)
+                                                                          LoggingLevel.ERROR)), 2)
 
 
 if __name__ == '__main__':

--- a/tests/expression_type_calculation_test.py
+++ b/tests/expression_type_calculation_test.py
@@ -86,11 +86,11 @@ class ExpressionTypeCalculationTest(unittest.TestCase):
         model = ModelParser.parse_model(
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__),
                                                        'resources', 'ExpressionTypeTest.nestml'))))
-        Logger.set_current_neuron(model.get_neuron_list()[0])
+        Logger.set_current_node(model.get_neuron_list()[0])
         model.accept(ExpressionTestVisitor())
         # ExpressionTestVisitor().handle(model)
-        Logger.set_current_neuron(None)
-        self.assertEqual(len(Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0],
+        Logger.set_current_node(None)
+        self.assertEqual(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
                                                                             LoggingLevel.ERROR)), 2)
 
 

--- a/tests/function_parameter_templating_test.py
+++ b/tests/function_parameter_templating_test.py
@@ -54,7 +54,7 @@ class FunctionParameterTemplatingTest(unittest.TestCase):
         model = ModelParser.parse_model(
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__),
                                                        'resources', 'FunctionParameterTemplatingTest.nestml'))))
-        self.assertEqual(len(Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0],
+        self.assertEqual(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
                                                                             LoggingLevel.ERROR)), 7)
 
 

--- a/tests/function_parameter_templating_test.py
+++ b/tests/function_parameter_templating_test.py
@@ -55,7 +55,7 @@ class FunctionParameterTemplatingTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__),
                                                        'resources', 'FunctionParameterTemplatingTest.nestml'))))
         self.assertEqual(len(Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0],
-                                                                            LoggingLevel.ERROR)), 7)
+                                                                          LoggingLevel.ERROR)), 7)
 
 
 if __name__ == '__main__':

--- a/tests/random_number_generators_test.py
+++ b/tests/random_number_generators_test.py
@@ -49,4 +49,4 @@ class RandomNumberGeneratorsTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'resources')),
                          'random_number_generators_test.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)

--- a/tests/unit_system_test.py
+++ b/tests/unit_system_test.py
@@ -131,9 +131,9 @@ class UnitSystemTest(unittest.TestCase):
             os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), 'resources')),
                          'DeclarationWithSameVariableNameAsUnit.nestml'))
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.ERROR)), 0)
         self.assertEqual(len(
-            Logger.get_all_messages_of_level_and_or_neuron(model.get_neuron_list()[0], LoggingLevel.WARNING)), 3)
+            Logger.get_all_messages_of_level_and_or_node(model.get_neuron_list()[0], LoggingLevel.WARNING)), 3)
 
     def test_expression_after_magnitude_conversion_in_standalone_function_call(self):
         model = ModelParser.parse_model(


### PR DESCRIPTION
This splits off some of the more trivial changes proposed as part of #582, to make that PR smaller and easier to review.

- Refactoring variable/function names to be more generic ("node" instead of "neuron")
- Adds the ability to "freeze" the log
- Clean up type annotations