### PR TITLE
Allow passing lists of input model files and directories

### DIFF
--- a/doc/running.rst
+++ b/doc/running.rst
@@ -18,7 +18,7 @@ where arguments are:
    * - ``-h`` or ``--help``
      - Print help message.
    * - ``--input_path``
-     - Path to the source file or directory containing the model.
+     - One or more input path(s). Each path is a NESTML file, or a directory containing NESTML files. Directories will be searched recursively for files matching '*.nestml'.
    * - ``--target_path``
      - (Optional) Path to target directory where generated code will be written into. Default is ``target``, which will be created in the current working directory if it does not yet exist.
    * - ``--target``
@@ -71,7 +71,7 @@ This operation expects the same set of arguments as in the case of command line 
      - Type
      - Default
    * - input_path
-     - string
+     - str or Sequence[str]
      - *no default*
    * - target_path
      - string

--- a/pynestml/frontend/frontend_configuration.py
+++ b/pynestml/frontend/frontend_configuration.py
@@ -249,7 +249,7 @@ appropriate numeric solver otherwise.
                     cls.paths_to_compilation_units.append(os.path.join(_path, fn))
             else:
                 # input_path should be either a file or a directory
-                code, message = Messages.get_input_path_not_found(path=cls.provided_input_path)
+                code, message = Messages.get_input_path_not_found(path=_path)
                 Logger.log_message(code=code, message=message, log_level=LoggingLevel.ERROR)
                 raise InvalidPathException(message)
 

--- a/pynestml/frontend/frontend_configuration.py
+++ b/pynestml/frontend/frontend_configuration.py
@@ -33,7 +33,7 @@ from pynestml.utils.logger import Logger
 from pynestml.utils.logger import LoggingLevel
 from pynestml.utils.messages import Messages, MessageCode
 
-help_input_path = 'Path to a single file or a directory containing the source models.'
+help_input_path = 'One or more input path(s). Each path is a NESTML file, or a directory containing NESTML files. Directories will be searched recursively for files matching \'*.nestml\'.'
 help_target_path = 'Path to a target directory where models should be generated to. Standard is "target".'
 help_target = 'Name of the target platform to build code for. Default is NEST.'
 help_logging = 'Indicates which messages shall be logged and printed to the screen. Standard is ERROR.'
@@ -218,7 +218,12 @@ appropriate numeric solver otherwise.
             os.makedirs(cls.target_path)
 
     @classmethod
-    def handle_input_path(cls, path):
+    def handle_input_path(cls, path) -> None:
+        """
+        Sets cls.paths_to_compilation_units with a list of absolute paths to NESTML files.
+
+        Use glob to search directories recursively.
+        """
         cls.provided_input_path = path
 
         if not path or path == ['']:

--- a/pynestml/frontend/frontend_configuration.py
+++ b/pynestml/frontend/frontend_configuration.py
@@ -18,7 +18,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
-import argparse  # used for parsing of input arguments
+
+from typing import Sequence
+
+import argparse
+import glob
 import os
 import re
 
