### PR TITLE
Replace pytest-xdist with a shell loop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,4 +102,9 @@ jobs:
         - echo $PYNESTKERNEL_LOCATION
         - export PYTHONPATH=$PYTHONPATH:$PYNESTKERNEL_LOCATION
         # tests have to run in separate processes, hence the loop over files. This works better than pytest-xdist and pytest-forked, because they cannot show debug (stdout) output.
-        - for fn in $TRAVIS_BUILD_DIR/tests/nest_tests/*.py; do pytest -s -o log_cli=true -o log_cli_level="DEBUG" ${fn}; done
+        - |
+          rc=0
+          for fn in $TRAVIS_BUILD_DIR/tests/nest_tests/*.py; do
+              pytest -s -o log_cli=true -o log_cli_level="DEBUG" ${fn} || rc=1
+          done;
+          exit $rc

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ jobs:
     - stage: integration
       install:
         # install nest-simulator
-        - pip install cython pytest-xdist
+        - pip install cython
         - cd
         - git clone --depth=1 https://github.com/nest/nest-simulator
         - mkdir nest_install
@@ -101,5 +101,5 @@ jobs:
         - export PYNESTKERNEL_LOCATION=`dirname $PYNESTKERNEL_LOCATION`
         - echo $PYNESTKERNEL_LOCATION
         - export PYTHONPATH=$PYTHONPATH:$PYNESTKERNEL_LOCATION
-        - pytest -s  -o log_cli=true -o log_cli_level="DEBUG" --forked $TRAVIS_BUILD_DIR/tests/nest_tests
-
+        # tests have to run in separate processes, hence the loop over files. This works better than pytest-xdist and pytest-forked, because they cannot show debug (stdout) output.
+        - for fn in $TRAVIS_BUILD_DIR/tests/nest_tests/*.py; do pytest -s -o log_cli=true -o log_cli_level="DEBUG" ${fn}; done


### PR DESCRIPTION
Integration tests have to run in separate processes, because each test individually imports nest and installs one or more extension modules with the same name.

Up until now, we used a third-party extension to pytest, namely pytest-xdist, but this prevents us from inspecting debug output (it eats stdout). This PR replaces pytest-xdist with a simple shell loop, reducing the dependencies and allowing inspection of the complete log.