### PR TITLE
Add 'current' type input ports as zero-value parameters for ODE-toolbox analysis

### DIFF
--- a/pynestml/codegeneration/nest_codegenerator.py
+++ b/pynestml/codegeneration/nest_codegenerator.py
@@ -807,6 +807,12 @@ class NESTCodeGenerator(CodeGenerator):
                     odetoolbox_indict["parameters"][var.get_complete_name(
                     )] = gsl_printer.print_expression(decl.get_expression())
 
+        # add "current" type input ports to parameters with zero value, to prevent unknown terms from preventing an analytic solution
+        if neuron.get_input_blocks() is not None:
+            for input_port in neuron.get_input_blocks().get_input_ports():
+                if input_port.is_current():
+                    odetoolbox_indict["parameters"][input_port.get_name()] = "0"
+
         return odetoolbox_indict
 
     def make_inline_expressions_self_contained(self, inline_expressions: List[ASTInlineExpression]) -> List[ASTInlineExpression]:

--- a/tests/nest_tests/nest_integration_test.py
+++ b/tests/nest_tests/nest_integration_test.py
@@ -47,7 +47,7 @@ class NestIntegrationTest(unittest.TestCase):
         models = []
 
         models.append(("iaf_psc_delta", "iaf_psc_delta_nestml", None, 1E-3))
-        models.append(("iaf_psc_exp", "iaf_psc_exp_nestml", None, .01))
+        models.append(("iaf_psc_exp", "iaf_psc_exp_nestml", None, 1E-3))
         models.append(("iaf_psc_alpha", "iaf_psc_alpha_nestml", None, 1E-3))
 
         models.append(("iaf_cond_exp", "iaf_cond_exp_nestml", 1E-3, 1E-3))


### PR DESCRIPTION
The dynamics of the iaf_psc_exp neuron is defined as:
```
inline I_syn pA = convolve(I_kernel_in, in_spikes) + convolve(I_kernel_ex, ex_spikes) + I_e + I_stim
V_abs' = -V_abs / tau_m + I_syn / C_m
```
with
```
parameters:
    [...]
    I_e pA = 0 pA      # constant external input current
end
```
and 
```
input:
    [...]
    I_stim pA <- current
end
```
The issue is that ODE-toolbox suggests a numeric solver for V_m, rather than an analytic solver. This is because the input port ``I_stim`` is not passed to ODE-toolbox, so it doesn't know about and assumes the most general case: that it is not constant within each timestep. Hence, it recommends a numeric solver.

This PR adds all continuous-valued ("current" type) input ports to the ODE-toolbox input as a parameter with value 0, solving the issue.

@jougs: could you verify that "current" type input ports are indeed expected to have a constant value within a single timestep? (I am 99% sure of this but want to double-check that I'm not missing certain design considerations.)