@@ -54,7 +58,7 @@ class FrontendConfiguration(object):
     """
     argument_parser = None
     paths_to_compilation_units = None
-    provided_path = None
+    provided_input_path = None
     logging_level = None
     target = None
     target_path = None
@@ -80,7 +84,7 @@ appropriate numeric solver otherwise.
 
  Version ''' + str(pynestml.__version__), formatter_class=argparse.RawDescriptionHelpFormatter)
 
-        cls.argument_parser.add_argument(qualifier_input_path_arg, metavar='PATH',
+        cls.argument_parser.add_argument(qualifier_input_path_arg, metavar='PATH', nargs='+',
                                          type=str, help=help_input_path, required=True)
         cls.argument_parser.add_argument(qualifier_target_path_arg, metavar='PATH', type=str, help=help_target_path)
         cls.argument_parser.add_argument(qualifier_target_arg, choices=[
@@ -110,34 +114,22 @@ appropriate numeric solver otherwise.
                 raise Exception('The specified module name ("' + parsed_args.module_name
                                 + '") cannot be parsed as a C variable name')
             cls.module_name = parsed_args.module_name
-        elif os.path.isfile(parsed_args.input_path):
+        else:
             cls.module_name = 'nestmlmodule'
             Logger.log_message(code=MessageCode.MODULE_NAME_INFO, message='No module name specified; the generated module will be named "'
                                + cls.module_name + '"', log_level=LoggingLevel.INFO)
-        elif os.path.isdir(parsed_args.input_path):
-            cls.module_name = os.path.basename(os.path.normpath(parsed_args.input_path))
-            if not re.match(r'[a-zA-Z_][a-zA-Z0-9_]*\Z', cls.module_name):
-                raise Exception('No module name specified; tried to use the input directory name ("'
-                                + cls.module_name + '"), but it cannot be parsed as a C variable name')
-            if not cls.module_name.endswith('module'):
-                cls.module_name += 'module'
-            Logger.log_message(code=MessageCode.MODULE_NAME_INFO, message='No module name specified; the generated module will be named "'
-                               + cls.module_name + '"', log_level=LoggingLevel.INFO)
-        else:
-            assert False  # input_path should be either a file or a directory; failure should have been caught already by handle_input_path()
 
         cls.store_log = parsed_args.store_log
         cls.suffix = parsed_args.suffix
         cls.is_dev = parsed_args.dev
 
     @classmethod
-    def get_path(cls):
+    def get_provided_input_path(cls) -> Sequence[str]:
         """
-        Returns the path to the handed over directory or file.
-        :return: a single path
-        :rtype: str
+        Returns the list of file and directory names as supplied by the user.
+        :return: a list of file and directory names
         """
-        return cls.provided_path
+        return cls.provided_input_path
 
     @classmethod
     def get_files(cls):
@@ -227,26 +219,40 @@ appropriate numeric solver otherwise.
 
     @classmethod
     def handle_input_path(cls, path):
-        if path is None or path == '':
-            # check if the mandatory path arg has been handed over, just terminate
-            raise InvalidPathException('No input path specified.')
+        cls.provided_input_path = path
+
+        if not path or path == ['']:
+            # mandatory path arg has not been handed over
+            code, message = Messages.get_input_path_not_found(path="")
+            Logger.log_message(code=code, message=message, log_level=LoggingLevel.ERROR)
+            raise InvalidPathException(message)
+
+        if type(path) is str:
+            path = [path]
 
         cls.paths_to_compilation_units = list()
-        if os.path.isabs(path):
-            cls.provided_path = path
-        else:
-            # a relative path, reconstruct it. get the parent dir where models, pynestml etc. is located
-            pynestml_dir = os.getcwd()
-            cls.provided_path = os.path.join(pynestml_dir, path)
+        for _path in path:
+            if not os.path.isabs(_path):
+                # turn relative to absolute path
+                pynestml_dir = os.getcwd()
+                _path = os.path.join(pynestml_dir, _path)
 
-        if os.path.isfile(cls.provided_path):
-            cls.paths_to_compilation_units.append(cls.provided_path)
-        elif os.path.isdir(cls.provided_path):
-            for filename in os.listdir(cls.provided_path):
-                if filename.endswith('.nestml'):
-                    cls.paths_to_compilation_units.append(os.path.join(cls.provided_path, filename))
-        else:
-            # input_path should be either a file or a directory
-            code, message = Messages.get_input_path_not_found(path=cls.provided_path)
+            if os.path.isfile(_path):
+                cls.paths_to_compilation_units.append(_path)
+            elif os.path.isdir(_path):
+                for fn in glob.glob(os.path.join(_path, "**", "*.nestml"), recursive=True):
+                    cls.paths_to_compilation_units.append(os.path.join(_path, fn))
+            else:
+                # input_path should be either a file or a directory
+                code, message = Messages.get_input_path_not_found(path=cls.provided_input_path)
+                Logger.log_message(code=code, message=message, log_level=LoggingLevel.ERROR)
+                raise InvalidPathException(message)
+
+        if not cls.paths_to_compilation_units:
+            code, message = Messages.get_no_files_in_input_path(" ".join(path))
             Logger.log_message(code=code, message=message, log_level=LoggingLevel.ERROR)
-            raise Exception(message)
+            raise InvalidPathException(message)
+
+        Logger.log_message(message="List of files that will be processed:", log_level=LoggingLevel.INFO)
+        for fn in cls.paths_to_compilation_units:
+            Logger.log_message(message=fn, log_level=LoggingLevel.INFO)

--- a/pynestml/frontend/pynestml_frontend.py
+++ b/pynestml/frontend/pynestml_frontend.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Union, Sequence
+
 import os
 import sys
 
@@ -37,14 +39,14 @@ from pynestml.utils.model_parser import ModelParser
 from pynestml.utils.model_installer import install_nest as nest_installer
 
 
-def to_nest(input_path, target_path=None, logging_level='ERROR',
+def to_nest(input_path: Union[str, Sequence[str]], target_path=None, logging_level='ERROR',
             module_name=None, store_log=False, suffix="", dev=False):
     '''Translate NESTML files into their equivalent C++ code for the NEST simulator.
 
     Parameters
     ----------
-    input_path : str
-        Path to the NESTML file or to a folder containing NESTML files to convert to NEST code.
+    input_path : str **or** Sequence[str]
+        Path to the NESTML file(s) or to folder(s) containing NESTML files to convert to NEST code.
     target_path : str, optional (default: append "target" to `input_path`)
         Path to the generated C++ code and install files.
     logging_level : str, optional (default: 'ERROR')
@@ -63,7 +65,11 @@ def to_nest(input_path, target_path=None, logging_level='ERROR',
     #    return
     args = list()
     args.append(qualifier_input_path_arg)
-    args.append(str(input_path))
+    if type(input_path) is str:
+        args.append(str(input_path))
+    else:
+        for s in input_path:
+            args.append(s)
 
     if target_path is not None:
         args.append(qualifier_target_path_arg)
@@ -120,8 +126,7 @@ def main():
     """Returns the process exit code: 0 for success, > 0 for failure"""
     try:
         FrontendConfiguration.parse_config(sys.argv[1:])
-    except InvalidPathException:
-        print('Not a valid path to model or directory: "%s"!' % FrontendConfiguration.get_path())
+    except InvalidPathException as e:
         return 1
     # the default Python recursion limit is 1000, which might not be enough in practice when running an AST visitor on a deep tree, e.g. containing an automatically generated expression
     sys.setrecursionlimit(10000)

--- a/pynestml/utils/messages.py
+++ b/pynestml/utils/messages.py
@@ -103,6 +103,7 @@ class MessageCode(Enum):
     KERNEL_WRONG_TYPE = 73
     KERNEL_IV_WRONG_TYPE = 74
     EMIT_SPIKE_FUNCTION_BUT_NO_OUTPUT_PORT = 75
+    NO_FILES_IN_INPUT_PATH = 76
 
 
 class Messages(object):
@@ -1151,9 +1152,13 @@ class Messages(object):
         message = 'Initial value \'%s\' was found to be of type \'%s\' (should be %s)!' % (iv_name, actual_type, expected_type)
         return MessageCode.KERNEL_IV_WRONG_TYPE, message
 
-
     @classmethod
     def get_could_not_determine_cond_based(cls, type_str, name):
         message = "Unable to determine based on type '" + type_str + \
             "' of variable '" + name + "' whether conductance-based or current-based"
         return MessageCode.LEXER_ERROR, message
+
+    @classmethod
+    def get_no_files_in_input_path(cls, path: str):
+        message = "No files found matching '*.nestml' in provided input path '" + path + "'"
+        return MessageCode.NO_FILES_IN_INPUT_PATH, message


### PR DESCRIPTION
Currently, it is only possible to pass a single file or a single directory path as input to NESTML. This PR allows passing an enumeration of paths, so that you can single out particular models, for example:

```sh
nestml --input_path "models/iaf_psc_exp.nestml" "models/stdp.nestml"
```

This also works in the Python API:
```python
to_nest(input_path=["models/iaf_psc_exp.nestml", "models/stdp.nestml"], ...)
```
