### PR TITLE
Documentation changes for merging of state and initial_values blocks

### DIFF
--- a/doc/models_library/aeif_cond_alpha.rst
+++ b/doc/models_library/aeif_cond_alpha.rst
@@ -108,34 +108,34 @@ Source code
 .. code:: nestml
 
    neuron aeif_cond_alpha:
-     initial_values:
+     state:
        V_m mV = E_L # Membrane potential
        w pA = 0pA # Spike-adaptation current
      end
+
      equations:
-       function V_bounded mV = min(V_m,V_peak) # prevent exponential divergence
+       inline V_bounded mV = min(V_m,V_peak) # prevent exponential divergence
        kernel g_in = (e / tau_syn_in) * t * exp(-t / tau_syn_in)
        kernel g_ex = (e / tau_syn_ex) * t * exp(-t / tau_syn_ex)
 
-       /* Add functions to simplify the equation definition of V_m*/
-       function exp_arg real = (V_bounded - V_th) / Delta_T
-       function I_spike pA = g_L * Delta_T * exp(exp_arg)
-       function I_syn_exc pA = convolve(g_ex,spikesExc) * (V_bounded - E_ex)
-       function I_syn_inh pA = convolve(g_in,spikesInh) * (V_bounded - E_in)
+       # Add aliases to simplify the equation definition of V_m
+       inline exp_arg real = (V_bounded - V_th) / Delta_T
+       inline I_spike pA = g_L * Delta_T * exp(exp_arg)
+       inline I_syn_exc pA = convolve(g_ex,spikesExc) * (V_bounded - E_ex)
+       inline I_syn_inh pA = convolve(g_in,spikesInh) * (V_bounded - E_in)
        V_m'=(-g_L * (V_bounded - E_L) + I_spike - I_syn_exc - I_syn_inh - w + I_e + I_stim) / C_m
        w'=(a * (V_m - E_L) - w) / tau_w
      end
 
      parameters:
-
-       /* membrane parameters*/
+       # membrane parameters
        C_m pF = 281.0pF # Membrane Capacitance
        t_ref ms = 0.0ms # Refractory period
        V_reset mV = -60.0mV # Reset Potential
        g_L nS = 30.0nS # Leak Conductance
        E_L mV = -70.6mV # Leak reversal Potential (aka resting potential)
 
-       /* spike adaptation parameters*/
+       # spike adaptation parameters
        a nS = 4nS # Subthreshold adaptation
        b pA = 80.5pA # pike-triggered adaptation
        Delta_T mV = 2.0mV # Slope factor
@@ -143,32 +143,32 @@ Source code
        V_th mV = -50.4mV # Threshold Potential
        V_peak mV = 0mV # Spike detection threshold
 
-       /* synaptic parameters*/
+       # synaptic parameters
        E_ex mV = 0mV # Excitatory reversal Potential
        tau_syn_ex ms = 0.2ms # Synaptic Time Constant Excitatory Synapse
        E_in mV = -85.0mV # Inhibitory reversal Potential
        tau_syn_in ms = 2.0ms # Synaptic Time Constant for Inhibitory Synapse
 
-       /* constant external input current*/
+       # constant external input current
        I_e pA = 0pA
      end
      internals:
 
-       /* Impulse to add to DG_EXC on spike arrival to evoke unit-amplitude*/
-       /* conductance excursion.*/
+       # Impulse to add to DG_EXC on spike arrival to evoke unit-amplitude
+       # conductance excursion.
        PSConInit_E nS/ms = nS * e / tau_syn_ex
 
-       /* Impulse to add to DG_INH on spike arrival to evoke unit-amplitude*/
-       /* conductance excursion.*/
+       # Impulse to add to DG_INH on spike arrival to evoke unit-amplitude
+       # conductance excursion.
        PSConInit_I nS/ms = nS * e / tau_syn_in
 
-       /* refractory time in steps*/
+       # refractory time in steps
        RefractoryCounts integer = steps(t_ref)
-       /* counts number of tick during the refractory period*/
 
-       /* counts number of tick during the refractory period*/
+       # counts number of tick during the refractory period
        r integer 
      end
+
      input:
        spikesInh nS <-inhibitory spike
        spikesExc nS <-excitatory spike

--- a/doc/models_library/aeif_cond_exp.rst
+++ b/doc/models_library/aeif_cond_exp.rst
@@ -114,34 +114,35 @@ Source code
 .. code:: nestml
 
    neuron aeif_cond_exp:
-     initial_values:
+     state:
        V_m mV = E_L # Membrane potential
        w pA = 0pA # Spike-adaptation current
      end
+
      equations:
-       function V_bounded mV = min(V_m,V_peak) # prevent exponential divergence
+       inline V_bounded mV = min(V_m,V_peak) # prevent exponential divergence
        kernel g_in = exp(-1 / tau_syn_in * t)
        kernel g_ex = exp(-1 / tau_syn_ex * t)
 
-       /* Add aliases to simplify the equation definition of V_m*/
-       function exp_arg real = (V_bounded - V_th) / Delta_T
-       function I_spike pA = g_L * Delta_T * exp(exp_arg)
-       function I_syn_exc pA = convolve(g_ex,spikeExc) * (V_bounded - E_ex)
-       function I_syn_inh pA = convolve(g_in,spikeInh) * (V_bounded - E_in)
+       #  Add aliases to simplify the equation definition of V_m
+       inline exp_arg real = (V_bounded - V_th) / Delta_T
+       inline I_spike pA = g_L * Delta_T * exp(exp_arg)
+       inline I_syn_exc pA = convolve(g_ex,spikeExc) * (V_bounded - E_ex)
+       inline I_syn_inh pA = convolve(g_in,spikeInh) * (V_bounded - E_in)
        V_m'=(-g_L * (V_bounded - E_L) + I_spike - I_syn_exc - I_syn_inh - w + I_e + I_stim) / C_m
        w'=(a * (V_bounded - E_L) - w) / tau_w
      end
 
      parameters:
 
-       /* membrane parameters*/
+       # membrane parameters
        C_m pF = 281.0pF # Membrane Capacitance
        t_ref ms = 0.0ms # Refractory period
        V_reset mV = -60.0mV # Reset Potential
        g_L nS = 30.0nS # Leak Conductance
        E_L mV = -70.6mV # Leak reversal Potential (aka resting potential)
 
-       /* spike adaptation parameters*/
+       # spike adaptation parameters
        a nS = 4nS # Subthreshold adaptation.
        b pA = 80.5pA # Spike-trigg_exred adaptation.
        Delta_T mV = 2.0mV # Slope factor
@@ -149,24 +150,24 @@ Source code
        V_th mV = -50.4mV # Threshold Potential
        V_peak mV = 0mV # Spike detection threshold.
 
-       /* synaptic parameters*/
+       # synaptic parameters
        E_ex mV = 0mV # Excitatory reversal Potential
        tau_syn_ex ms = 0.2ms # Synaptic Time Constant Excitatory Synapse
        E_in mV = -85.0mV # Inhibitory reversal Potential
        tau_syn_in ms = 2.0ms # Synaptic Time Constant for Inhibitory Synapse
 
-       /* constant external input current*/
+       # constant external input current
        I_e pA = 0pA
      end
+
      internals:
-
-       /* refractory time in steps*/
+       # refractory time in steps
        RefractoryCounts integer = steps(t_ref)
-       /* counts number of tick during the refractory period*/
 
-       /* counts number of tick during the refractory period*/
+       # counts number of tick during the refractory period
        r integer 
      end
+
      input:
        spikeInh nS <-inhibitory spike
        spikeExc nS <-excitatory spike

--- a/doc/models_library/hh_cond_exp_destexhe.rst
+++ b/doc/models_library/hh_cond_exp_destexhe.rst
@@ -135,48 +135,40 @@ Source code
        r integer  # counts number of tick during the refractory period
        g_noise_ex uS = g_noise_ex0
        g_noise_in uS = g_noise_in0
-     end
-     initial_values:
+
        V_m mV = E_L # Membrane potential
-       function alpha_n_init 1/ms = 0.032 / (ms * mV) * (15.0mV - V_m) / (exp((15.0mV - V_m) / 5.0mV) - 1.0)
-       function beta_n_init 1/ms = 0.5 / ms * exp((10.0mV - V_m) / 40.0mV)
-       function alpha_m_init 1/ms = 0.32 / (ms * mV) * (13.0mV - V_m) / (exp((13.0mV - V_m) / 4.0mV) - 1.0)
-       function beta_m_init 1/ms = 0.28 / (ms * mV) * (V_m - 40.0mV) / (exp((V_m - 40.0mV) / 5.0mV) - 1.0)
-       function alpha_h_init 1/ms = 0.128 / ms * exp((17.0mV - V_m) / 18.0mV)
-       function beta_h_init 1/ms = (4.0 / (1.0 + exp((40.0mV - V_m) / 5.0mV))) / ms
-       function alpha_p_init 1/ms = 0.0001 / (ms * mV) * (V_m + 30.0mV) / (1.0 - exp(-(V_m + 30.0mV) / 9.0mV))
-       function beta_p_init 1/ms = -0.0001 / (ms * mV) * (V_m + 30.0mV) / (1.0 - exp((V_m + 30.0mV) / 9.0mV))
        Act_m real = alpha_m_init / (alpha_m_init + beta_m_init)
        Act_h real = alpha_h_init / (alpha_h_init + beta_h_init)
        Inact_n real = alpha_n_init / (alpha_n_init + beta_n_init)
        Noninact_p real = alpha_p_init / (alpha_p_init + beta_p_init)
      end
+
      equations:
 
-       /* synapses: exponential conductance*/
+       # synapses: exponential conductance
        kernel g_in = exp(-1 / tau_syn_in * t)
        kernel g_ex = exp(-1 / tau_syn_ex * t)
 
-       /* Add aliases to simplify the equation definition of V_m*/
-       function I_Na pA = g_Na * Act_m * Act_m * Act_m * Act_h * (V_m - E_Na)
-       function I_K pA = g_K * Inact_n * Inact_n * Inact_n * Inact_n * (V_m - E_K)
-       function I_L pA = g_L * (V_m - E_L)
-       function I_M pA = g_M * Noninact_p * (V_m - E_K)
-       function I_noise pA = (g_noise_ex * (V_m - E_ex) + g_noise_in * (V_m - E_in))
-       function I_syn_exc pA = convolve(g_ex,spikeExc) * (V_m - E_ex)
-       function I_syn_inh pA = convolve(g_in,spikeInh) * (V_m - E_in)
+       # Add aliases to simplify the equation definition of V_m
+       inline I_Na pA = g_Na * Act_m * Act_m * Act_m * Act_h * (V_m - E_Na)
+       inline I_K pA = g_K * Inact_n * Inact_n * Inact_n * Inact_n * (V_m - E_K)
+       inline I_L pA = g_L * (V_m - E_L)
+       inline I_M pA = g_M * Noninact_p * (V_m - E_K)
+       inline I_noise pA = (g_noise_ex * (V_m - E_ex) + g_noise_in * (V_m - E_in))
+       inline I_syn_exc pA = convolve(g_ex,spikeExc) * (V_m - E_ex)
+       inline I_syn_inh pA = convolve(g_in,spikeInh) * (V_m - E_in)
        V_m'=(-I_Na - I_K - I_M - I_L - I_syn_exc - I_syn_inh + I_e + I_stim - I_noise) / C_m
 
-       /* channel dynamics*/
-       function V_rel mV = V_m - V_T
-       function alpha_n 1/ms = 0.032 / (ms * mV) * (15.0mV - V_rel) / (exp((15.0mV - V_rel) / 5.0mV) - 1.0)
-       function beta_n 1/ms = 0.5 / ms * exp((10.0mV - V_rel) / 40.0mV)
-       function alpha_m 1/ms = 0.32 / (ms * mV) * (13.0mV - V_rel) / (exp((13.0mV - V_rel) / 4.0mV) - 1.0)
-       function beta_m 1/ms = 0.28 / (ms * mV) * (V_rel - 40.0mV) / (exp((V_rel - 40.0mV) / 5.0mV) - 1.0)
-       function alpha_h 1/ms = 0.128 / ms * exp((17.0mV - V_rel) / 18.0mV)
-       function beta_h 1/ms = (4.0 / (1.0 + exp((40.0mV - V_rel) / 5.0mV))) / ms
-       function alpha_p 1/ms = 0.0001 / (ms * mV) * (V_m + 30.0mV) / (1.0 - exp(-(V_m + 30.0mV) / 9.0mV))
-       function beta_p 1/ms = -0.0001 / (ms * mV) * (V_m + 30.0mV) / (1.0 - exp((V_m + 30.0mV) / 9.0mV))
+       # channel dynamics
+       inline V_rel mV = V_m - V_T
+       inline alpha_n 1/ms = 0.032 / (ms * mV) * (15.0mV - V_rel) / (exp((15.0mV - V_rel) / 5.0mV) - 1.0)
+       inline beta_n 1/ms = 0.5 / ms * exp((10.0mV - V_rel) / 40.0mV)
+       inline alpha_m 1/ms = 0.32 / (ms * mV) * (13.0mV - V_rel) / (exp((13.0mV - V_rel) / 4.0mV) - 1.0)
+       inline beta_m 1/ms = 0.28 / (ms * mV) * (V_rel - 40.0mV) / (exp((V_rel - 40.0mV) / 5.0mV) - 1.0)
+       inline alpha_h 1/ms = 0.128 / ms * exp((17.0mV - V_rel) / 18.0mV)
+       inline beta_h 1/ms = (4.0 / (1.0 + exp((40.0mV - V_rel) / 5.0mV))) / ms
+       inline alpha_p 1/ms = 0.0001 / (ms * mV) * (V_m + 30.0mV) / (1.0 - exp(-(V_m + 30.0mV) / 9.0mV))
+       inline beta_p 1/ms = -0.0001 / (ms * mV) * (V_m + 30.0mV) / (1.0 - exp((V_m + 30.0mV) / 9.0mV))
        Act_m'=(alpha_m - (alpha_m + beta_m) * Act_m)
        Act_h'=(alpha_h - (alpha_h + beta_h) * Act_h)
        Inact_n'=(alpha_n - (alpha_n + beta_n) * Inact_n)
@@ -192,9 +184,7 @@ Source code
        E_K mV = -90.0mV # Potassium reversal potential
        E_L mV = -80.0mV # Leak reversal Potential (aka resting potential)
        V_T mV = -58.0mV # Voltage offset that controls dynamics. For default
-       /* parameters, V_T = -63mV results in a threshold around -50mV.*/
 
-       /* parameters, V_T = -63mV results in a threshold around -50mV.*/
        tau_syn_ex ms = 2.7ms # Synaptic Time Constant Excitatory Synapse
        tau_syn_in ms = 10.5ms # Synaptic Time Constant for Inhibitory Synapse
        I_e pA = 0pA # Constant Current
@@ -202,12 +192,13 @@ Source code
        E_in mV = -75.0mV # Inhibitory synaptic reversal potential
        g_M nS = 173.18nS # Conductance of non-inactivating K+ channel
 
-       /* Conductance OU noise*/
+       # Conductance OU noise
        g_noise_ex0 uS = 0.012uS # Mean of the excitatory noise conductance
        g_noise_in0 uS = 0.057uS # Mean of the inhibitory noise conductance
        sigma_noise_ex uS = 0.003uS # Standard deviation of the excitatory noise conductance
        sigma_noise_in uS = 0.0066uS # Standard deviation of the inhibitory noise conductance
      end
+
      internals:
        RefractoryCounts integer = 20
        D_ex uS**2/ms = 2 * sigma_noise_ex ** 2 / tau_syn_ex
@@ -215,6 +206,7 @@ Source code
        A_ex uS = ((D_ex * tau_syn_ex / 2) * (1 - exp(-2 * resolution() / tau_syn_ex))) ** 0.5
        A_in uS = ((D_in * tau_syn_in / 2) * (1 - exp(-2 * resolution() / tau_syn_in))) ** 0.5
      end
+
      input:
        spikeInh nS <-inhibitory spike
        spikeExc nS <-excitatory spike
@@ -229,7 +221,7 @@ Source code
        g_noise_ex = g_noise_ex0 + (g_noise_ex - g_noise_ex0) * exp(-resolution() / tau_syn_ex) + A_ex * random_normal(0,1)
        g_noise_in = g_noise_in0 + (g_noise_in - g_noise_in0) * exp(-resolution() / tau_syn_in) + A_in * random_normal(0,1)
 
-       /* sending spikes: crossing 0 mV, pseudo-refractoriness and local maximum...*/
+       # sending spikes: crossing 0 mV, pseudo-refractoriness and local maximum...
        if r > 0:
          r -= 1
        elif V_m > V_T + 30mV and U_old > V_m:

--- a/doc/models_library/hh_cond_exp_traub.rst
+++ b/doc/models_library/hh_cond_exp_traub.rst
@@ -139,42 +139,35 @@ Source code
 
    neuron hh_cond_exp_traub:
      state:
-       r integer  # counts number of tick during the refractory period
-     end
-     initial_values:
+       r integer = 0 # counts number of tick during the refractory period
        V_m mV = E_L # Membrane potential
-       function alpha_n_init 1/ms = 0.032 / (ms * mV) * (15.0mV - V_m) / (exp((15.0mV - V_m) / 5.0mV) - 1.0)
-       function beta_n_init 1/ms = 0.5 / ms * exp((10.0mV - V_m) / 40.0mV)
-       function alpha_m_init 1/ms = 0.32 / (ms * mV) * (13.0mV - V_m) / (exp((13.0mV - V_m) / 4.0mV) - 1.0)
-       function beta_m_init 1/ms = 0.28 / (ms * mV) * (V_m - 40.0mV) / (exp((V_m - 40.0mV) / 5.0mV) - 1.0)
-       function alpha_h_init 1/ms = 0.128 / ms * exp((17.0mV - V_m) / 18.0mV)
-       function beta_h_init 1/ms = (4.0 / (1.0 + exp((40.0mV - V_m) / 5.0mV))) / ms
+
        Act_m real = alpha_m_init / (alpha_m_init + beta_m_init)
        Act_h real = alpha_h_init / (alpha_h_init + beta_h_init)
        Inact_n real = alpha_n_init / (alpha_n_init + beta_n_init)
      end
-     equations:
 
-       /* synapses: exponential conductance*/
+     equations:
+       # synapses: exponential conductance
        kernel g_in = exp(-1 / tau_syn_in * t)
        kernel g_ex = exp(-1 / tau_syn_ex * t)
 
-       /* Add aliases to simplify the equation definition of V_m*/
-       function I_Na pA = g_Na * Act_m * Act_m * Act_m * Act_h * (V_m - E_Na)
-       function I_K pA = g_K * Inact_n * Inact_n * Inact_n * Inact_n * (V_m - E_K)
-       function I_L pA = g_L * (V_m - E_L)
-       function I_syn_exc pA = convolve(g_ex,spikeExc) * (V_m - E_ex)
-       function I_syn_inh pA = convolve(g_in,spikeInh) * (V_m - E_in)
+       # Add aliases to simplify the equation definition of V_m
+       inline I_Na pA = g_Na * Act_m * Act_m * Act_m * Act_h * (V_m - E_Na)
+       inline I_K pA = g_K * Inact_n * Inact_n * Inact_n * Inact_n * (V_m - E_K)
+       inline I_L pA = g_L * (V_m - E_L)
+       inline I_syn_exc pA = convolve(g_ex,spikeExc) * (V_m - E_ex)
+       inline I_syn_inh pA = convolve(g_in,spikeInh) * (V_m - E_in)
        V_m'=(-I_Na - I_K - I_L - I_syn_exc - I_syn_inh + I_e + I_stim) / C_m
 
-       /* channel dynamics*/
-       function V_rel mV = V_m - V_T
-       function alpha_n 1/ms = 0.032 / (ms * mV) * (15.0mV - V_rel) / (exp((15.0mV - V_rel) / 5.0mV) - 1.0)
-       function beta_n 1/ms = 0.5 / ms * exp((10.0mV - V_rel) / 40.0mV)
-       function alpha_m 1/ms = 0.32 / (ms * mV) * (13.0mV - V_rel) / (exp((13.0mV - V_rel) / 4.0mV) - 1.0)
-       function beta_m 1/ms = 0.28 / (ms * mV) * (V_rel - 40.0mV) / (exp((V_rel - 40.0mV) / 5.0mV) - 1.0)
-       function alpha_h 1/ms = 0.128 / ms * exp((17.0mV - V_rel) / 18.0mV)
-       function beta_h 1/ms = (4.0 / (1.0 + exp((40.0mV - V_rel) / 5.0mV))) / ms
+       # channel dynamics
+       inline V_rel mV = V_m - V_T
+       inline alpha_n 1/ms = 0.032 / (ms * mV) * (15.0mV - V_rel) / (exp((15.0mV - V_rel) / 5.0mV) - 1.0)
+       inline beta_n 1/ms = 0.5 / ms * exp((10.0mV - V_rel) / 40.0mV)
+       inline alpha_m 1/ms = 0.32 / (ms * mV) * (13.0mV - V_rel) / (exp((13.0mV - V_rel) / 4.0mV) - 1.0)
+       inline beta_m 1/ms = 0.28 / (ms * mV) * (V_rel - 40.0mV) / (exp((V_rel - 40.0mV) / 5.0mV) - 1.0)
+       inline alpha_h 1/ms = 0.128 / ms * exp((17.0mV - V_rel) / 18.0mV)
+       inline beta_h 1/ms = (4.0 / (1.0 + exp((40.0mV - V_rel) / 5.0mV))) / ms
        Act_m'=(alpha_m - (alpha_m + beta_m) * Act_m)
        Act_h'=(alpha_h - (alpha_h + beta_h) * Act_h)
        Inact_n'=(alpha_n - (alpha_n + beta_n) * Inact_n)
@@ -189,21 +182,21 @@ Source code
        E_K mV = -90.0mV # Potassium reversal potential
        E_L mV = -60.0mV # Leak reversal Potential (aka resting potential)
        V_T mV = -63.0mV # Voltage offset that controls dynamics. For default
-       /* parameters, V_T = -63 mV results in a threshold around -50 mV.*/
 
-       /* parameters, V_T = -63 mV results in a threshold around -50 mV.*/
        tau_syn_ex ms = 5.0ms # Synaptic Time Constant Excitatory Synapse
        tau_syn_in ms = 10.0ms # Synaptic Time Constant for Inhibitory Synapse
        t_ref ms = 2.0ms # Refractory period
        E_ex mV = 0.0mV # Excitatory synaptic reversal potential
        E_in mV = -80.0mV # Inhibitory synaptic reversal potential
 
-       /* constant external input current*/
+       # constant external input current
        I_e pA = 0pA
      end
+
      internals:
        RefractoryCounts integer = steps(t_ref)
      end
+
      input:
        spikeInh nS <-inhibitory spike
        spikeExc nS <-excitatory spike
@@ -216,7 +209,7 @@ Source code
        U_old mV = V_m
        integrate_odes()
 
-       /* sending spikes: crossing 0 mV, pseudo-refractoriness and local maximum...*/
+       # sending spikes: crossing 0 mV, pseudo-refractoriness and local maximum...
        if r > 0:
          r -= 1
        elif V_m > V_T + 30mV and U_old > V_m:

--- a/doc/models_library/hill_tononi.rst
+++ b/doc/models_library/hill_tononi.rst
@@ -190,199 +190,210 @@ Source code
 .. code:: nestml
 
    neuron hill_tononi:
-     state:
-       r_potassium integer 
-       g_spike boolean = false
-     end
-     initial_values:
-       V_m mV = (g_NaL * E_Na + g_KL * E_K) / (g_NaL + g_KL) # membrane potential
-       Theta mV = Theta_eq # Threshold
-       g_AMPA,g_NMDA,g_GABAA,g_GABAB,IKNa_D nS = 0.0nS
-       g_AMPA__d,g_NMDA__d,g_GABAA__d,g_GABAB__d nS/ms = 0.0nS / ms
-       IT_m,IT_h,Ih_m real = 0.0
-     end
-     equations:
+      state:
+        r_potassium integer = 0
+        g_spike boolean = false
 
-       /**/
-       /* V_m*/
-       /**/
-       function I_syn_ampa pA = -g_AMPA * (V_m - AMPA_E_rev)
-       function I_syn_nmda pA = -g_NMDA * (V_m - NMDA_E_rev) / (1 + exp((NMDA_Vact - V_m) / NMDA_Sact))
-       function I_syn_gaba_a pA = -g_GABAA * (V_m - GABA_A_E_rev)
-       function I_syn_gaba_b pA = -g_GABAB * (V_m - GABA_B_E_rev)
-       function I_syn pA = I_syn_ampa + I_syn_nmda + I_syn_gaba_a + I_syn_gaba_b
-       function I_Na pA = -g_NaL * (V_m - E_Na)
-       function I_K pA = -g_KL * (V_m - E_K)
+        V_m mV = ( g_NaL * E_Na + g_KL * E_K ) / ( g_NaL + g_KL ) # membrane potential
+        Theta mV = Theta_eq # Threshold
+        IKNa_D, IT_m, IT_h, Ih_m nS = 0.0 nS
 
-       /* I_Na(p), m_inf^3 according to Compte et al, J Neurophysiol 2003 89:2707*/
-       function INaP_thresh mV = -55.7mV
-       function INaP_slope mV = 7.7mV
-       function m_inf_NaP real = 1.0 / (1.0 + exp(-(V_m - INaP_thresh) / INaP_slope))
-       function d_half real = 0.25
-       function m_inf_KNa real = 1.0 / (1.0 + (d_half / (IKNa_D / nS)) ** 3.5)
+        g_AMPA real = 0
+        g_NMDA real = 0
+        g_GABAA real = 0
+        g_GABAB real = 0
+        g_AMPA$ real = AMPAInitialValue
+        g_NMDA$ real = NMDAInitialValue
+        g_GABAA$ real = GABA_AInitialValue
+        g_GABAB$ real = GABA_BInitialValue
+      end
 
-       /* Persistent Na current; member only to allow recording*/
-   recordable    function I_NaP pA = -NaP_g_peak * m_inf_NaP ** 3 * (V_m - NaP_E_rev)
+      equations:
+        #############
+        # V_m
+        #############
 
-       /* Depol act. K current; member only to allow recording*/
-   recordable    function I_KNa pA = -KNa_g_peak * m_inf_KNa * (V_m - KNa_E_rev)
+        inline I_syn_ampa pA = -convolve(g_AMPA, AMPA) * ( V_m - AMPA_E_rev )
+        inline I_syn_nmda pA = -convolve(g_NMDA, NMDA) * ( V_m - NMDA_E_rev ) / ( 1 + exp( ( NMDA_Vact - V_m ) / NMDA_Sact ) )
+        inline I_syn_gaba_a pA = -convolve(g_GABAA, GABA_A) * ( V_m - GABA_A_E_rev )
+        inline I_syn_gaba_b pA = -convolve(g_GABAB, GABA_B) * ( V_m - GABA_B_E_rev )
+        inline I_syn pA = I_syn_ampa + I_syn_nmda + I_syn_gaba_a + I_syn_gaba_b
 
-       /* Low-thresh Ca current; member only to allow recording*/
-   recordable    function I_T pA = -T_g_peak * IT_m * IT_m * IT_h * (V_m - T_E_rev)
-   recordable    function I_h pA = -h_g_peak * Ih_m * (V_m - h_E_rev)
+        inline I_Na pA = -g_NaL * ( V_m - E_Na )
+        inline I_K pA = -g_KL * ( V_m - E_K )
 
-       /* The spike current is only activate immediately after a spike.*/
-       function I_spike pA = (g_spike)?-(V_m - E_K) / Tau_spike / mV * ms * pA:0pA
-       V_m'=((I_Na + I_K + I_syn + I_NaP + I_KNa + I_T + I_h + I_e + I_stim) / Tau_m + I_spike / (ms * mV)) * s / nF
+        # I_Na(p), m_inf^3 according to Compte et al, J Neurophysiol 2003 89:2707
+        inline INaP_thresh mV = -55.7 mV
+        inline INaP_slope mV = 7.7 mV
+        inline m_inf_NaP real = 1.0 / ( 1.0 + exp( -( V_m - INaP_thresh ) / INaP_slope ) )
+        # Persistent Na current; member only to allow recording
+        recordable inline I_NaP pA = -NaP_g_peak * m_inf_NaP**3 * ( V_m - NaP_E_rev )
 
-       /**/
-       /* Intrinsic currents*/
-       /**/
-       /* I_T*/
-       function m_inf_T real = 1.0 / (1.0 + exp(-(V_m / mV + 59.0) / 6.2))
-       function h_inf_T real = 1.0 / (1.0 + exp((V_m / mV + 83.0) / 4))
-       /* I_KNa*/
+        inline d_half real = 0.25
+        inline m_inf_KNa real = 1.0 / ( 1.0 + ( d_half / ( IKNa_D / nS ) )**3.5 )
+        # Depol act. K current; member only to allow recording
+        recordable inline I_KNa pA = -KNa_g_peak * m_inf_KNa * ( V_m - KNa_E_rev )
 
-       /* I_KNa*/
-       function D_influx_peak real = 0.025
-       function tau_D real = 1250.0 # yes, 1.25 s
-       function D_thresh mV = -10.0mV
-       function D_slope mV = 5.0mV
-       function D_influx real = 1.0 / (1.0 + exp(-(V_m - D_thresh) / D_slope))
-       Theta'=-(Theta - Theta_eq) / Tau_theta
+        # Low-thresh Ca current; member only to allow recording
+        recordable inline I_T pA = -T_g_peak * IT_m * IT_m * IT_h * ( V_m - T_E_rev )
 
-       /* equation modified from y[](1-D_eq) to (y[]-D_eq), since we'd not*/
-       /* be converging to equilibrium otherwise*/
-       IKNa_D'=(D_influx_peak * D_influx * nS - (IKNa_D - KNa_D_EQ / mV) / tau_D) / ms
-       function tau_m_T ms = (0.22 / (exp(-(V_m / mV + 132.0) / 16.7) + exp((V_m / mV + 16.8) / 18.2)) + 0.13) * ms
-       function tau_h_T ms = (8.2 + (56.6 + 0.27 * exp((V_m / mV + 115.2) / 5.0)) / (1.0 + exp((V_m / mV + 86.0) / 3.2))) * ms
-       function tau_m_h ms = (1.0 / (exp(-14.59 - 0.086 * V_m / mV) + exp(-1.87 + 0.0701 * V_m / mV))) * ms
-       function I_h_Vthreshold real = -75.0
-       function m_inf_h real = 1.0 / (1.0 + exp((V_m / mV - I_h_Vthreshold) / 5.5))
-       IT_m'=(m_inf_T - IT_m) / tau_m_T
-       IT_h'=(h_inf_T - IT_h) / tau_h_T
-       Ih_m'=(m_inf_h - Ih_m) / tau_m_h
+        recordable inline I_h pA = -h_g_peak * Ih_m  * ( V_m - h_E_rev )
+        # The spike current is only activate immediately after a spike.
+        inline I_spike mV = (g_spike) ? -( V_m - E_K ) / Tau_spike : 0
+        V_m'  = ( ( I_Na + I_K + I_syn + I_NaP + I_KNa + I_T + I_h + I_e + I_stim ) / Tau_m + I_spike * pA/(ms * mV) ) * s/nF
 
-       /**/
-       /* Synapses*/
-       /**/
-       g_AMPA__d'=-g_AMPA__d / AMPA_Tau_1
-       g_AMPA'=g_AMPA__d - g_AMPA / AMPA_Tau_2
-       g_NMDA__d'=-g_NMDA__d / NMDA_Tau_1
-       g_NMDA'=g_NMDA__d - g_NMDA / NMDA_Tau_2
-       g_GABAA__d'=-g_GABAA__d / GABA_A_Tau_1
-       g_GABAA'=g_GABAA__d - g_GABAA / GABA_A_Tau_2
-       g_GABAB__d'=-g_GABAB__d / GABA_B_Tau_1
-       g_GABAB'=g_GABAB__d - g_GABAB / GABA_B_Tau_2
-     end
+        #############
+        # Intrinsic currents
+        #############
+        # I_T
+        inline m_inf_T real = 1.0 / ( 1.0 + exp( -( V_m / mV + 59.0 ) / 6.2 ) )
+        inline h_inf_T real = 1.0 / ( 1.0 + exp( ( V_m / mV + 83.0 ) / 4 ) )
+        inline tau_m_h real = 1.0 / ( exp( -14.59 - 0.086 * V_m / mV ) + exp( -1.87 + 0.0701 * V_m / mV ) )
+        # I_KNa
+        inline D_influx_peak real = 0.025
+        inline tau_D real = 1250.0 # yes, 1.25 s
+        inline D_thresh mV = -10.0
+        inline D_slope mV = 5.0
+        inline D_influx real = 1.0 / ( 1.0 + exp( -( V_m - D_thresh ) / D_slope ) )
 
-     parameters:
-       E_Na mV = 30.0mV
-       E_K mV = -90.0mV
-       g_NaL nS = 0.2nS
-       g_KL nS = 1.0nS # 1.0 - 1.85
-       Tau_m ms = 16.0ms # membrane time constant applying to all currents but repolarizing K-current (see [1, p 1677])
-       Theta_eq mV = -51.0mV # equilibrium value
-       Tau_theta ms = 2.0ms # time constant
-       Tau_spike ms = 1.75ms # membrane time constant applying to repolarizing K-current
-       t_spike ms = 2.0ms # duration of re-polarizing potassium current
+        Theta' = -( Theta - Theta_eq ) / Tau_theta
 
-       /* Parameters for synapse of type AMPA, GABA_A, GABA_B and NMDA*/
-       AMPA_g_peak nS = 0.1nS # peak conductance
-       AMPA_E_rev mV = 0.0mV # reversal potential
-       AMPA_Tau_1 ms = 0.5ms # rise time
-       AMPA_Tau_2 ms = 2.4ms # decay time, Tau_1 < Tau_2
-       NMDA_g_peak nS = 0.075nS # peak conductance
-       NMDA_Tau_1 ms = 4.0ms # rise time
-       NMDA_Tau_2 ms = 40.0ms # decay time, Tau_1 < Tau_2
-       NMDA_E_rev mV = 0.0mV # reversal potential
-       NMDA_Vact mV = -58.0mV # inactive for V << Vact, inflection of sigmoid
-       NMDA_Sact mV = 2.5mV # scale of inactivation
-       GABA_A_g_peak nS = 0.33nS # peak conductance
-       GABA_A_Tau_1 ms = 1.0ms # rise time
-       GABA_A_Tau_2 ms = 7.0ms # decay time, Tau_1 < Tau_2
-       GABA_A_E_rev mV = -70.0mV # reversal potential
-       GABA_B_g_peak nS = 0.0132nS # peak conductance
-       GABA_B_Tau_1 ms = 60.0ms # rise time
-       GABA_B_Tau_2 ms = 200.0ms # decay time, Tau_1 < Tau_2
-       GABA_B_E_rev mV = -90.0mV # reversal potential for intrinsic current
+        # equation modified from y[](1-D_eq) to (y[]-D_eq), since we'd not
+        # be converging to equilibrium otherwise
+        IKNa_D' = ( D_influx_peak * D_influx * nS - ( IKNa_D  - KNa_D_EQ / mV ) / tau_D ) / ms
+        inline tau_m_T real = 0.22 / ( exp( -( V_m / mV + 132.0 ) / 16.7 ) + exp( ( V_m / mV + 16.8 ) / 18.2 ) ) + 0.13
+        inline tau_h_T real = 8.2 + ( 56.6 + 0.27 * exp( ( V_m / mV + 115.2 ) / 5.0 ) ) / ( 1.0 + exp( ( V_m / mV + 86.0 ) / 3.2 ) )
+        inline I_h_Vthreshold real = -75.0
+        inline m_inf_h real = 1.0 / ( 1.0 + exp( ( V_m / mV - I_h_Vthreshold ) / 5.5 ) )
+        IT_m' = ( m_inf_T * nS - IT_m ) / tau_m_T / ms
+        IT_h' = ( h_inf_T * nS - IT_h ) / tau_h_T / ms
+        Ih_m' = ( m_inf_h * nS - Ih_m ) / tau_m_h / ms
 
-       /* parameters for intrinsic currents*/
-       NaP_g_peak nS = 1.0nS # peak conductance for intrinsic current
-       NaP_E_rev mV = 30.0mV # reversal potential for intrinsic current
-       KNa_g_peak nS = 1.0nS # peak conductance for intrinsic current
-       KNa_E_rev mV = -90.0mV # reversal potential for intrinsic current
-       T_g_peak nS = 1.0nS # peak conductance for intrinsic current
-       T_E_rev mV = 0.0mV # reversal potential for intrinsic current
-       h_g_peak nS = 1.0nS # peak conductance for intrinsic current
-       h_E_rev mV = -40.0mV # reversal potential for intrinsic current
-       KNa_D_EQ pA = 0.001pA
+        #############
+        # Synapses
+        #############
+        kernel g_AMPA' = g_AMPA$ - g_AMPA  / AMPA_Tau_2,
+               g_AMPA$' = -g_AMPA$ / AMPA_Tau_1
 
-       /* constant external input current*/
-       I_e pA = 0pA
-     end
-     internals:
-       AMPAInitialValue real = compute_synapse_constant(AMPA_Tau_1,AMPA_Tau_2,AMPA_g_peak)
-       NMDAInitialValue real = compute_synapse_constant(NMDA_Tau_1,NMDA_Tau_2,NMDA_g_peak)
-       GABA_AInitialValue real = compute_synapse_constant(GABA_A_Tau_1,GABA_A_Tau_2,GABA_A_g_peak)
-       GABA_BInitialValue real = compute_synapse_constant(GABA_B_Tau_1,GABA_B_Tau_2,GABA_B_g_peak)
-       PotassiumRefractoryCounts integer = steps(t_spike)
-     end
-     input:
-       AMPA nS <-spike
-       NMDA nS <-spike
-       GABA_A nS <-spike
-       GABA_B nS <-spike
-       I_stim pA <-current
-     end
+        kernel g_NMDA' = g_NMDA$ - g_NMDA / NMDA_Tau_2,
+               g_NMDA$' = -g_NMDA$ / NMDA_Tau_1
 
-     output: spike
+        kernel g_GABAA' = g_GABAA$ - g_GABAA / GABA_A_Tau_2,
+               g_GABAA$' = -g_GABAA$ / GABA_A_Tau_1
 
-     update:
-       integrate_odes()
+        kernel g_GABAB' = g_GABAB$ - g_GABAB / GABA_B_Tau_2,
+               g_GABAB$' = -g_GABAB$ / GABA_B_Tau_1
+      end
 
-       /* Deactivate potassium current after spike time have expired*/
-       if (r_potassium > 0) and (r_potassium - 1 == 0):
-         g_spike = false # Deactivate potassium current.
-       end
-       r_potassium -= 1
-       g_AMPA__d += AMPAInitialValue * AMPA / ms
-       g_NMDA__d += NMDAInitialValue * NMDA / ms
-       g_GABAA__d += GABA_AInitialValue * GABA_A / ms
-       g_GABAB__d += GABA_BInitialValue * GABA_B / ms
-       if (not g_spike) and V_m >= Theta:
+      parameters:
+        E_Na mV = 30.0 mV
+        E_K mV = -90.0 mV
+        g_NaL nS =  0.2 nS
+        g_KL nS = 1.0 nS       # 1.0 - 1.85
+        Tau_m ms = 16.0 ms     # membrane time constant applying to all currents but repolarizing K-current (see [1, p 1677])
+        Theta_eq mV = -51.0 mV # equilibrium value
+        Tau_theta ms = 2.0 ms  # time constant
+        Tau_spike ms = 1.75 ms # membrane time constant applying to repolarizing K-current
+        t_spike ms = 2.0 ms    # duration of re-polarizing potassium current
 
-         /* Set V and Theta to the sodium reversal potential.*/
-         V_m = E_Na
-         Theta = E_Na
+        # Parameters for synapse of type AMPA, GABA_A, GABA_B and NMDA
+        AMPA_g_peak nS = 0.1 nS      # peak conductance
+        AMPA_E_rev mV = 0.0 mV       # reversal potential
+        AMPA_Tau_1 ms = 0.5 ms       # rise time
+        AMPA_Tau_2 ms = 2.4 ms       # decay time, Tau_1 < Tau_2
+        NMDA_g_peak nS = 0.075 nS    # peak conductance
+        NMDA_Tau_1 ms = 4.0 ms       # rise time
+        NMDA_Tau_2 ms = 40.0 ms      # decay time, Tau_1 < Tau_2
+        NMDA_E_rev mV = 0.0 mV       # reversal potential
+        NMDA_Vact mV = -58.0 mV      # inactive for V << Vact, inflection of sigmoid
+        NMDA_Sact mV = 2.5 mV        # scale of inactivation
+        GABA_A_g_peak nS = 0.33 nS   # peak conductance
+        GABA_A_Tau_1 ms = 1.0 ms     # rise time
+        GABA_A_Tau_2 ms = 7.0 ms     # decay time, Tau_1 < Tau_2
+        GABA_A_E_rev mV = -70.0 mV   # reversal potential
+        GABA_B_g_peak nS = 0.0132 nS # peak conductance
+        GABA_B_Tau_1 ms = 60.0 ms    # rise time
+        GABA_B_Tau_2 ms = 200.0 ms   # decay time, Tau_1 < Tau_2
+        GABA_B_E_rev mV = -90.0 mV   # reversal potential for intrinsic current
 
-         /* Activate fast potassium current. Drives the*/
-         /* membrane potential towards the potassium reversal*/
-         /* potential (activate only if duration is non-zero).*/
-         if PotassiumRefractoryCounts > 0:
-           g_spike = true
-         else:
-           g_spike = false
-         end
-         r_potassium = PotassiumRefractoryCounts
-         emit_spike()
-       end
-     end
+        # parameters for intrinsic currents
+        NaP_g_peak nS = 1.0 nS       # peak conductance for intrinsic current
+        NaP_E_rev mV = 30.0 mV       # reversal potential for intrinsic current
+        KNa_g_peak nS = 1.0 nS       # peak conductance for intrinsic current
+        KNa_E_rev mV = -90.0 mV      # reversal potential for intrinsic current
+        T_g_peak nS = 1.0 nS         # peak conductance for intrinsic current
+        T_E_rev mV = 0.0 mV          # reversal potential for intrinsic current
+        h_g_peak nS = 1.0 nS         # peak conductance for intrinsic current
+        h_E_rev mV = -40.0 mV        # reversal potential for intrinsic current
+        KNa_D_EQ pA = 0.001 pA
 
-   function compute_synapse_constant(Tau_1 msTau_2 msg_peak real) real:
+        # constant external input current
+        I_e pA = 0 pA
+      end
 
-       /* Factor used to account for the missing 1/((1/Tau_2)-(1/Tau_1)) term*/
-       /* in the ht_neuron_dynamics integration of the synapse terms.*/
-       /* See: Exact digital simulation of time-invariant linear systems*/
-       /* with applications to neuronal modeling, Rotter and Diesmann,*/
-       /* section 3.1.2.*/
-       exact_integration_adjustment real = ((1 / Tau_2) - (1 / Tau_1)) * ms
-       t_peak real = (Tau_2 * Tau_1) * ln(Tau_2 / Tau_1) / (Tau_2 - Tau_1) / ms
-       normalisation_factor real = 1 / (exp(-t_peak / Tau_1) - exp(-t_peak / Tau_2))
-       return g_peak * normalisation_factor * exact_integration_adjustment
-   end
+      internals:
+        AMPAInitialValue real = compute_synapse_constant( AMPA_Tau_1, AMPA_Tau_2, AMPA_g_peak )
+        NMDAInitialValue real = compute_synapse_constant( NMDA_Tau_1, NMDA_Tau_2, NMDA_g_peak )
 
-   end
+        GABA_AInitialValue real = compute_synapse_constant( GABA_A_Tau_1, GABA_A_Tau_2, GABA_A_g_peak )
+        GABA_BInitialValue real = compute_synapse_constant( GABA_B_Tau_1, GABA_B_Tau_2, GABA_B_g_peak )
+        PotassiumRefractoryCounts integer = steps(t_spike)
+      end
+
+      input:
+          AMPA nS  <- spike
+          NMDA nS  <- spike
+          GABA_A nS <- spike
+          GABA_B nS <- spike
+          I_stim pA <- current
+      end
+
+      output: spike
+
+      update:
+        integrate_odes()
+
+        # Deactivate potassium current after spike time have expired
+        if (r_potassium > 0) and (r_potassium-1 == 0):
+          g_spike = false # Deactivate potassium current.
+        end
+        r_potassium -= 1
+
+        if (not g_spike) and V_m >= Theta:
+          # Set V and Theta to the sodium reversal potential.
+          V_m = E_Na
+          Theta = E_Na
+
+          # Activate fast potassium current. Drives the
+          # membrane potential towards the potassium reversal
+          # potential (activate only if duration is non-zero).
+          if PotassiumRefractoryCounts > 0:
+            g_spike = true
+          else:
+            g_spike = false
+          end
+
+          r_potassium = PotassiumRefractoryCounts
+
+          emit_spike()
+        end
+      end
+
+      function compute_synapse_constant(Tau_1 ms, Tau_2 ms, g_peak real) real:
+        # Factor used to account for the missing 1/((1/Tau_2)-(1/Tau_1)) term
+        # in the ht_neuron_dynamics integration of the synapse terms.
+        # See: Exact digital simulation of time-invariant linear systems
+        # with applications to neuronal modeling, Rotter and Diesmann,
+        # section 3.1.2.
+        exact_integration_adjustment real = ( ( 1 / Tau_2 ) - ( 1 / Tau_1 ) ) * ms
+
+        t_peak real = ( Tau_2 * Tau_1 ) * ln( Tau_2 / Tau_1 ) / ( Tau_2 - Tau_1 ) / ms
+        normalisation_factor real = 1 / ( exp( -t_peak / Tau_1 ) - exp( -t_peak / Tau_2 ) )
+
+        return g_peak * normalisation_factor * exact_integration_adjustment
+      end
+    end
+
 
 
 

--- a/doc/models_library/iaf_chxk_2008.rst
+++ b/doc/models_library/iaf_chxk_2008.rst
@@ -105,57 +105,58 @@ Source code
 .. code:: nestml
 
    neuron iaf_chxk_2008:
-     initial_values:
-       V_m mV = E_L # membrane potential
-       G_ahp nS = 0nS # AHP conductance
-       G_ahp__d nS/ms = 0nS / ms # AHP conductance
-       /*G_ahp' nS/ms = e / tau_ahp * nS    AHP conductance*/
 
+     state:
+       V_m mV = E_L   # membrane potential
+       g_ahp nS = 0 nS      # AHP conductance
+       g_ahp' nS/ms = 0 nS/ms   # AHP conductance
      end
+
      equations:
-       kernel g_in = (e / tau_syn_in) * t * exp(-t / tau_syn_in)
-       kernel g_ex = (e / tau_syn_ex) * t * exp(-t / tau_syn_ex)
-       G_ahp__d'=(-2 / tau_ahp) * G_ahp__d - (1 / tau_ahp ** 2) * G_ahp
-       function I_syn_exc pA = convolve(g_ex,spikesExc) * (V_m - E_ex)
-       function I_syn_inh pA = convolve(g_in,spikesInh) * (V_m - E_in)
-       function I_ahp pA = G_ahp * (V_m - E_ahp)
-       function I_leak pA = g_L * (V_m - E_L)
-       V_m'=(-I_leak - I_syn_exc - I_syn_inh - I_ahp + I_e + I_stim) / C_m
-       G_ahp'=G_ahp__d
+       kernel g_in = (e/tau_syn_in) * t * exp(-t/tau_syn_in)
+       kernel g_ex = (e/tau_syn_ex) * t * exp(-t/tau_syn_ex)
+       g_ahp'' = -2 * g_ahp' / tau_ahp - g_ahp / tau_ahp**2
+
+       inline I_syn_exc pA = convolve(g_ex, spikesExc) * ( V_m - E_ex )
+       inline I_syn_inh pA = convolve(g_in, spikesInh) * ( V_m - E_in )
+       inline I_ahp pA = g_ahp * ( V_m - E_ahp )
+       inline I_leak pA = g_L * ( V_m - E_L )
+
+       V_m' = ( -I_leak - I_syn_exc - I_syn_inh - I_ahp + I_e + I_stim ) / C_m
      end
 
      parameters:
-       V_th mV = -45.0mV # Threshold Potential
-       E_ex mV = 20mV # Excitatory reversal potential
-       E_in mV = -90mV # Inhibitory reversal potential
-       g_L nS = 100nS # Leak Conductance
-       C_m pF = 1000.0pF # Membrane Capacitance
-       E_L mV = -60.0mV # Leak reversal Potential (aka resting potential)
-       tau_syn_ex ms = 1ms # Synaptic Time Constant Excitatory Synapse
-       tau_syn_in ms = 1ms # Synaptic Time Constant for Inhibitory Synapse
-       tau_ahp ms = 0.5ms # Afterhyperpolarization (AHP) time constant
-       g_ahp nS = 443.8nS # AHP conductance
-       E_ahp mV = -95mV # AHP potential
-       ahp_bug boolean = false # If true, discard AHP conductance value from previous spikes
+       V_th mV = -45.0 mV        # Threshold Potential
+       E_ex mV = 20 mV           # Excitatory reversal potential
+       E_in mV = -90 mV          # Inhibitory reversal potential
+       g_L nS = 100 nS           # Leak Conductance
+       C_m pF = 1000.0 pF        # Membrane Capacitance
+       E_L mV = -60.0 mV         # Leak reversal Potential (aka resting potential)
+       tau_syn_ex ms = 1 ms      # Synaptic Time Constant Excitatory Synapse
+       tau_syn_in ms = 1 ms      # Synaptic Time Constant for Inhibitory Synapse
+       tau_ahp ms = 0.5 ms       # Afterhyperpolarization (AHP) time constant
+       G_ahp nS = 443.8 nS       # AHP conductance
+       E_ahp mV = -95 mV         # AHP potential
+       ahp_bug boolean = false   # If true, discard AHP conductance value from previous spikes
 
-       /* constant external input current*/
-       I_e pA = 0pA
+       # constant external input current
+       I_e pA = 0 pA
      end
-     internals:
 
-       /* Impulse to add to DG_EXC on spike arrival to evoke unit-amplitude*/
-       /* conductance excursion.*/
+     internals:
+       # Impulse to add to DG_EXC on spike arrival to evoke unit-amplitude conductance excursion.
        PSConInit_E nS/ms = nS * e / tau_syn_ex
 
-       /* Impulse to add to DG_INH on spike arrival to evoke unit-amplitude*/
-       /* conductance excursion.*/
+       # Impulse to add to DG_INH on spike arrival to evoke unit-amplitude conductance excursion.
        PSConInit_I nS/ms = nS * e / tau_syn_in
-       PSConInit_AHP real = g_ahp * e / tau_ahp * (ms / nS)
+
+       PSConInit_AHP real = G_ahp * e / tau_ahp * (ms/nS)
      end
+
      input:
-       spikesInh nS <-inhibitory spike
-       spikesExc nS <-excitatory spike
-       I_stim pA <-current
+         spikesInh nS <- inhibitory spike
+         spikesExc nS <- excitatory spike
+         I_stim pA <- current
      end
 
      output: spike
@@ -164,28 +165,32 @@ Source code
        vm_prev mV = V_m
        integrate_odes()
        if vm_prev < V_th and V_m >= V_th:
+         # Neuron is not absolute refractory
 
-         /* Find precise spike time using linear interpolation*/
-         sigma real = (V_m - V_th) * resolution() / (V_m - vm_prev) / ms
-         alpha real = exp(-sigma / tau_ahp)
+         # Find precise spike time using linear interpolation
+         sigma real = ( V_m - V_th ) * resolution() / ( V_m - vm_prev ) / ms
+
+         alpha real = exp( -sigma / tau_ahp )
+
          delta_g_ahp real = PSConInit_AHP * sigma * alpha
          delta_dg_ahp real = PSConInit_AHP * alpha
-         if ahp_bug == true:
 
-           /* Bug in original code ignores AHP conductance from previous spikes*/
-           G_ahp = delta_g_ahp * nS
-           G_ahp__d = delta_dg_ahp * nS / ms
+         if ahp_bug == true:
+           # Bug in original code ignores AHP conductance from previous spikes
+           g_ahp  = delta_g_ahp * nS
+           g_ahp' = delta_dg_ahp * nS/ms
          else:
-           G_ahp += delta_g_ahp * nS
-           G_ahp__d += delta_dg_ahp * nS / ms
+           # Correct implementation adds initial values for new AHP to AHP history
+           g_ahp  += delta_g_ahp * nS
+           g_ahp' += delta_dg_ahp * nS/ms
          end
+
          emit_spike()
        end
+
      end
 
    end
-
-
 
 Characterisation
 ++++++++++++++++

--- a/doc/models_library/iaf_cond_alpha.rst
+++ b/doc/models_library/iaf_cond_alpha.rst
@@ -101,60 +101,62 @@ Source code
 .. code:: nestml
 
    neuron iaf_cond_alpha:
-     state:
-       r integer  # counts number of tick during the refractory period
-     end
-     initial_values:
-       V_m mV = E_L # membrane potential
-     end
-     equations:
-       kernel g_in = (e / tau_syn_in) * t * exp(-t / tau_syn_in)
-       kernel g_ex = (e / tau_syn_ex) * t * exp(-t / tau_syn_ex)
-       function I_syn_exc pA = convolve(g_ex,spikeExc) * (V_m - E_ex)
-       function I_syn_inh pA = convolve(g_in,spikeInh) * (V_m - E_in)
-       function I_leak pA = g_L * (V_m - E_L)
-       V_m'=(-I_leak - I_syn_exc - I_syn_inh + I_e + I_stim) / C_m
-     end
+      state:
+        r integer = 0      # counts number of tick during the refractory period
+        V_m mV = E_L   # membrane potential
+      end
 
-     parameters:
-       V_th mV = -55.0mV # Threshold Potential
-       V_reset mV = -60.0mV # Reset Potential
-       t_ref ms = 2.0ms # Refractory period
-       g_L nS = 16.6667nS # Leak Conductance
-       C_m pF = 250.0pF # Membrane Capacitance
-       E_ex mV = 0mV # Excitatory reversal Potential
-       E_in mV = -85.0mV # Inhibitory reversal Potential
-       E_L mV = -70.0mV # Leak reversal Potential (aka resting potential)
-       tau_syn_ex ms = 0.2ms # Synaptic Time Constant Excitatory Synapse
-       tau_syn_in ms = 2.0ms # Synaptic Time Constant for Inhibitory Synapse
+      equations:
+        kernel g_in = (e/tau_syn_in) * t * exp(-t/tau_syn_in)
+        kernel g_ex = (e/tau_syn_ex) * t * exp(-t/tau_syn_ex)
 
-       /* constant external input current*/
-       I_e pA = 0pA
-     end
-     internals:
-       RefractoryCounts integer = steps(t_ref) # refractory time in steps
-     end
-     input:
-       spikeInh nS <-inhibitory spike
-       spikeExc nS <-excitatory spike
-       I_stim pA <-current
-     end
+        inline I_syn_exc pA = convolve(g_ex, spikeExc)  * ( V_m - E_ex )
+        inline I_syn_inh pA = convolve(g_in, spikeInh)  * ( V_m - E_in )
+        inline I_leak pA = g_L * ( V_m - E_L )
 
-     output: spike
+        V_m' = ( -I_leak - I_syn_exc - I_syn_inh + I_e + I_stim ) / C_m
+      end
 
-     update:
-       integrate_odes()
-       if r != 0: # neuron is absolute refractory
-         r = r - 1
-         V_m = V_reset # clamp potential
-       elif V_m >= V_th:
-         r = RefractoryCounts
-         V_m = V_reset # clamp potential
-         emit_spike()
-       end
-     end
+      parameters:
+        V_th mV = -55.0 mV    # Threshold Potential
+        V_reset mV = -60.0 mV # Reset Potential
+        t_ref ms = 2. ms      # Refractory period
+        g_L nS = 16.6667 nS   # Leak Conductance
+        C_m pF = 250.0 pF    # Membrane Capacitance
+        E_ex mV = 0 mV        # Excitatory reversal Potential
+        E_in mV = -85.0 mV    # Inhibitory reversal Potential
+        E_L mV = -70.0 mV     # Leak reversal Potential (aka resting potential)
+        tau_syn_ex ms = 0.2 ms  # Synaptic Time Constant Excitatory Synapse
+        tau_syn_in ms = 2.0 ms  # Synaptic Time Constant for Inhibitory Synapse
 
-   end
+        # constant external input current
+        I_e pA = 0 pA
+      end
+
+      internals:
+        RefractoryCounts integer = steps(t_ref) # refractory time in steps
+      end
+
+      input:
+        spikeInh nS <- inhibitory spike
+        spikeExc nS <- excitatory spike
+        I_stim pA <- current
+      end
+
+      output: spike
+
+      update:
+        integrate_odes()
+        if r != 0: # neuron is absolute refractory
+          r =  r - 1
+          V_m = V_reset # clamp potential
+        elif V_m >= V_th:  # neuron is not absolute refractory
+          r = RefractoryCounts
+          V_m = V_reset # clamp potential
+          emit_spike()
+        end
+      end
+    end
 
 
 

--- a/doc/models_library/iaf_cond_exp.rst
+++ b/doc/models_library/iaf_cond_exp.rst
@@ -90,60 +90,63 @@ Source code
 .. code:: nestml
 
    neuron iaf_cond_exp:
-     state:
-       r integer  # counts number of tick during the refractory period
-     end
-     initial_values:
-       V_m mV = E_L # membrane potential
-     end
-     equations:
-       kernel g_in = exp(-t / tau_syn_in) # inputs from the inh conductance
-       kernel g_ex = exp(-t / tau_syn_ex) # inputs from the exc conductance
-       function I_syn_exc pA = convolve(g_ex,spikeExc) * (V_m - E_ex)
-       function I_syn_inh pA = convolve(g_in,spikeInh) * (V_m - E_in)
-       function I_leak pA = g_L * (V_m - E_L)
-       V_m'=(-I_leak - I_syn_exc - I_syn_inh + I_e + I_stim) / C_m
-     end
+      state:
+        r integer = 0     # counts number of tick during the refractory period
+        V_m mV = E_L     # membrane potential
+      end
 
-     parameters:
-       V_th mV = -55.0mV # Threshold Potential
-       V_reset mV = -60.0mV # Reset Potential
-       t_ref ms = 2.0ms # Refractory period
-       g_L nS = 16.6667nS # Leak Conductance
-       C_m pF = 250.0pF # Membrane Capacitance
-       E_ex mV = 0mV # Excitatory reversal Potential
-       E_in mV = -85.0mV # Inhibitory reversal Potential
-       E_L mV = -70.0mV # Leak reversal Potential (aka resting potential)
-       tau_syn_ex ms = 0.2ms # Synaptic Time Constant Excitatory Synapse
-       tau_syn_in ms = 2.0ms # Synaptic Time Constant for Inhibitory Synapse
+      equations:
+        kernel g_in = exp(-t/tau_syn_in) # inputs from the inh conductance
+        kernel g_ex = exp(-t/tau_syn_ex) # inputs from the exc conductance
 
-       /* constant external input current*/
-       I_e pA = 0pA
-     end
-     internals:
-       RefractoryCounts integer = steps(t_ref) # refractory time in steps
-     end
-     input:
-       spikeInh nS <-inhibitory spike
-       spikeExc nS <-excitatory spike
-       I_stim pA <-current
-     end
+        inline I_syn_exc pA = convolve(g_ex, spikeExc) * ( V_m - E_ex )
+        inline I_syn_inh pA = convolve(g_in, spikeInh) * ( V_m - E_in )
+        inline I_leak pA = g_L * ( V_m - E_L )
+        V_m' = ( -I_leak - I_syn_exc - I_syn_inh + I_e + I_stim ) / C_m
+      end
 
-     output: spike
+      parameters:
+        V_th mV = -55.0 mV     # Threshold Potential
+        V_reset mV = -60.0 mV  # Reset Potential
+        t_ref ms = 2.0 ms      # Refractory period
+        g_L nS = 16.6667 nS    # Leak Conductance
+        C_m pF = 250.0 pF      # Membrane Capacitance
+        E_ex mV = 0 mV         # Excitatory reversal Potential
+        E_in mV = -85.0 mV     # Inhibitory reversal Potential
+        E_L mV = -70.0 mV      # Leak reversal Potential (aka resting potential)
+        tau_syn_ex ms = 0.2 ms # Synaptic Time Constant Excitatory Synapse
+        tau_syn_in ms = 2.0 ms # Synaptic Time Constant for Inhibitory Synapse
 
-     update:
-       integrate_odes()
-       if r != 0: # neuron is absolute refractory
-         r = r - 1
-         V_m = V_reset # clamp potential
-       elif V_m >= V_th:
-         r = RefractoryCounts
-         V_m = V_reset # clamp potential
-         emit_spike()
-       end
-     end
+        # constant external input current
+        I_e pA = 0 pA
+      end
 
-   end
+      internals:
+        RefractoryCounts integer = steps(t_ref) # refractory time in steps
+      end
+
+      input:
+        spikeInh nS <- inhibitory spike
+        spikeExc nS <- excitatory spike
+        I_stim pA <- current
+      end
+
+      output: spike
+
+      update:
+        integrate_odes()
+        if r != 0: # neuron is absolute refractory
+          r =  r - 1
+          V_m = V_reset # clamp potential
+        elif V_m >= V_th:  # neuron is not absolute refractory
+          r = RefractoryCounts
+          V_m = V_reset # clamp potential
+          emit_spike()
+        end
+
+      end
+
+    end
 
 
 

--- a/doc/models_library/iaf_cond_exp_sfa_rr.rst
+++ b/doc/models_library/iaf_cond_exp_sfa_rr.rst
@@ -109,74 +109,79 @@ Source code
 .. code:: nestml
 
    neuron iaf_cond_exp_sfa_rr:
-     state:
-       r integer  # counts number of tick during the refractory period
-     end
-     initial_values:
-       V_m mV = E_L # membrane potential
-       g_sfa nS = 0nS # inputs from the sfa conductance
-       g_rr nS = 0nS # inputs from the rr conductance
-     end
-     equations:
-       kernel g_in = exp(-t / tau_syn_in) # inputs from the inh conductance
-       kernel g_ex = exp(-t / tau_syn_ex) # inputs from the exc conductance
-       g_sfa'=-g_sfa / tau_sfa
-       g_rr'=-g_rr / tau_rr
-       function I_syn_exc pA = convolve(g_ex,spikesExc) * (V_m - E_ex)
-       function I_syn_inh pA = convolve(g_in,spikesInh) * (V_m - E_in)
-       function I_L pA = g_L * (V_m - E_L)
-       function I_sfa pA = g_sfa * (V_m - E_sfa)
-       function I_rr pA = g_rr * (V_m - E_rr)
-       V_m'=(-I_L + I_e + I_stim - I_syn_exc - I_syn_inh - I_sfa - I_rr) / C_m
-     end
+      state:
+        r integer = 0   # counts number of tick during the refractory period
 
-     parameters:
-       V_th mV = -57.0mV # Threshold Potential
-       V_reset mV = -70.0mV # Reset Potential
-       t_ref ms = 0.5ms # Refractory period
-       g_L nS = 28.95nS # Leak Conductance
-       C_m pF = 289.5pF # Membrane Capacitance
-       E_ex mV = 0mV # Excitatory reversal Potential
-       E_in mV = -75.0mV # Inhibitory reversal Potential
-       E_L mV = -70.0mV # Leak reversal Potential (aka resting potential)
-       tau_syn_ex ms = 1.5ms # Synaptic Time Constant Excitatory Synapse
-       tau_syn_in ms = 10.0ms # Synaptic Time Constant for Inhibitory Synapse
-       q_sfa nS = 14.48nS # Outgoing spike activated quantal spike-frequency adaptation conductance increase
-       q_rr nS = 3214.0nS # Outgoing spike activated quantal relative refractory conductance increase.
-       tau_sfa ms = 110.0ms # Time constant of spike-frequency adaptation.
-       tau_rr ms = 1.97ms # Time constant of the relative refractory mechanism.
-       E_sfa mV = -70.0mV # spike-frequency adaptation conductance reversal potential
-       E_rr mV = -70.0mV # relative refractory mechanism conductance reversal potential
+        V_m mV = E_L # membrane potential
+        g_sfa nS = 0 nS     # inputs from the sfa conductance
+        g_rr nS = 0 nS      # inputs from the rr conductance
+      end
 
-       /* constant external input current*/
-       I_e pA = 0pA
-     end
-     internals:
-       RefractoryCounts integer = steps(t_ref) # refractory time in steps
-     end
-     input:
-       spikesInh nS <-inhibitory spike
-       spikesExc nS <-excitatory spike
-       I_stim pA <-current
-     end
+      equations:
+        kernel g_in = exp(-t/tau_syn_in) # inputs from the inh conductance
+        kernel g_ex = exp(-t/tau_syn_ex) # inputs from the exc conductance
 
-     output: spike
+        g_sfa' = -g_sfa / tau_sfa
+        g_rr' = -g_rr / tau_rr
 
-     update:
-       integrate_odes()
-       if r != 0: # neuron is absolute refractory
-         r = r - 1
-         V_m = V_reset # clamp potential
-       elif V_m >= V_th:
-         r = RefractoryCounts
-         V_m = V_reset # clamp potential
-         g_sfa += q_sfa
-         g_rr += q_rr
-         emit_spike()
-       end
-     end
+        inline I_syn_exc pA = convolve(g_ex, spikesExc) * ( V_m - E_ex )
+        inline I_syn_inh pA = convolve(g_in, spikesInh) * ( V_m - E_in )
+        inline I_L pA = g_L * ( V_m - E_L )
+        inline I_sfa pA = g_sfa * ( V_m - E_sfa )
+        inline I_rr pA = g_rr * ( V_m - E_rr )
 
-   end
+        V_m' = ( -I_L + I_e + I_stim - I_syn_exc - I_syn_inh - I_sfa - I_rr ) / C_m
+      end
+
+      parameters:
+        V_th mV = -57.0 mV      # Threshold Potential
+        V_reset mV = -70.0 mV   # Reset Potential
+        t_ref ms = 0.5 ms       # Refractory period
+        g_L nS = 28.95 nS       # Leak Conductance
+        C_m pF = 289.5 pF       # Membrane Capacitance
+        E_ex mV = 0 mV          # Excitatory reversal Potential
+        E_in mV = -75.0 mV      # Inhibitory reversal Potential
+        E_L mV = -70.0 mV       # Leak reversal Potential (aka resting potential)
+        tau_syn_ex ms = 1.5 ms  # Synaptic Time Constant Excitatory Synapse
+        tau_syn_in ms = 10.0 ms # Synaptic Time Constant for Inhibitory Synapse
+        q_sfa nS = 14.48 nS     # Outgoing spike activated quantal spike-frequency adaptation conductance increase
+        q_rr nS = 3214.0 nS     # Outgoing spike activated quantal relative refractory conductance increase.
+        tau_sfa ms = 110.0 ms   # Time constant of spike-frequency adaptation.
+        tau_rr ms = 1.97 ms     # Time constant of the relative refractory mechanism.
+        E_sfa mV = -70.0 mV     # spike-frequency adaptation conductance reversal potential
+        E_rr mV = -70.0 mV      # relative refractory mechanism conductance reversal potential
+
+        # constant external input current
+        I_e pA = 0 pA
+      end
+
+      internals:
+        RefractoryCounts integer = steps(t_ref) # refractory time in steps
+      end
+
+      input:
+        spikesInh nS <- inhibitory spike
+        spikesExc nS <- excitatory spike
+        I_stim pA <- current
+      end
+
+      output: spike
+
+      update:
+        integrate_odes()
+        if r != 0:  # neuron is absolute refractory
+          r =  r - 1
+          V_m = V_reset # clamp potential
+        elif V_m >= V_th: # neuron is not absolute refractory
+          r = RefractoryCounts
+          V_m = V_reset # clamp potential
+          g_sfa += q_sfa
+          g_rr += q_rr
+          emit_spike()
+        end
+      end
+    end
+
 
 
 

--- a/doc/models_library/iaf_psc_delta.rst
+++ b/doc/models_library/iaf_psc_delta.rst
@@ -114,76 +114,80 @@ Source code
 
 .. code:: nestml
 
-   neuron iaf_psc_delta:
-     state:
-       refr_spikes_buffer mV = 0mV
-       r integer  # counts number of tick during the refractory period
-     end
-     initial_values:
-       V_abs mV = 0mV
-       function V_m mV = V_abs + E_L # Membrane potential.
-     end
-     equations:
-       kernel G = delta(t,tau_m)
-       V_abs'=-1 / tau_m * V_abs + 1 / C_m * (convolve(G,spikes) + I_e + I_stim)
-     end
+    neuron iaf_psc_delta:
 
-     parameters:
-       tau_m ms = 10ms # Membrane time constant.
-       C_m pF = 250pF # Capacity of the membrane
-       t_ref ms = 2ms # Duration of refractory period.
-       tau_syn ms = 2ms # Time constant of synaptic current.
-       E_L mV = -70mV # Resting membrane potential.
-       function V_reset mV = -70mV - E_L # Reset potential of the membrane.
-       function Theta mV = -55mV - E_L # Spike threshold.
-       V_min mV = -inf * 1mV # Absolute lower value for the membrane potential
-       with_refr_input boolean = false # If true, do not discard input during  refractory period. Default: false.
+      state:
+        refr_spikes_buffer mV = 0 mV
+        r integer  = 0 # counts number of tick during the refractory period
+        V_abs mV = 0 mV
+      end
 
-       /* constant external input current*/
-       I_e pA = 0pA
-     end
-     internals:
-       h ms = resolution()
-       RefractoryCounts integer = steps(t_ref) # refractory time in steps
-     end
-     input:
-       spikes pA <-spike
-       I_stim pA <-current
-     end
+      equations:
+        kernel G = delta(t)
+        recordable inline V_m mV = V_abs + E_L # Membrane potential.
+        V_abs' = -V_abs / tau_m + (mV / pA / ms) * convolve(G, spikes) + (I_e + I_stim) / C_m
+      end
 
-     output: spike
+      parameters:
+        tau_m   ms = 10 ms      # Membrane time constant.
+        C_m     pF = 250 pF     # Capacity of the membrane
+        t_ref   ms = 2 ms       # Duration of refractory period.
+        tau_syn ms = 2 ms       # Time constant of synaptic current.
+        E_L     mV = -70 mV     # Resting membrane potential.
+        V_reset mV = -70 mV - E_L # Reset potential of the membrane.
+        Theta   mV = -55 mV - E_L # Spike threshold.
+        V_min mV = -inf * 1 mV           # Absolute lower value for the membrane potential
+        with_refr_input boolean = false # If true, do not discard input during  refractory period. Default: false.
 
-     update:
-       if r == 0: # neuron not refractory
-         integrate_odes()
+        # constant external input current
+        I_e pA = 0 pA
+      end
 
-         /* if we have accumulated spikes from refractory period,*/
-         /* add and reset accumulator*/
-         if with_refr_input and refr_spikes_buffer != 0.0mV:
-           V_abs += refr_spikes_buffer
-           refr_spikes_buffer = 0.0mV
-         end
+      internals:
+        h ms = resolution()
+        RefractoryCounts integer = steps(t_ref) # refractory time in steps
+      end
 
-         /* lower bound of membrane potential*/
-         V_abs = V_abs < V_min?V_min:V_abs
-       else:
+      input:
+        spikes pA <- spike
+        I_stim pA <- current
+      end
 
-         /* read spikes from buffer and accumulate them, discounting*/
-         /* for decay until end of refractory period*/
-         /* the buffer is clear automatically*/
-         if with_refr_input:
-           refr_spikes_buffer += spikes * exp(-r * h / tau_m) * mV / pA
-         end
-         r -= 1
-       end
-       if V_abs >= Theta: # threshold crossing
-         r = RefractoryCounts
-         V_abs = V_reset
-         emit_spike()
-       end
-     end
+      output: spike
 
-   end
+      update:
+        if r == 0: # neuron not refractory
+          integrate_odes()
+
+          # if we have accumulated spikes from refractory period,
+          # add and reset accumulator
+          if with_refr_input and refr_spikes_buffer != 0.0 mV:
+            V_abs += refr_spikes_buffer
+            refr_spikes_buffer = 0.0 mV
+          end
+
+          # lower bound of membrane potential
+          V_abs = V_abs < V_min?V_min:V_abs
+
+        else: # neuron is absolute refractory
+          # read spikes from buffer and accumulate them, discounting
+          # for decay until end of refractory period
+          # the buffer is clear automatically
+          if with_refr_input:
+            refr_spikes_buffer += spikes * exp(-r * h / tau_m) * mV/pA
+          end
+          r -= 1
+        end
+
+        if V_abs >= Theta: # threshold crossing
+            r = RefractoryCounts
+            V_abs = V_reset
+            emit_spike()
+        end
+
+      end
+
+    end
 
 
 

--- a/doc/models_library/iaf_psc_exp.rst
+++ b/doc/models_library/iaf_psc_exp.rst
@@ -100,59 +100,62 @@ Source code
 .. code:: nestml
 
    neuron iaf_psc_exp:
-     state:
-       r integer  # counts number of tick during the refractory period
-     end
-     initial_values:
-       V_abs mV = 0mV
-       function V_m mV = V_abs + E_L # Membrane potential.
-     end
-     equations:
-       kernel I_kernel_in = exp(-t / tau_syn_in)
-       kernel I_kernel_ex = exp(-t / tau_syn_ex)
-       function I_syn pA = convolve(I_kernel_in,in_spikes) + convolve(I_kernel_ex,ex_spikes)
-       V_abs'=-V_abs / tau_m + (I_syn + I_e + I_stim) / C_m
-     end
+      state:
+        r integer = 0  # counts number of tick during the refractory period
+        V_abs mV = 0 mV
+      end
 
-     parameters:
-       C_m pF = 250pF # Capacity of the membrane
-       tau_m ms = 10ms # Membrane time constant.
-       tau_syn_in ms = 2ms # Time constant of synaptic current.
-       tau_syn_ex ms = 2ms # Time constant of synaptic current.
-       t_ref ms = 2ms # Duration of refractory period
-       E_L mV = -70mV # Resting potential.
-       function V_reset mV = -70mV - E_L # reset value of the membrane potential
-       function Theta mV = -55mV - E_L # Threshold, RELATIVE TO RESTING POTENTIAL(!).
-       /* I.e. the real threshold is (E_L_+V_th_)*/
+      equations:
+        kernel I_kernel_in = exp(-1/tau_syn_in*t)
+        kernel I_kernel_ex = exp(-1/tau_syn_ex*t)
+        recordable inline V_m mV = V_abs + E_L # Membrane potential.
+        inline I_syn pA = convolve(I_kernel_in, in_spikes) + convolve(I_kernel_ex, ex_spikes) + I_e + I_stim
+        V_abs' = -V_abs / tau_m + I_syn / C_m
+      end
 
-       /* constant external input current*/
-       I_e pA = 0pA
-     end
-     internals:
-       RefractoryCounts integer = steps(t_ref) # refractory time in steps
-     end
-     input:
-       ex_spikes pA <-excitatory spike
-       in_spikes pA <-inhibitory spike
-       I_stim pA <-current
-     end
+      parameters:
+        C_m pF = 250 pF       # Capacity of the membrane
+        tau_m ms = 10 ms      # Membrane time constant
+        tau_syn_in ms = 2 ms  # Time constant of synaptic current
+        tau_syn_ex ms = 2 ms  # Time constant of synaptic current
+        t_ref ms = 2 ms       # Duration of refractory period
+        E_L  mV = -70 mV      # Resting potential
+        V_reset mV = -70 mV - E_L # reset value of the membrane potential
+        Theta   mV = -55 mV - E_L # Threshold, RELATIVE TO RESTING POTENTIAL (!).
+                                       # I.e. the real threshold is (E_L_+V_th_)
 
-     output: spike
+        # constant external input current
+        I_e pA = 0 pA
+      end
 
-     update:
-       if r == 0: # neuron not refractory, so evolve V
-         integrate_odes()
-       else:
-         r = r - 1 # neuron is absolute refractory
-       end
-       if V_abs >= Theta: # threshold crossing
-         r = RefractoryCounts
-         V_abs = V_reset
-         emit_spike()
-       end
-     end
+      internals:
+        RefractoryCounts integer = steps(t_ref) # refractory time in steps
+      end
 
-   end
+      input:
+        ex_spikes pA <- excitatory spike
+        in_spikes pA <- inhibitory spike
+        I_stim pA <- current
+      end
+
+      output: spike
+
+      update:
+        if r == 0: # neuron not refractory, so evolve V
+          integrate_odes()
+        else:
+          r = r - 1 # neuron is absolute refractory
+        end
+
+        if V_abs >= Theta: # threshold crossing
+          r = RefractoryCounts
+          V_abs = V_reset
+          emit_spike()
+        end
+
+      end
+
+    end
 
 
 

--- a/doc/models_library/izhikevich.rst
+++ b/doc/models_library/izhikevich.rst
@@ -100,53 +100,55 @@ Source code
 
 .. code:: nestml
 
-   neuron izhikevich:
-     initial_values:
-       V_m mV = V_m_init # Membrane potential
-       U_m real = b * V_m_init # Membrane potential recovery variable
-     end
-     equations:
-       V_m'=(0.04 * V_m * V_m / mV + 5.0 * V_m + (140 - U_m) * mV + ((I_e + I_stim) * GOhm)) / ms
-       U_m'=a * (b * V_m - U_m * mV) / (mV * ms)
-     end
+    neuron izhikevich:
 
-     parameters:
-       a real = 0.02 # describes time scale of recovery variable
-       b real = 0.2 # sensitivity of recovery variable
-       c mV = -65mV # after-spike reset value of V_m
-       d real = 8.0 # after-spike reset value of U_m
-       V_m_init mV = -70mV # initial membrane potential
-       V_min mV = -inf * mV # Absolute lower value for the membrane potential.
+      state:
+        V_m mV = V_m_init         # Membrane potential
+        U_m real = b * V_m_init   # Membrane potential recovery variable
+      end
 
-       /* constant external input current*/
-       I_e pA = 0pA
-     end
-     input:
-       spikes mV <-spike
-       I_stim pA <-current
-     end
+      equations:
+        V_m' = ( 0.04 * V_m * V_m / mV + 5.0 * V_m + ( 140 - U_m ) * mV + ( (I_e + I_stim) * GOhm ) ) / ms
+        U_m' = a*(b*V_m-U_m * mV) / (mV*ms)
+      end
 
-     output: spike
+      parameters:
+        a real = 0.02        # describes time scale of recovery variable
+        b real = 0.2         # sensitivity of recovery variable
+        c mV = -65 mV        # after-spike reset value of V_m
+        d real = 8.0         # after-spike reset value of U_m
+        V_m_init mV = -65 mV # initial membrane potential
+        V_min mV = -inf * mV # Absolute lower value for the membrane potential.
 
-     update:
-       integrate_odes()
-       /* Add synaptic current*/
+        # constant external input current
+        I_e pA = 0 pA
+      end
 
-       /* Add synaptic current*/
-       V_m += spikes
+      input:
+        spikes mV <- spike
+        I_stim pA <- current
+      end
 
-       /* lower bound of membrane potential*/
-       V_m = (V_m < V_min)?V_min:V_m
+      output: spike
 
-       /* threshold crossing*/
-       if V_m >= 30mV:
-         V_m = c
-         U_m += d
-         emit_spike()
-       end
-     end
+      update:
+        integrate_odes()
+        # Add synaptic current
+        V_m += spikes
 
-   end
+        # lower bound of membrane potential
+        V_m = (V_m < V_min)? V_min : V_m
+
+        # threshold crossing
+        if V_m >= 30 mV:
+          V_m = c
+          U_m += d
+          emit_spike()
+        end
+
+      end
+
+    end
 
 
 

--- a/doc/models_library/izhikevich_psc_alpha.rst
+++ b/doc/models_library/izhikevich_psc_alpha.rst
@@ -108,68 +108,72 @@ Source code
 
 .. code:: nestml
 
-   neuron izhikevich_psc_alpha:
-     state:
-       r integer  # number of steps in the current refractory phase
-     end
-     initial_values:
-       V_m mV = -65mV # Membrane potential
-       U_m pA = 0pA # Membrane potential recovery variable
-     end
-     equations:
+    neuron izhikevich_psc_alpha:
 
-       /* synapses: alpha functions*/
-       kernel I_syn_in = (e / tau_syn_in) * t * exp(-t / tau_syn_in)
-       kernel I_syn_ex = (e / tau_syn_ex) * t * exp(-t / tau_syn_ex)
-       function I_syn_exc pA = convolve(I_syn_ex,spikesExc)
-       function I_syn_inh pA = convolve(I_syn_in,spikesInh)
-       V_m'=(k * (V_m - V_r) * (V_m - V_t) - U_m + I_e + I_stim + I_syn_inh + I_syn_exc) / C_m
-       U_m'=a * (b * (V_m - V_r) - U_m)
-     end
+      state:
+        r integer = 0 # number of steps in the current refractory phase
+        V_m mV = -65 mV # Membrane potential
+        U_m pA = 0 pA   # Membrane potential recovery variable
+      end
 
-     parameters:
-       C_m pF = 200.0pF # Membrane capacitance
-       k pF/mV/ms = 8.0pF / mV / ms # Spiking slope
-       V_r mV = -65.0mV # resting potential
-       V_t mV = -45.0mV # threshold potential
-       a 1/ms = 0.01 / ms # describes time scale of recovery variable
-       b nS = 9.0nS # sensitivity of recovery variable
-       c mV = -65mV # after-spike reset value of V_m
-       d pA = 60.0pA # after-spike reset value of U_m
-       V_peak mV = 0.0mV # Spike detection threashold (reset condition)
-       tau_syn_ex ms = 0.2ms # Synaptic Time Constant Excitatory Synapse
-       tau_syn_in ms = 2.0ms # Synaptic Time Constant for Inhibitory Synapse
-       t_ref ms = 2.0ms # Refractory period
+      equations:
+        # synapses: alpha functions
+        kernel I_syn_in = (e/tau_syn_in) * t * exp(-t/tau_syn_in)
+        kernel I_syn_ex = (e/tau_syn_ex) * t * exp(-t/tau_syn_ex)
 
-       /* constant external input current*/
-       I_e pA = 0pA
-     end
-     internals:
-       RefractoryCounts integer = steps(t_ref) # refractory time in steps
-     end
-     input:
-       spikesInh pA <-inhibitory spike
-       spikesExc pA <-excitatory spike
-       I_stim pA <-current
-     end
+        inline I_syn_exc pA = convolve(I_syn_ex, spikesExc)
+        inline I_syn_inh pA = convolve(I_syn_in, spikesInh)
 
-     output: spike
+        V_m' = ( k * (V_m - V_r) * (V_m - V_t) - U_m + I_e + I_stim + I_syn_inh + I_syn_exc ) / C_m
+        U_m' = a * ( b*(V_m - V_r) - U_m )
+      end
 
-     update:
-       integrate_odes()
+      parameters:
+        C_m pF = 200. pF           # Membrane capacitance
+        k pF/mV/ms = 8. pF/mV/ms   # Spiking slope
+        V_r mV = -65. mV           # resting potential
+        V_t mV = -45. mV           # threshold potential
+        a 1/ms = 0.01 /ms          # describes time scale of recovery variable
+        b nS = 9. nS               # sensitivity of recovery variable
+        c mV = -65 mV              # after-spike reset value of V_m
+        d pA = 60. pA              # after-spike reset value of U_m
+        V_peak mV = 0. mV          # Spike detection threashold (reset condition)
+        tau_syn_ex ms = 0.2 ms     # Synaptic Time Constant Excitatory Synapse
+        tau_syn_in ms = 2.0 ms     # Synaptic Time Constant for Inhibitory Synapse
+        t_ref ms = 2.0 ms          # Refractory period
 
-       /* refractoriness and threshold crossing*/
-       if r > 0: # is refractory?
-         r -= 1
-       elif V_m >= V_peak:
-         V_m = c
-         U_m += d
-         emit_spike()
-         r = RefractoryCounts
-       end
-     end
+        # constant external input current
+        I_e pA = 0 pA
+      end
 
-   end
+      internals:
+        RefractoryCounts integer = steps(t_ref) # refractory time in steps
+      end
+
+      input:
+        spikesInh pA <- inhibitory spike
+        spikesExc pA <- excitatory spike
+        I_stim pA <- current
+      end
+
+      output: spike
+
+      update:
+        integrate_odes()
+
+        # refractoriness and threshold crossing
+        if r > 0: # is refractory?
+          r -= 1
+        elif V_m >= V_peak:
+          V_m = c
+          U_m += d
+          emit_spike()
+          r = RefractoryCounts
+        end
+
+      end
+
+    end
 
 
 

--- a/doc/models_library/terub_gpe.rst
+++ b/doc/models_library/terub_gpe.rst
@@ -117,136 +117,143 @@ Source code
 
 .. code:: nestml
 
-   neuron terub_gpe:
-     state:
-       r integer  # counts number of tick during the refractory period
-     end
-     initial_values:
-       V_m mV = E_L # Membrane potential
-       gate_h real = 0.0 # gating variable h
-       gate_n real = 0.0 # gating variable n
-       gate_r real = 0.0 # gating variable r
-       Ca_con real = 0.0 # gating variable r
-     end
-     equations:
+    neuron terub_gpe:
+      state:
+        r integer = 0 # counts number of tick during the refractory period
 
-       /* Parameters for Terman Rubin GPe Neuron*/
-       function g_tau_n_0 ms = 0.05ms
-       function g_tau_n_1 ms = 0.27ms
-       function g_theta_n_tau mV = -40.0mV
-       function g_sigma_n_tau mV = -12.0mV
-       function g_tau_h_0 ms = 0.05ms
-       function g_tau_h_1 ms = 0.27ms
-       function g_theta_h_tau mV = -40.0mV
-       function g_sigma_h_tau mV = -12.0mV
-       function g_tau_r ms = 30.0ms
+        V_m mV = E_L #  Membrane potential
 
-       /* steady state values for gating variables*/
-       function g_theta_a mV = -57.0mV
-       function g_sigma_a mV = 2.0mV
-       function g_theta_h mV = -58.0mV
-       function g_sigma_h mV = -12.0mV
-       function g_theta_m mV = -37.0mV
-       function g_sigma_m mV = 10.0mV
-       function g_theta_n mV = -50.0mV
-       function g_sigma_n mV = 14.0mV
-       function g_theta_r mV = -70.0mV
-       function g_sigma_r mV = -2.0mV
-       function g_theta_s mV = -35.0mV
-       function g_sigma_s mV = 2.0mV
+        gate_h     real = 0.0 # gating variable h
+        gate_n     real = 0.0 # gating variable n
+        gate_r     real = 0.0 # gating variable r
+        Ca_con     real = 0.0 # gating variable r
+      end
 
-       /* time evolvement of gating variables*/
-       function g_phi_h real = 0.05
-       function g_phi_n real = 0.1 # Report: 0.1, Terman Rubin 2002: 0.05
-       function g_phi_r real = 1.0
+      equations:
+        # Parameters for Terman Rubin GPe Neuron
+        inline g_tau_n_0 ms = 0.05 ms
+        inline g_tau_n_1 ms = 0.27 ms
+        inline g_theta_n_tau mV = -40.0 mV
+        inline g_sigma_n_tau mV = -12.0 mV
 
-       /* Calcium concentration and afterhyperpolarization current*/
-       function g_epsilon 1/ms = 0.0001 / ms
-       function g_k_Ca real = 15.0 # Report:15,  Terman Rubin 2002: 20.0
-       function g_k1 real = 30.0
-       function I_ex_mod real = -convolve(g_ex,spikeExc) * V_m
-       function I_in_mod real = convolve(g_in,spikeInh) * (V_m - E_gg)
-       function tau_n real = g_tau_n_0 + g_tau_n_1 / (1.0 + exp(-(V_m - g_theta_n_tau) / g_sigma_n_tau))
-       function tau_h real = g_tau_h_0 + g_tau_h_1 / (1.0 + exp(-(V_m - g_theta_h_tau) / g_sigma_h_tau))
-       function tau_r real = g_tau_r
-       function a_inf real = 1.0 / (1.0 + exp(-(V_m - g_theta_a) / g_sigma_a))
-       function h_inf real = 1.0 / (1.0 + exp(-(V_m - g_theta_h) / g_sigma_h))
-       function m_inf real = 1.0 / (1.0 + exp(-(V_m - g_theta_m) / g_sigma_m))
-       function n_inf real = 1.0 / (1.0 + exp(-(V_m - g_theta_n) / g_sigma_n))
-       function r_inf real = 1.0 / (1.0 + exp(-(V_m - g_theta_r) / g_sigma_r))
-       function s_inf real = 1.0 / (1.0 + exp(-(V_m - g_theta_s) / g_sigma_s))
-       function I_Na real = g_Na * m_inf * m_inf * m_inf * gate_h * (V_m - E_Na)
-       function I_K real = g_K * gate_n * gate_n * gate_n * gate_n * (V_m - E_K)
-       function I_L real = g_L * (V_m - E_L)
-       function I_T real = g_T * a_inf * a_inf * a_inf * gate_r * (V_m - E_Ca)
-       function I_Ca real = g_Ca * s_inf * s_inf * (V_m - E_Ca)
-       function I_ahp real = g_ahp * (Ca_con / (Ca_con + g_k1)) * (V_m - E_K)
+        inline g_tau_h_0 ms = 0.05 ms
+        inline g_tau_h_1 ms = 0.27 ms
+        inline g_theta_h_tau mV = -40.0 mV
+        inline g_sigma_h_tau mV = -12.0 mV
+        inline g_tau_r ms = 30.0 ms
 
-       /* synapses: alpha functions*/
-       /* alpha function for the g_in*/
-       kernel g_in = (e / tau_syn_in) * t * exp(-t / tau_syn_in)
-       /* alpha function for the g_ex*/
+        # steady state values for gating variables
+        inline g_theta_a mV = -57.0 mV
+        inline g_sigma_a mV =  2.0 mV
+        inline g_theta_h mV = -58.0 mV
+        inline g_sigma_h mV = -12.0 mV
+        inline g_theta_m mV = -37.0 mV
+        inline g_sigma_m mV = 10.0 mV
+        inline g_theta_n mV = -50.0 mV
+        inline g_sigma_n mV = 14.0 mV
+        inline g_theta_r mV = -70.0 mV
+        inline g_sigma_r mV = -2.0 mV
+        inline g_theta_s mV = -35.0 mV
+        inline g_sigma_s mV = 2.0 mV
 
-       /* alpha function for the g_ex*/
-       kernel g_ex = (e / tau_syn_ex) * t * exp(-t / tau_syn_ex)
+        # time evolvement of gating variables
+        inline g_phi_h real =  0.05
+        inline g_phi_n real =  0.1 #Report: 0.1, Terman Rubin 2002: 0.05
+        inline g_phi_r real = 1.0
 
-       /* V dot -- synaptic input are currents, inhib current is negative*/
-       V_m'=(-(I_Na + I_K + I_L + I_T + I_Ca + I_ahp) * pA + I_e + I_stim + I_ex_mod * pA + I_in_mod * pA) / C_m
+        # Calcium concentration and afterhyperpolarization current
+        inline g_epsilon 1/ms =  0.0001 /ms
+        inline g_k_Ca real = 15.0 #Report:15,  Terman Rubin 2002: 20.0
+        inline g_k1 real = 30.0
 
-       /* channel dynamics*/
-       gate_h'=g_phi_h * ((h_inf - gate_h) / tau_h) / ms # h-variable
-       gate_n'=g_phi_n * ((n_inf - gate_n) / tau_n) / ms # n-variable
-       gate_r'=g_phi_r * ((r_inf - gate_r) / tau_r) / ms # r-variable
+        inline I_ex_mod real = -convolve(g_ex, spikeExc) * V_m
+        inline I_in_mod real = convolve(g_in, spikeInh) * (V_m-E_gg)
 
-       /* Calcium concentration*/
-       Ca_con'=g_epsilon * (-I_Ca - I_T - g_k_Ca * Ca_con)
-     end
+        inline tau_n real = g_tau_n_0 + g_tau_n_1 / (1. + exp(-(V_m-g_theta_n_tau)/g_sigma_n_tau))
+        inline tau_h real = g_tau_h_0 + g_tau_h_1 / (1. + exp(-(V_m-g_theta_h_tau)/g_sigma_h_tau))
+        inline tau_r real = g_tau_r
 
-     parameters:
-       E_L mV = -55mV # Resting membrane potential.
-       g_L nS = 0.1nS # Leak conductance.
-       C_m pF = 1.0pF # Capacity of the membrane.
-       E_Na mV = 55mV # Sodium reversal potential.
-       g_Na nS = 120nS # Sodium peak conductance.
-       E_K mV = -80.0mV # Potassium reversal potential.
-       g_K nS = 30.0nS # Potassium peak conductance.
-       E_Ca mV = 120mV # Calcium reversal potential.
-       g_Ca nS = 0.15nS # Calcium peak conductance.
-       g_T nS = 0.5nS # T-type Calcium channel peak conductance.
-       g_ahp nS = 30nS # afterpolarization current peak conductance.
-       tau_syn_ex ms = 1.0ms # Rise time of the excitatory synaptic alpha function.
-       tau_syn_in ms = 12.5ms # Rise time of the inhibitory synaptic alpha function.
-       E_gg mV = -100mV # reversal potential for inhibitory input (from GPe)
-       t_ref ms = 2ms # refractory time
+        inline a_inf real = 1. / (1. + exp(-(V_m-g_theta_a)/g_sigma_a))
+        inline h_inf real = 1. / (1. + exp(-(V_m-g_theta_h)/g_sigma_h))
+        inline m_inf real = 1. / (1. + exp(-(V_m-g_theta_m)/g_sigma_m))
+        inline n_inf real = 1. / (1. + exp(-(V_m-g_theta_n)/g_sigma_n))
+        inline r_inf real = 1. / (1. + exp(-(V_m-g_theta_r)/g_sigma_r))
+        inline s_inf real = 1. / (1. + exp(-(V_m-g_theta_s)/g_sigma_s))
 
-       /* constant external input current*/
-       I_e pA = 0pA
-     end
-     internals:
-       refractory_counts integer = steps(t_ref)
-     end
-     input:
-       spikeInh nS <-inhibitory spike
-       spikeExc nS <-excitatory spike
-       I_stim pA <-current
-     end
+        inline I_Na  real =  g_Na  * m_inf * m_inf * m_inf * gate_h    * (V_m - E_Na)
+        inline I_K   real =  g_K   * gate_n * gate_n * gate_n * gate_n * (V_m - E_K )
+        inline I_L   real =  g_L                                       * (V_m - E_L )
+        inline I_T   real =  g_T   * a_inf* a_inf * a_inf * gate_r     * (V_m - E_Ca)
+        inline I_Ca  real =  g_Ca  * s_inf * s_inf                     * (V_m - E_Ca)
+        inline I_ahp real =  g_ahp * (Ca_con / (Ca_con + g_k1))        * (V_m - E_K )
 
-     output: spike
+        # synapses: alpha functions
+        ## alpha function for the g_in
+        kernel g_in = (e/tau_syn_in) * t * exp(-t/tau_syn_in)
+        ## alpha function for the g_ex
+        kernel g_ex = (e/tau_syn_ex) * t * exp(-t/tau_syn_ex)
 
-     update:
-       U_old mV = V_m
-       integrate_odes()
+        # V dot -- synaptic input are currents, inhib current is negative
+        V_m' = ( -(I_Na + I_K + I_L + I_T + I_Ca + I_ahp) * pA + I_e + I_stim + I_ex_mod * pA + I_in_mod * pA) / C_m
 
-       /* sending spikes: crossing 0 mV, pseudo-refractoriness and local maximum...*/
-       if r > 0:
-         r -= 1
-       elif V_m > 0mV and U_old > V_m:
-         r = refractory_counts
-         emit_spike()
-       end
-     end
+        # channel dynamics
+        gate_h' = g_phi_h *((h_inf-gate_h) / tau_h) / ms # h-variable
+        gate_n' = g_phi_n *((n_inf-gate_n) / tau_n) / ms # n-variable
+        gate_r' = g_phi_r *((r_inf-gate_r) / tau_r) / ms # r-variable
 
-   end
+        # Calcium concentration
+        Ca_con' = g_epsilon*(-I_Ca - I_T - g_k_Ca * Ca_con)
+      end
+
+      parameters:
+        E_L        mV = -55 mV  # Resting membrane potential.
+        g_L        nS = 0.1 nS  # Leak conductance.
+        C_m        pF = 1.0 pF # Capacity of the membrane.
+        E_Na       mV = 55 mV   # Sodium reversal potential.
+        g_Na       nS = 120 nS # Sodium peak conductance.
+        E_K        mV = -80.0 mV# Potassium reversal potential.
+        g_K        nS = 30.0 nS # Potassium peak conductance.
+        E_Ca       mV = 120 mV  # Calcium reversal potential.
+        g_Ca       nS = 0.15 nS # Calcium peak conductance.
+        g_T        nS = 0.5 nS  # T-type Calcium channel peak conductance.
+        g_ahp      nS = 30 nS   # afterpolarization current peak conductance.
+        tau_syn_ex ms = 1.0 ms  # Rise time of the excitatory synaptic alpha function.
+        tau_syn_in ms = 12.5 ms # Rise time of the inhibitory synaptic alpha function.
+        E_gg       mV = -100 mV # reversal potential for inhibitory input (from GPe)
+        t_ref      ms = 2 ms    # refractory time
+
+        # constant external input current
+        I_e pA = 0 pA
+      end
+
+      internals:
+        refractory_counts integer = steps(t_ref)
+      end
+
+      input:
+        spikeInh nS <- inhibitory spike
+        spikeExc nS <- excitatory spike
+        I_stim pA <- current
+      end
+
+      output: spike
+
+      update:
+        U_old mV = V_m
+        integrate_odes()
+
+        # sending spikes: crossing 0 mV, pseudo-refractoriness and local maximum...
+        if r > 0:
+          r -= 1
+        elif V_m > 0 mV and U_old > V_m:
+          r = refractory_counts
+          emit_spike()
+        end
+
+      end
+
+    end
+
 
 
 

--- a/doc/models_library/terub_stn.rst
+++ b/doc/models_library/terub_stn.rst
@@ -115,142 +115,151 @@ Source code
 
 .. code:: nestml
 
-   neuron terub_stn:
-     state:
-       r integer  # counts number of tick during the refractory period
-     end
-     initial_values:
-       V_m mV = E_L # Membrane potential
-       gate_h real = 0.0 # gating variable h
-       gate_n real = 0.0 # gating variable n
-       gate_r real = 0.0 # gating variable r
-       Ca_con real = 0.0 # gating variable r
-     end
-     equations:
+    neuron terub_stn:
+      state:
+        r integer = 0 # counts number of tick during the refractory period
 
-       /*time constants for slow gating variables*/
-       function tau_n_0 ms = 1.0ms
-       function tau_n_1 ms = 100.0ms
-       function theta_n_tau mV = -80.0mV
-       function sigma_n_tau mV = -26.0mV
-       function tau_h_0 ms = 1.0ms
-       function tau_h_1 ms = 500.0ms
-       function theta_h_tau mV = -57.0mV
-       function sigma_h_tau mV = -3.0mV
-       function tau_r_0 ms = 7.1ms # Guo 7.1 Terman02 40.0
-       function tau_r_1 ms = 17.5ms
-       function theta_r_tau mV = 68.0mV
-       function sigma_r_tau mV = -2.2mV
+        V_m mV = E_L #  Membrane potential
+        gate_h real = 0.0 # gating variable h
+        gate_n real = 0.0 # gating variable n
+        gate_r real = 0.0 # gating variable r
+        Ca_con real = 0.0 # gating variable r
+      end
 
-       /*steady state values for gating variables*/
-       function theta_a mV = -63.0mV
-       function sigma_a mV = 7.8mV
-       function theta_h mV = -39.0mV
-       function sigma_h mV = -3.1mV
-       function theta_m mV = -30.0mV
-       function sigma_m mV = 15.0mV
-       function theta_n mV = -32.0mV
-       function sigma_n mV = 8.0mV
-       function theta_r mV = -67.0mV
-       function sigma_r mV = -2.0mV
-       function theta_s mV = -39.0mV
-       function sigma_s mV = 8.0mV
-       function theta_b real = 0.25 # Guo 0.25 Terman02 0.4
-       function sigma_b real = 0.07 # Guo 0.07 Terman02 -0.1
+      equations:
+        #Parameters for Terman Rubin STN Neuron
 
-       /*time evolvement of gating variables*/
-       function phi_h real = 0.75
-       function phi_n real = 0.75
-       function phi_r real = 0.5 # Guo 0.5 Terman02 0.2
+        #time constants for slow gating variables
+        inline tau_n_0 ms = 1.0 ms
+        inline tau_n_1 ms = 100.0 ms
+        inline theta_n_tau mV = -80.0 mV
+        inline sigma_n_tau mV = -26.0 mV
 
-       /* Calcium concentration and afterhyperpolarization current*/
-       function epsilon 1/ms = 5e-05 / ms # 1/ms Guo 0.00005 Terman02 0.0000375
-       function k_Ca real = 22.5
-       function k1 real = 15.0
-       function I_ex_mod pA = -convolve(g_ex,spikeExc) * V_m
-       function I_in_mod pA = convolve(g_in,spikeInh) * (V_m - E_gs)
-       function tau_n ms = tau_n_0 + tau_n_1 / (1.0 + exp(-(V_m - theta_n_tau) / sigma_n_tau))
-       function tau_h ms = tau_h_0 + tau_h_1 / (1.0 + exp(-(V_m - theta_h_tau) / sigma_h_tau))
-       function tau_r ms = tau_r_0 + tau_r_1 / (1.0 + exp(-(V_m - theta_r_tau) / sigma_r_tau))
-       function a_inf real = 1.0 / (1.0 + exp(-(V_m - theta_a) / sigma_a))
-       function h_inf real = 1.0 / (1.0 + exp(-(V_m - theta_h) / sigma_h))
-       function m_inf real = 1.0 / (1.0 + exp(-(V_m - theta_m) / sigma_m))
-       function n_inf real = 1.0 / (1.0 + exp(-(V_m - theta_n) / sigma_n))
-       function r_inf real = 1.0 / (1.0 + exp(-(V_m - theta_r) / sigma_r))
-       function s_inf real = 1.0 / (1.0 + exp(-(V_m - theta_s) / sigma_s))
-       function b_inf real = 1.0 / (1.0 + exp((gate_r - theta_b) / sigma_b)) - 1.0 / (1.0 + exp(-theta_b / sigma_b))
-       function I_Na pA = g_Na * m_inf * m_inf * m_inf * gate_h * (V_m - E_Na)
-       function I_K pA = g_K * gate_n * gate_n * gate_n * gate_n * (V_m - E_K)
-       function I_L pA = g_L * (V_m - E_L)
-       function I_T pA = g_T * a_inf * a_inf * a_inf * b_inf * b_inf * (V_m - E_Ca)
-       function I_Ca pA = g_Ca * s_inf * s_inf * (V_m - E_Ca)
-       function I_ahp pA = g_ahp * (Ca_con / (Ca_con + k1)) * (V_m - E_K)
+        inline tau_h_0 ms = 1.0 ms
+        inline tau_h_1 ms = 500.0 ms
+        inline theta_h_tau mV = -57.0 mV
+        inline sigma_h_tau mV = -3.0 mV
 
-       /* V dot -- synaptic input are currents, inhib current is negative*/
-       V_m'=(-(I_Na + I_K + I_L + I_T + I_Ca + I_ahp) + I_e + I_stim + I_ex_mod + I_in_mod) / C_m
+        inline tau_r_0 ms = 7.1 ms # Guo 7.1 Terman02 40.0
+        inline tau_r_1 ms = 17.5 ms
+        inline theta_r_tau mV = 68.0 mV
+        inline sigma_r_tau mV = -2.2 mV
 
-       /*channel dynamics*/
-       gate_h'=phi_h * ((h_inf - gate_h) / tau_h) # h-variable
-       gate_n'=phi_n * ((n_inf - gate_n) / tau_n) # n-variable
-       gate_r'=phi_r * ((r_inf - gate_r) / tau_r) # r-variable
+        #steady state values for gating variables
+        inline theta_a mV = -63.0 mV
+        inline sigma_a mV = 7.8 mV
+        inline theta_h mV = -39.0 mV
+        inline sigma_h mV = -3.1 mV
+        inline theta_m mV = -30.0 mV
+        inline sigma_m mV = 15.0 mV
+        inline theta_n mV = -32.0 mV
+        inline sigma_n mV = 8.0 mV
+        inline theta_r mV = -67.0 mV
+        inline sigma_r mV = -2.0 mV
+        inline theta_s mV = -39.0 mV
+        inline sigma_s mV = 8.0 mV
 
-       /*Calcium concentration*/
-       Ca_con'=epsilon * ((-I_Ca - I_T) / pA - k_Ca * Ca_con)
+        inline theta_b real = 0.25 # Guo 0.25 Terman02 0.4
+        inline sigma_b real = 0.07 # Guo 0.07 Terman02 -0.1
 
-       /* synapses: alpha functions*/
-       /* alpha function for the g_in*/
-       kernel g_in = (e / tau_syn_in) * t * exp(-t / tau_syn_in)
-       /* alpha function for the g_ex*/
+        #time evolvement of gating variables
+        inline phi_h real = 0.75
+        inline phi_n real = 0.75
+        inline phi_r real = 0.5 # Guo 0.5 Terman02 0.2
 
-       /* alpha function for the g_ex*/
-       kernel g_ex = (e / tau_syn_ex) * t * exp(-t / tau_syn_ex)
-     end
+        # Calcium concentration and afterhyperpolarization current
+        inline epsilon 1/ms = 0.00005 / ms # 1/ms Guo 0.00005 Terman02 0.0000375
+        inline k_Ca real = 22.5
+        inline k1 real = 15.0
 
-     parameters:
-       E_L mV = -60mV # Resting membrane potential.
-       g_L nS = 2.25nS # Leak conductance.
-       C_m pF = 1.0pF # Capacity of the membrane.
-       E_Na mV = 55mV # Sodium reversal potential.
-       g_Na nS = 37.5nS # Sodium peak conductance.
-       E_K mV = -80.0mV # Potassium reversal potential.
-       g_K nS = 45.0nS # Potassium peak conductance.
-       E_Ca mV = 120mV # Calcium reversal potential.
-       g_Ca nS = 140nS # Calcium peak conductance.
-       g_T nS = 0.5nS # T-type Calcium channel peak conductance.
-       g_ahp nS = 9nS # afterpolarization current peak conductance.
-       tau_syn_ex ms = 1.0ms # Rise time of the excitatory synaptic alpha function.
-       tau_syn_in ms = 0.08ms # Rise time of the inhibitory synaptic alpha function.
-       E_gs mV = -85.0mV # reversal potential for inhibitory input (from GPe)
-       t_ref ms = 2ms # refractory time
+        inline I_ex_mod pA = -convolve(g_ex, spikeExc) * V_m
+        inline I_in_mod pA = convolve(g_in, spikeInh) * (V_m - E_gs)
 
-       /* constant external input current*/
-       I_e pA = 0pA
-     end
-     internals:
-       refractory_counts integer = steps(t_ref)
-     end
-     input:
-       spikeInh nS <-inhibitory spike
-       spikeExc nS <-excitatory spike
-       I_stim pA <-current
-     end
+        inline tau_n ms = tau_n_0 + tau_n_1 / (1. + exp(-(V_m-theta_n_tau)/sigma_n_tau))
+        inline tau_h ms = tau_h_0 + tau_h_1 / (1. + exp(-(V_m-theta_h_tau)/sigma_h_tau))
+        inline tau_r ms = tau_r_0 + tau_r_1 / (1. + exp(-(V_m-theta_r_tau)/sigma_r_tau))
 
-     output: spike
+        inline a_inf real = 1. / (1. +exp(-(V_m-theta_a)/sigma_a))
+        inline h_inf real = 1. / (1. + exp(-(V_m-theta_h)/sigma_h));
+        inline m_inf real = 1. / (1. + exp(-(V_m-theta_m)/sigma_m))
+        inline n_inf real = 1. / (1. + exp(-(V_m-theta_n)/sigma_n))
+        inline r_inf real = 1. / (1. + exp(-(V_m-theta_r)/sigma_r))
+        inline s_inf real = 1. / (1. + exp(-(V_m-theta_s)/sigma_s))
+        inline b_inf real = 1. / (1. + exp((gate_r-theta_b)/sigma_b)) - 1. / (1. + exp(-theta_b/sigma_b))
 
-     update:
-       U_old mV = V_m
-       integrate_odes()
+        inline I_Na  pA =  g_Na  * m_inf * m_inf * m_inf * gate_h    * (V_m - E_Na)
+        inline I_K   pA =  g_K   * gate_n * gate_n * gate_n * gate_n * (V_m - E_K )
+        inline I_L   pA =  g_L                                 * (V_m - E_L )
+        inline I_T   pA =  g_T   *a_inf*a_inf*a_inf*b_inf*b_inf* (V_m - E_Ca)
+        inline I_Ca  pA =  g_Ca  * s_inf * s_inf               * (V_m - E_Ca)
+        inline I_ahp pA =  g_ahp * (Ca_con / (Ca_con + k1))    * (V_m - E_K )
 
-       /* sending spikes: crossing 0 mV, pseudo-refractoriness and local maximum...*/
-       if r > 0:
-         r -= 1
-       elif V_m > 0mV and U_old > V_m:
-         r = refractory_counts
-         emit_spike()
-       end
-     end
+        # V dot -- synaptic input are currents, inhib current is negative
+        V_m' = ( -(I_Na + I_K + I_L + I_T + I_Ca + I_ahp) + I_e + I_stim + I_ex_mod + I_in_mod) / C_m
 
-   end
+        #channel dynamics
+        gate_h' = phi_h *((h_inf-gate_h) / tau_h)  # h-variable
+        gate_n' = phi_n *((n_inf-gate_n) / tau_n)  # n-variable
+        gate_r' = phi_r *((r_inf-gate_r) / tau_r)  # r-variable
+
+        #Calcium concentration
+        Ca_con' = epsilon*( (-I_Ca  - I_T ) / pA - k_Ca * Ca_con)
+
+        # synapses: alpha functions
+        ## alpha function for the g_in
+        kernel g_in = (e/tau_syn_in) * t * exp(-t/tau_syn_in)
+        ## alpha function for the g_ex
+        kernel g_ex = (e/tau_syn_ex) * t * exp(-t/tau_syn_ex)
+      end
+
+      parameters:
+        E_L        mV = -60 mV  # Resting membrane potential.
+        g_L        nS = 2.25 nS # Leak conductance.
+        C_m        pF = 1.0 pF # Capacity of the membrane.
+        E_Na       mV = 55 mV   # Sodium reversal potential.
+        g_Na       nS = 37.5 nS # Sodium peak conductance.
+        E_K        mV = -80.0 mV# Potassium reversal potential.
+        g_K        nS = 45.0 nS # Potassium peak conductance.
+        E_Ca       mV = 140 mV  # Calcium reversal potential.
+        g_Ca       nS = 0.5 nS  # Calcium peak conductance.
+        g_T        nS = 0.5 nS  # T-type Calcium channel peak conductance.
+        g_ahp      nS = 9 nS    # afterpolarization current peak conductance.
+        tau_syn_ex ms = 1.0 ms  # Rise time of the excitatory synaptic alpha function.
+        tau_syn_in ms = 0.08 ms # Rise time of the inhibitory synaptic alpha function.
+        E_gs       mV = -85.0 mV# reversal potential for inhibitory input (from GPe)
+        t_ref      ms = 2 ms    # refractory time
+
+        # constant external input current
+        I_e pA = 0 pA
+      end
+
+      internals:
+        refractory_counts integer = steps(t_ref)
+      end
+
+      input:
+        spikeInh pA <- inhibitory spike
+        spikeExc pA <- excitatory spike
+        I_stim pA <- current
+      end
+
+      output: spike
+
+      update:
+        U_old mV = V_m
+        integrate_odes()
+
+        # sending spikes: crossing 0 mV, pseudo-refractoriness and local maximum...
+        if r > 0:
+          r -= 1
+        elif V_m > 0 mV and U_old > V_m:
+          r = refractory_counts
+          emit_spike()
+        end
+
+      end
+
+    end
 
 
 

--- a/doc/models_library/traub_cond_multisyn.rst
+++ b/doc/models_library/traub_cond_multisyn.rst
@@ -160,147 +160,164 @@ Source code
 
 .. code:: nestml
 
-   neuron traub_cond_multisyn:
-     state:
-       r integer  # number of steps in the current refractory phase
-     end
-     initial_values:
-       V_m mV = -70.0mV # Membrane potential
-       function alpha_n_init real = 0.032 * (V_m / mV + 52.0) / (1.0 - exp(-(V_m / mV + 52.0) / 5.0))
-       function beta_n_init real = 0.5 * exp(-(V_m / mV + 57.0) / 40.0)
-       function alpha_m_init real = 0.32 * (V_m / mV + 54.0) / (1.0 - exp(-(V_m / mV + 54.0) / 4.0))
-       function beta_m_init real = 0.28 * (V_m / mV + 27.0) / (exp((V_m / mV + 27.0) / 5.0) - 1.0)
-       function alpha_h_init real = 0.128 * exp(-(V_m / mV + 50.0) / 18.0)
-       function beta_h_init real = 4.0 / (1.0 + exp(-(V_m / mV + 27.0) / 5.0))
-       Act_m real = alpha_m_init / (alpha_m_init + beta_m_init) # Activation variable m for Na
-       Inact_h real = alpha_h_init / (alpha_h_init + beta_h_init) # Inactivation variable h for Na
-       Act_n real = alpha_n_init / (alpha_n_init + beta_n_init) # Activation variable n for K
-       g_AMPA nS = 0.0nS
-       g_AMPA__d nS/ms = 0.0nS / ms
-       g_NMDA nS = 0.0nS
-       g_NMDA__d nS/ms = 0.0nS / ms
-       g_GABAA nS = 0.0nS
-       g_GABAA__d nS/ms = 0.0nS / ms
-       g_GABAB nS = 0.0nS
-       g_GABAB__d nS/ms = 0.0nS / ms
-     end
-     equations:
-   recordable    function I_syn_ampa pA = -g_AMPA * (V_m - AMPA_E_rev)
-   recordable    function I_syn_nmda pA = -g_NMDA * (V_m - NMDA_E_rev) / (1 + exp((NMDA_Vact - V_m) / NMDA_Sact))
-   recordable    function I_syn_gaba_a pA = -g_GABAA * (V_m - GABA_A_E_rev)
-   recordable    function I_syn_gaba_b pA = -g_GABAB * (V_m - GABA_B_E_rev)
-   recordable    function I_syn pA = I_syn_ampa + I_syn_nmda + I_syn_gaba_a + I_syn_gaba_b
-       function I_Na pA = g_Na * Act_m * Act_m * Act_m * Inact_h * (V_m - E_Na)
-       function I_K pA = g_K * Act_n * Act_n * Act_n * Act_n * (V_m - E_K)
-       function I_L pA = g_L * (V_m - E_L)
-       V_m'=(-(I_Na + I_K + I_L) + I_e + I_stim + I_syn) / C_m
+    neuron traub_cond_multisyn:
+      state:
+        r integer = 0 # number of steps in the current refractory phase
 
-       /* Act_n*/
-       function alpha_n real = 0.032 * (V_m / mV + 52.0) / (1.0 - exp(-(V_m / mV + 52.0) / 5.0))
-       function beta_n real = 0.5 * exp(-(V_m / mV + 57.0) / 40.0)
-       Act_n'=(alpha_n * (1 - Act_n) - beta_n * Act_n) / ms # n-variable
+        V_m mV = -70. mV # Membrane potential
 
-       /* Act_m*/
-       function alpha_m real = 0.32 * (V_m / mV + 54.0) / (1.0 - exp(-(V_m / mV + 54.0) / 4.0))
-       function beta_m real = 0.28 * (V_m / mV + 27.0) / (exp((V_m / mV + 27.0) / 5.0) - 1.0)
-       Act_m'=(alpha_m * (1 - Act_m) - beta_m * Act_m) / ms # m-variable
+        Act_m real =  alpha_m_init / ( alpha_m_init + beta_m_init )     # Activation variable m for Na
+        Inact_h real = alpha_h_init / ( alpha_h_init + beta_h_init )    # Inactivation variable h for Na
+        Act_n real = alpha_n_init / (alpha_n_init + beta_n_init)        # Activation variable n for K
 
-       /* Inact_h'*/
-       function alpha_h real = 0.128 * exp(-(V_m / mV + 50.0) / 18.0)
-       function beta_h real = 4.0 / (1.0 + exp(-(V_m / mV + 27.0) / 5.0))
-       Inact_h'=(alpha_h * (1 - Inact_h) - beta_h * Inact_h) / ms # h-variable
-       g_AMPA__d'=-g_AMPA__d / AMPA_Tau_1
-       g_AMPA'=g_AMPA__d - g_AMPA / AMPA_Tau_2
-       g_NMDA__d'=-g_NMDA__d / NMDA_Tau_1
-       g_NMDA'=g_NMDA__d - g_NMDA / NMDA_Tau_2
-       g_GABAA__d'=-g_GABAA__d / GABA_A_Tau_1
-       g_GABAA'=g_GABAA__d - g_GABAA / GABA_A_Tau_2
-       g_GABAB__d'=-g_GABAB__d / GABA_B_Tau_1
-       g_GABAB'=g_GABAB__d - g_GABAB / GABA_B_Tau_2
-     end
+        g_AMPA real = 0
+        g_NMDA real = 0
+        g_GABAA real = 0
+        g_GABAB real = 0
+        g_AMPA$ real = AMPAInitialValue
+        g_NMDA$ real = NMDAInitialValue
+        g_GABAA$ real = GABA_AInitialValue
+        g_GABAB$ real = GABA_BInitialValue
+      end
 
-     parameters:
-       t_ref ms = 2.0ms # Refractory period 2.0
-       g_Na nS = 10000.0nS # Sodium peak conductance
-       g_K nS = 8000.0nS # Potassium peak conductance
-       g_L nS = 10nS # Leak conductance
-       C_m pF = 100.0pF # Membrane Capacitance
-       E_Na mV = 50.0mV # Sodium reversal potential
-       E_K mV = -100.0mV # Potassium reversal potentia
-       E_L mV = -67.0mV # Leak reversal Potential (aka resting potential)
-       V_Tr mV = -20.0mV # Spike Threshold
+      equations:
+        recordable inline I_syn_ampa pA = -convolve(g_AMPA, AMPA) * ( V_m - AMPA_E_rev )
+        recordable inline I_syn_nmda pA = -convolve(g_NMDA, NMDA) * ( V_m - NMDA_E_rev ) / ( 1 + exp( ( NMDA_Vact - V_m ) / NMDA_Sact ) )
+        recordable inline I_syn_gaba_a pA = -convolve(g_GABAA, GABA_A) * ( V_m - GABA_A_E_rev )
+        recordable inline I_syn_gaba_b pA = -convolve(g_GABAB, GABA_B) * ( V_m - GABA_B_E_rev )
+        recordable inline I_syn pA = I_syn_ampa + I_syn_nmda + I_syn_gaba_a + I_syn_gaba_b
 
-       /* Parameters for synapse of type AMPA, GABA_A, GABA_B and NMDA*/
-       AMPA_g_peak nS = 0.1nS # peak conductance
-       AMPA_E_rev mV = 0.0mV # reversal potential
-       AMPA_Tau_1 ms = 0.5ms # rise time
-       AMPA_Tau_2 ms = 2.4ms # decay time, Tau_1 < Tau_2
-       NMDA_g_peak nS = 0.075nS # peak conductance
-       NMDA_Tau_1 ms = 4.0ms # rise time
-       NMDA_Tau_2 ms = 40.0ms # decay time, Tau_1 < Tau_2
-       NMDA_E_rev mV = 0.0mV # reversal potential
-       NMDA_Vact mV = -58.0mV # inactive for V << Vact, inflection of sigmoid
-       NMDA_Sact mV = 2.5mV # scale of inactivation
-       GABA_A_g_peak nS = 0.33nS # peak conductance
-       GABA_A_Tau_1 ms = 1.0ms # rise time
-       GABA_A_Tau_2 ms = 7.0ms # decay time, Tau_1 < Tau_2
-       GABA_A_E_rev mV = -70.0mV # reversal potential
-       GABA_B_g_peak nS = 0.0132nS # peak conductance
-       GABA_B_Tau_1 ms = 60.0ms # rise time
-       GABA_B_Tau_2 ms = 200.0ms # decay time, Tau_1 < Tau_2
-       GABA_B_E_rev mV = -90.0mV # reversal potential for intrinsic current
+        inline I_Na  pA = g_Na * Act_m * Act_m * Act_m * Inact_h * ( V_m - E_Na )
+        inline I_K   pA  = g_K * Act_n * Act_n * Act_n * Act_n * ( V_m - E_K )
+        inline I_L   pA = g_L * ( V_m - E_L )
 
-       /* constant external input current*/
-       I_e pA = 0pA
-     end
-     internals:
-       AMPAInitialValue real = compute_synapse_constant(AMPA_Tau_1,AMPA_Tau_2,AMPA_g_peak)
-       NMDAInitialValue real = compute_synapse_constant(NMDA_Tau_1,NMDA_Tau_2,NMDA_g_peak)
-       GABA_AInitialValue real = compute_synapse_constant(GABA_A_Tau_1,GABA_A_Tau_2,GABA_A_g_peak)
-       GABA_BInitialValue real = compute_synapse_constant(GABA_B_Tau_1,GABA_B_Tau_2,GABA_B_g_peak)
-       RefractoryCounts integer = steps(t_ref) # refractory time in steps
-     end
-     input:
-       AMPA nS <-spike
-       NMDA nS <-spike
-       GABA_A nS <-spike
-       GABA_B nS <-spike
-       I_stim pA <-current
-     end
+        V_m' = ( -( I_Na + I_K + I_L ) + I_e + I_stim + I_syn ) / C_m
 
-     output: spike
+        # Act_n
+        inline alpha_n real = 0.032 * (V_m / mV + 52.) / (1. - exp(-(V_m / mV + 52.) / 5.))
+        inline beta_n  real = 0.5 * exp(-(V_m / mV + 57.) / 40.)
+        Act_n' = ( alpha_n * ( 1 - Act_n ) - beta_n * Act_n ) / ms # n-variable
 
-     update:
-       U_old mV = V_m
-       integrate_odes()
-       g_AMPA__d += AMPAInitialValue * AMPA / ms
-       g_NMDA__d += NMDAInitialValue * NMDA / ms
-       g_GABAA__d += GABA_AInitialValue * GABA_A / ms
-       g_GABAB__d += GABA_BInitialValue * GABA_B / ms
+        # Act_m
+        inline alpha_m real = 0.32 * (V_m / mV + 54.) / (1.0 - exp(-(V_m / mV + 54.) / 4.))
+        inline beta_m  real = 0.28 * (V_m / mV + 27.) / (exp((V_m / mV + 27.) / 5.) - 1.)
+        Act_m' = ( alpha_m * ( 1 - Act_m ) - beta_m * Act_m ) / ms # m-variable
 
-       /* sending spikes: */
-       if r > 0: # is refractory?
-         r -= 1
-       elif V_m > V_Tr and U_old > V_Tr:
-         r = RefractoryCounts
-         emit_spike()
-       end
-     end
+        # Inact_h'
+        inline alpha_h real = 0.128 * exp(-(V_m / mV + 50.0) / 18.0)
+        inline beta_h  real = 4.0 / (1.0 + exp(-(V_m / mV + 27.) / 5.))
+        Inact_h' = ( alpha_h * ( 1 - Inact_h ) - beta_h * Inact_h ) / ms # h-variable
 
-   function compute_synapse_constant(Tau_1 msTau_2 msg_peak real) real:
+        #############
+        # Synapses
+        #############
 
-       /* Factor used to account for the missing 1/((1/Tau_2)-(1/Tau_1)) term*/
-       /* in the ht_neuron_dynamics integration of the synapse terms.*/
-       /* See: Exact digital simulation of time-invariant linear systems*/
-       /* with applications to neuronal modeling, Rotter and Diesmann,*/
-       /* section 3.1.2.*/
-       exact_integration_adjustment real = ((1 / Tau_2) - (1 / Tau_1)) * ms
-       t_peak real = (Tau_2 * Tau_1) * ln(Tau_2 / Tau_1) / (Tau_2 - Tau_1) / ms
-       normalisation_factor real = 1 / (exp(-t_peak / Tau_1) - exp(-t_peak / Tau_2))
-       return g_peak * normalisation_factor * exact_integration_adjustment
-   end
+        kernel g_AMPA' = g_AMPA$ - g_AMPA / tau_AMPA_2,
+               g_AMPA$' = -g_AMPA$ / tau_AMPA_1
 
-   end
+        kernel g_NMDA' = g_NMDA$ - g_NMDA / tau_NMDA_2,
+               g_NMDA$' = -g_NMDA$ / tau_NMDA_1
+
+        kernel g_GABAA' = g_GABAA$ - g_GABAA / tau_GABAA_2,
+               g_GABAA$' = -g_GABAA$ / tau_GABAA_1
+
+        kernel g_GABAB' = g_GABAB$ - g_GABAB / tau_GABAB_2,
+               g_GABAB$' = -g_GABAB$ / tau_GABAB_1
+      end
+
+      parameters:
+        t_ref ms = 2.0 ms       # Refractory period 2.0
+        g_Na nS = 10000.0 nS    # Sodium peak conductance
+        g_K nS = 8000.0 nS      # Potassium peak conductance
+        g_L nS = 10 nS          # Leak conductance
+        C_m pF = 100.0 pF       # Membrane Capacitance
+        E_Na mV = 50. mV        # Sodium reversal potential
+        E_K mV = -100. mV       # Potassium reversal potentia
+        E_L mV = -67. mV        # Leak reversal Potential (aka resting potential)
+        V_Tr mV = -20. mV       # Spike Threshold
+
+        # Parameters for synapse of type AMPA, GABA_A, GABA_B and NMDA
+        AMPA_g_peak nS = 0.1 nS      # peak conductance
+        AMPA_E_rev mV = 0.0 mV       # reversal potential
+        tau_AMPA_1 ms = 0.5 ms       # rise time
+        tau_AMPA_2 ms = 2.4 ms       # decay time, Tau_1 < Tau_2
+
+        NMDA_g_peak nS = 0.075 nS    # peak conductance
+        tau_NMDA_1 ms = 4.0 ms       # rise time
+        tau_NMDA_2 ms = 40.0 ms      # decay time, Tau_1 < Tau_2
+        NMDA_E_rev mV = 0.0 mV       # reversal potential
+        NMDA_Vact mV = -58.0 mV      # inactive for V << Vact, inflection of sigmoid
+        NMDA_Sact mV = 2.5 mV        # scale of inactivation
+
+        GABA_A_g_peak nS = 0.33 nS   # peak conductance
+        tau_GABAA_1 ms = 1.0 ms     # rise time
+        tau_GABAA_2 ms = 7.0 ms     # decay time, Tau_1 < Tau_2
+        GABA_A_E_rev mV = -70.0 mV   # reversal potential
+
+        GABA_B_g_peak nS = 0.0132 nS # peak conductance
+        tau_GABAB_1 ms = 60.0 ms    # rise time
+        tau_GABAB_2 ms = 200.0 ms   # decay time, Tau_1 < Tau_2
+        GABA_B_E_rev mV = -90.0 mV   # reversal potential for intrinsic current
+
+        # constant external input current
+        I_e pA = 0 pA
+      end
+
+      internals:
+        AMPAInitialValue real = compute_synapse_constant( tau_AMPA_1, tau_AMPA_2, AMPA_g_peak )
+        NMDAInitialValue real = compute_synapse_constant( tau_NMDA_1, tau_NMDA_2, NMDA_g_peak )
+        GABA_AInitialValue real = compute_synapse_constant( tau_GABAA_1, tau_GABAA_2, GABA_A_g_peak )
+        GABA_BInitialValue real = compute_synapse_constant( tau_GABAB_1, tau_GABAB_2, GABA_B_g_peak )
+        RefractoryCounts integer = steps(t_ref) # refractory time in steps
+
+        alpha_n_init real = 0.032 * (V_m / mV + 52.) / (1. - exp(-(V_m / mV + 52.) / 5.))
+        beta_n_init  real = 0.5 * exp(-(V_m / mV + 57.) / 40.)
+        alpha_m_init real = 0.32 * (V_m / mV + 54.) / (1.0 - exp(-(V_m / mV + 54.) / 4.))
+        beta_m_init  real = 0.28 * (V_m / mV + 27.) / (exp((V_m / mV + 27.) / 5.) - 1.)
+        alpha_h_init real = 0.128 * exp(-(V_m / mV + 50.0) / 18.0)
+        beta_h_init  real = 4.0 / (1.0 + exp(-(V_m / mV + 27.) / 5.))
+      end
+
+      input:
+        AMPA nS  <- spike
+        NMDA nS  <- spike
+        GABA_A nS <- spike
+        GABA_B nS <- spike
+        I_stim pA <- current
+      end
+
+      output: spike
+
+      update:
+        U_old mV = V_m
+        integrate_odes()
+
+        # sending spikes:
+        if r > 0: # is refractory?
+          r -= 1
+        elif V_m > V_Tr and U_old > V_Tr: # threshold && maximum
+          r = RefractoryCounts
+          emit_spike()
+        end
+
+      end
+
+
+      function compute_synapse_constant(Tau_1 ms, Tau_2 ms, g_peak real) real:
+        # Factor used to account for the missing 1/((1/Tau_2)-(1/Tau_1)) term
+        # in the ht_neuron_dynamics integration of the synapse terms.
+        # See: Exact digital simulation of time-invariant linear systems
+        # with applications to neuronal modeling, Rotter and Diesmann,
+        # section 3.1.2.
+        exact_integration_adjustment real = ( ( 1 / Tau_2 ) - ( 1 / Tau_1 ) ) * ms
+
+        t_peak real = ( Tau_2 * Tau_1 ) * ln( Tau_2 / Tau_1 ) / ( Tau_2 - Tau_1 ) / ms
+        normalisation_factor real = 1 / ( exp( -t_peak / Tau_1 ) - exp( -t_peak / Tau_2 ) )
+
+        return g_peak * normalisation_factor * exact_integration_adjustment
+      end
+
+    end
 
 
 

--- a/doc/models_library/traub_psc_alpha.rst
+++ b/doc/models_library/traub_psc_alpha.rst
@@ -103,92 +103,95 @@ Source code
 
 .. code:: nestml
 
-   neuron traub_psc_alpha:
-     state:
-       r integer  # number of steps in the current refractory phase
-     end
-     initial_values:
-       V_m mV = -70.0mV # Membrane potential
-       function alpha_n_init real = 0.032 * (V_m / mV + 52.0) / (1.0 - exp(-(V_m / mV + 52.0) / 5.0))
-       function beta_n_init real = 0.5 * exp(-(V_m / mV + 57.0) / 40.0)
-       function alpha_m_init real = 0.32 * (V_m / mV + 54.0) / (1.0 - exp(-(V_m / mV + 54.0) / 4.0))
-       function beta_m_init real = 0.28 * (V_m / mV + 27.0) / (exp((V_m / mV + 27.0) / 5.0) - 1.0)
-       function alpha_h_init real = 0.128 * exp(-(V_m / mV + 50.0) / 18.0)
-       function beta_h_init real = 4.0 / (1.0 + exp(-(V_m / mV + 27.0) / 5.0))
-       Act_m real = alpha_m_init / (alpha_m_init + beta_m_init) # Activation variable m for Na
-       Inact_h real = alpha_h_init / (alpha_h_init + beta_h_init) # Inactivation variable h for Na
-       Act_n real = alpha_n_init / (alpha_n_init + beta_n_init) # Activation variable n for K
-     end
-     equations:
+    neuron traub_psc_alpha:
+      state:
+        r integer = 0 # number of steps in the current refractory phase
 
-       /* synapses: alpha functions*/
-       kernel I_syn_in = (e / tau_syn_in) * t * exp(-t / tau_syn_in)
-       kernel I_syn_ex = (e / tau_syn_ex) * t * exp(-t / tau_syn_ex)
-       function I_syn_exc pA = convolve(I_syn_ex,spikeExc)
-       function I_syn_inh pA = convolve(I_syn_in,spikeInh)
-       function I_Na pA = g_Na * Act_m * Act_m * Act_m * Inact_h * (V_m - E_Na)
-       function I_K pA = g_K * Act_n * Act_n * Act_n * Act_n * (V_m - E_K)
-       function I_L pA = g_L * (V_m - E_L)
-       V_m'=(-(I_Na + I_K + I_L) + I_e + I_stim + I_syn_inh + I_syn_exc) / C_m
+        V_m mV = -70. mV # Membrane potential
 
-       /* Act_n*/
-       function alpha_n real = 0.032 * (V_m / mV + 52.0) / (1.0 - exp(-(V_m / mV + 52.0) / 5.0))
-       function beta_n real = 0.5 * exp(-(V_m / mV + 57.0) / 40.0)
-       Act_n'=(alpha_n * (1 - Act_n) - beta_n * Act_n) / ms # n-variable
+        Act_m real =  alpha_m_init / ( alpha_m_init + beta_m_init )     # Activation variable m for Na
+        Inact_h real = alpha_h_init / ( alpha_h_init + beta_h_init )    # Inactivation variable h for Na
+        Act_n real =  alpha_n_init / ( alpha_n_init + beta_n_init )     # Activation variable n for K
+      end
 
-       /* Act_m*/
-       function alpha_m real = 0.32 * (V_m / mV + 54.0) / (1.0 - exp(-(V_m / mV + 54.0) / 4.0))
-       function beta_m real = 0.28 * (V_m / mV + 27.0) / (exp((V_m / mV + 27.0) / 5.0) - 1.0)
-       Act_m'=(alpha_m * (1 - Act_m) - beta_m * Act_m) / ms # m-variable
+      equations:
+        # synapses: alpha functions
+        kernel I_syn_in = (e/tau_syn_in) * t * exp(-t/tau_syn_in)
+        kernel I_syn_ex = (e/tau_syn_ex) * t * exp(-t/tau_syn_ex)
 
-       /* Inact_h'*/
-       function alpha_h real = 0.128 * exp(-(V_m / mV + 50.0) / 18.0)
-       function beta_h real = 4.0 / (1.0 + exp(-(V_m / mV + 27.0) / 5.0))
-       Inact_h'=(alpha_h * (1 - Inact_h) - beta_h * Inact_h) / ms # h-variable
-     end
+        inline I_syn_exc pA = convolve(I_syn_ex, spikeExc)
+        inline I_syn_inh pA = convolve(I_syn_in, spikeInh)
+        inline I_Na  pA = g_Na * Act_m * Act_m * Act_m * Inact_h * ( V_m - E_Na )
+        inline I_K   pA  = g_K * Act_n * Act_n * Act_n * Act_n * ( V_m - E_K )
+        inline I_L   pA = g_L * ( V_m - E_L )
+        V_m' = ( -( I_Na + I_K + I_L ) + I_e + I_stim + I_syn_inh + I_syn_exc ) / C_m
 
-     parameters:
-       t_ref ms = 2.0ms # Refractory period 2.0
-       g_Na nS = 10000.0nS # Sodium peak conductance
-       g_K nS = 8000.0nS # Potassium peak conductance
-       g_L nS = 10nS # Leak conductance
-       C_m pF = 100.0pF # Membrane Capacitance
-       E_Na mV = 50.0mV # Sodium reversal potential
-       E_K mV = -100.0mV # Potassium reversal potentia
-       E_L mV = -67.0mV # Leak reversal Potential (aka resting potential)
-       V_Tr mV = -20.0mV # Spike Threshold
-       tau_syn_ex ms = 0.2ms # Rise time of the excitatory synaptic alpha function i
-       tau_syn_in ms = 2.0ms # Rise time of the inhibitory synaptic alpha function
+        # Act_n
+        inline alpha_n real = 0.032 * (V_m / mV + 52.) / (1. - exp(-(V_m / mV + 52.) / 5.))
+        inline beta_n  real = 0.5 * exp(-(V_m / mV + 57.) / 40.)
+        Act_n' = ( alpha_n * ( 1 - Act_n ) - beta_n * Act_n ) / ms # n-variable
 
-       /* constant external input current*/
-       I_e pA = 0pA
-     end
-     internals:
-       RefractoryCounts integer = steps(t_ref) # refractory time in steps
-     end
-     input:
-       spikeInh pA <-inhibitory spike
-       spikeExc pA <-excitatory spike
-       I_stim pA <-current
-     end
+        # Act_m
+        inline alpha_m real = 0.32 * (V_m / mV + 54.) / (1.0 - exp(-(V_m / mV + 54.) / 4.))
+        inline beta_m  real = 0.28 * (V_m / mV + 27.) / (exp((V_m / mV + 27.) / 5.) - 1.)
+        Act_m' = ( alpha_m * ( 1 - Act_m ) - beta_m * Act_m ) / ms # m-variable
 
-     output: spike
+        # Inact_h'
+        inline alpha_h real = 0.128 * exp(-(V_m / mV + 50.0) / 18.0)
+        inline beta_h  real = 4.0 / (1.0 + exp(-(V_m / mV + 27.) / 5.))
+        Inact_h' = ( alpha_h * ( 1 - Inact_h ) - beta_h * Inact_h ) / ms # h-variable
+      end
 
-     update:
-       U_old mV = V_m
-       integrate_odes()
-       /* sending spikes: crossing 0 mV, pseudo-refractoriness and local maximum...*/
+      parameters:
+        t_ref ms = 2.0 ms           # Refractory period 2.0
+        g_Na nS = 10000.0 nS        # Sodium peak conductance
+        g_K nS = 8000.0 nS          # Potassium peak conductance
+        g_L nS = 10 nS              # Leak conductance
+        C_m pF = 100.0 pF           # Membrane Capacitance
+        E_Na mV = 50. mV            # Sodium reversal potential
+        E_K mV = -100. mV           # Potassium reversal potentia
+        E_L mV = -67. mV            # Leak reversal Potential (aka resting potential)
+        V_Tr mV = -20. mV           # Spike Threshold
+        tau_syn_ex ms = 0.2 ms      # Rise time of the excitatory synaptic alpha function
+        tau_syn_in ms = 2. ms       # Rise time of the inhibitory synaptic alpha function
 
-       /* sending spikes: crossing 0 mV, pseudo-refractoriness and local maximum...*/
-       if r > 0: # is refractory?
-         r -= 1
-       elif V_m > V_Tr and U_old > V_Tr:
-         r = RefractoryCounts
-         emit_spike()
-       end
-     end
+        # constant external input current
+        I_e pA = 0 pA
+      end
 
-   end
+      internals:
+        RefractoryCounts integer = steps(t_ref) # refractory time in steps
+
+        alpha_n_init real = 0.032 * (V_m / mV + 52.) / (1. - exp(-(V_m / mV + 52.) / 5.))
+        beta_n_init  real = 0.5 * exp(-(V_m / mV + 57.) / 40.)
+        alpha_m_init real = 0.32 * (V_m / mV + 54.) / (1.0 - exp(-(V_m / mV + 54.) / 4.))
+        beta_m_init  real = 0.28 * (V_m / mV + 27.) / (exp((V_m / mV + 27.) / 5.) - 1.)
+        alpha_h_init real = 0.128 * exp(-(V_m / mV + 50.0) / 18.0)
+        beta_h_init  real = 4.0 / (1.0 + exp(-(V_m / mV + 27.) / 5.))
+      end
+
+      input:
+        spikeInh pA <- inhibitory spike
+        spikeExc pA <- excitatory spike
+        I_stim pA <- current
+      end
+
+      output: spike
+
+      update:
+        U_old mV = V_m
+        integrate_odes()
+        # sending spikes: crossing 0 mV, pseudo-refractoriness and local maximum...
+        if r > 0: # is refractory?
+          r -= 1
+        elif V_m > V_Tr and U_old > V_Tr: # threshold && maximum
+          r = RefractoryCounts
+          emit_spike()
+        end
+
+      end
+
+    end
 
 
 

--- a/doc/models_library/wb_cond_exp.rst
+++ b/doc/models_library/wb_cond_exp.rst
@@ -98,91 +98,111 @@ Source code
 
 .. code:: nestml
 
-   neuron wb_cond_exp:
-     state:
-       r integer  # number of steps in the current refractory phase
-     end
-     initial_values:
-       V_m mV = -65.0mV # Membrane potential
-       function alpha_n_init 1/ms = -0.05 / (ms * mV) * (V_m + 34.0mV) / (exp(-0.1 * (V_m + 34.0mV)) - 1.0)
-       function beta_n_init 1/ms = 0.625 / ms * exp(-(V_m + 44.0mV) / 80.0mV)
-       function alpha_m_init 1/ms = 0.1 / (ms * mV) * (V_m + 35.0mV) / (1.0 - exp(-0.1mV * (V_m + 35.0mV)))
-       function beta_m_init 1/ms = 4.0 / (ms) * exp(-(V_m + 60.0mV) / 18.0mV)
-       function alpha_h_init 1/ms = 0.35 / ms * exp(-(V_m + 58.0mV) / 20.0mV)
-       function beta_h_init 1/ms = 5.0 / (exp(-0.1 / mV * (V_m + 28.0mV)) + 1.0) / ms
+    neuron wb_cond_exp:
+      state:
+        r integer = 0 # number of steps in the current refractory phase
 
-       /* Act_m real = alpha_m_init / ( alpha_m_init + beta_m_init )*/
-       Inact_h real = alpha_h_init / (alpha_h_init + beta_h_init)
-       Act_n real = alpha_n_init / (alpha_n_init + beta_n_init)
-     end
-     equations:
+        V_m mV = E_L    # Membrane potential
 
-       /* synapses: exponential conductance*/
-       kernel g_in = exp(-1.0 / tau_syn_in * t)
-       kernel g_ex = exp(-1.0 / tau_syn_ex * t)
-   recordable    function I_syn_exc pA = convolve(g_ex,spikeExc) * (V_m - E_ex)
-   recordable    function I_syn_inh pA = convolve(g_in,spikeInh) * (V_m - E_in)
-       function alpha_n 1/ms = -0.05 / (ms * mV) * (V_m + 34.0mV) / (exp(-0.1 * (V_m + 34.0mV)) - 1.0)
-       function beta_n 1/ms = 0.625 / ms * exp(-(V_m + 44.0mV) / 80.0mV)
-       function alpha_m 1/ms = 0.1 / (ms * mV) * (V_m + 35.0mV) / (1.0 - exp(-0.1mV * (V_m + 35.0mV)))
-       function beta_m 1/ms = 4.0 / (ms) * exp(-(V_m + 60.0mV) / 18.0mV)
-       function alpha_h 1/ms = 0.35 / ms * exp(-(V_m + 58.0mV) / 20.0mV)
-       function beta_h 1/ms = 5.0 / (exp(-0.1 / mV * (V_m + 28.0mV)) + 1.0) / ms
+        Inact_h real = alpha_h_init / ( alpha_h_init + beta_h_init )
+        Act_n real = alpha_n_init / ( alpha_n_init + beta_n_init )
+      end
 
-       /* alias Act_m real = alpha_m / ( alpha_m + beta_m ) */
-       /* function I_Na  pA = g_Na * Act_m * Act_m * Act_m * Inact_h * ( V_m - E_Na )*/
-       function I_Na pA = g_Na * alpha_m / (alpha_m + beta_m) * alpha_m / (alpha_m + beta_m) * alpha_m / (alpha_m + beta_m) * Inact_h * (V_m - E_Na)
-       function I_K pA = g_K * Act_n * Act_n * Act_n * Act_n * (V_m - E_K)
-       function I_L pA = g_L * (V_m - E_L)
-       V_m'=(-(I_Na + I_K + I_L) + I_e + I_stim + I_syn_inh + I_syn_exc) / C_m
-       Act_n'=(alpha_n * (1 - Act_n) - beta_n * Act_n) # n-variable
-       Inact_h'=(alpha_h * (1 - Inact_h) - beta_h * Inact_h) # h-variable
-     end
+      equations:
+        # synapses: exponential conductance
+        kernel g_in = exp(-1.0 / tau_syn_in * t)
+        kernel g_ex = exp(-1.0 / tau_syn_ex * t)
 
-     parameters:
-       t_ref ms = 2.0ms # Refractory period
-       g_Na nS = 3500.0nS # Sodium peak conductance
-       g_K nS = 900.0nS # Potassium peak conductance
-       g_L nS = 10nS # Leak conductance
-       C_m pF = 100.0pF # Membrane Capacitance
-       E_Na mV = 55.0mV # Sodium reversal potential
-       E_K mV = -90.0mV # Potassium reversal potentia
-       E_L mV = -65.0mV # Leak reversal Potential (aka resting potential)
-       V_Tr mV = -55.0mV # Spike Threshold
-       tau_syn_ex ms = 0.2ms # Rise time of the excitatory synaptic alpha function i
-       tau_syn_in ms = 10.0ms # Rise time of the inhibitory synaptic alpha function
-       E_ex mV = 0.0mV # Excitatory synaptic reversal potential
-       E_in mV = -75.0mV # Inhibitory synaptic reversal potential
+        recordable inline I_syn_exc pA = convolve(g_ex, spikeExc) * ( V_m - E_ex )
+        recordable inline I_syn_inh pA = convolve(g_in, spikeInh) * ( V_m - E_in )
 
-       /* constant external input current*/
-       I_e pA = 0pA
-     end
-     internals:
-       RefractoryCounts integer = steps(t_ref) # refractory time in steps
-     end
-     input:
-       spikeInh nS <-inhibitory spike
-       spikeExc nS <-excitatory spike
-       I_stim pA <-current
-     end
+        inline I_Na  pA = g_Na * _subexpr(V_m) * Inact_h * ( V_m - E_Na )
+        inline I_K   pA  = g_K * Act_n**4 * ( V_m - E_K )
+        inline I_L   pA = g_L * ( V_m - E_L )
 
-     output: spike
+        V_m' =( -( I_Na + I_K + I_L ) + I_e + I_stim + I_syn_inh + I_syn_exc ) / C_m
+        Act_n' = ( alpha_n(V_m) * ( 1 - Act_n ) - beta_n(V_m) * Act_n )  # n-variable
+        Inact_h' = ( alpha_h(V_m) * ( 1 - Inact_h ) - beta_h(V_m) * Inact_h ) # h-variable
+      end
 
-     update:
-       U_old mV = V_m
-       integrate_odes()
-       /* sending spikes: crossing 0 mV, pseudo-refractoriness and local maximum...*/
+      parameters:
+        t_ref ms = 2.0 ms           # Refractory period
+        g_Na nS = 3500.0 nS         # Sodium peak conductance
+        g_K nS = 900.0 nS           # Potassium peak conductance
+        g_L nS = 10 nS              # Leak conductance
+        C_m pF = 100.0 pF           # Membrane Capacitance
+        E_Na mV = 55.0 mV           # Sodium reversal potential
+        E_K mV = -90.0 mV           # Potassium reversal potentia
+        E_L mV = -65.0 mV           # Leak reversal Potential (aka resting potential)
+        V_Tr mV = -55.0 mV          # Spike Threshold
+        tau_syn_ex ms = 0.2 ms      # Rise time of the excitatory synaptic alpha function i
+        tau_syn_in ms = 10.0 ms     # Rise time of the inhibitory synaptic alpha function
+        E_ex mV = 0.0 mV            # Excitatory synaptic reversal potential
+        E_in mV = -75.0 mV          # Inhibitory synaptic reversal potential
 
-       /* sending spikes: crossing 0 mV, pseudo-refractoriness and local maximum...*/
-       if r > 0: # is refractory?
-         r -= 1
-       elif V_m > V_Tr and U_old > V_m:
-         r = RefractoryCounts
-         emit_spike()
-       end
-     end
+        # constant external input current
+        I_e pA = 0 pA
+      end
 
-   end
+      internals:
+        RefractoryCounts integer = steps(t_ref) # refractory time in steps
+
+        alpha_n_init 1/ms = -0.05/(ms*mV) * (E_L + 34.0 mV) / (exp(-0.1 * (E_L + 34.0 mV)) - 1.0)
+        beta_n_init  1/ms = 0.625/ms * exp(-(E_L + 44.0 mV) / 80.0 mV)
+        alpha_h_init 1/ms = 0.35/ms * exp(-(E_L + 58.0 mV) / 20.0 mV)
+        beta_h_init  1/ms = 5.0 / (exp(-0.1 / mV * (E_L + 28.0 mV)) + 1.0) /ms
+      end
+
+      input:
+        spikeInh nS <- inhibitory spike
+        spikeExc nS <- excitatory spike
+        I_stim pA <- current
+      end
+
+      output: spike
+
+      update:
+        U_old mV = V_m
+        integrate_odes()
+        # sending spikes: crossing 0 mV, pseudo-refractoriness and local maximum...
+        if r > 0: # is refractory?
+          r -= 1
+        elif V_m > V_Tr and U_old > V_m: # threshold && maximum
+          r = RefractoryCounts
+          emit_spike()
+        end
+      end
+
+      function _subexpr(V_m mV) real:
+        return alpha_m(V_m)**3 / ( alpha_m(V_m) + beta_m(V_m) )**3
+      end
+
+      function alpha_m(V_m mV) 1/ms:
+        return 0.1/(ms*mV) * (V_m + 35.0 mV) / (1.0 - exp(-0.1 mV * (V_m + 35.0 mV)))
+      end
+
+      function beta_m(V_m mV) 1/ms:
+        return 4.0/(ms) * exp(-(V_m + 60.0 mV) / 18.0 mV)
+      end
+
+      function alpha_n(V_m mV) 1/ms:
+        return -0.05/(ms*mV) * (V_m + 34.0 mV) / (exp(-0.1 * (V_m + 34.0 mV)) - 1.0)
+      end
+
+      function beta_n(V_m mV) 1/ms:
+        return 0.625/ms * exp(-(V_m + 44.0 mV) / 80.0 mV)
+      end
+
+      function alpha_h(V_m mV) 1/ms:
+        return 0.35/ms * exp(-(V_m + 58.0 mV) / 20.0 mV)
+      end
+
+      function beta_h(V_m mV) 1/ms:
+        return 5.0 / (exp(-0.1 / mV * (V_m + 28.0 mV)) + 1.0) /ms
+      end
+
+    end
+
 
 
 

--- a/doc/models_library/wb_cond_multisyn.rst
+++ b/doc/models_library/wb_cond_multisyn.rst
@@ -151,144 +151,177 @@ Source code
 
 .. code:: nestml
 
-   neuron wb_cond_multisyn:
-     state:
-       r integer  # number of steps in the current refractory phase
-     end
-     initial_values:
-       V_m mV = -65.0mV # Membrane potential
+    neuron wb_cond_multisyn:
+      state:
+        r integer = 0 # number of steps in the current refractory phase
 
-       /* function alpha_n_init real = 0.032 * (V_m / mV + 52.) / (1. - exp(-(V_m / mV + 52.) / 5.))     */
-       function alpha_n_init real = -0.05 * (V_m / mV + 34.0) / (exp(-0.1 * (V_m / mV + 34.0)) - 1.0)
-       function beta_n_init real = 0.625 * exp(-(V_m / mV + 44.0) / 80.0)
-       function alpha_m_init real = 0.1 * (V_m / mV + 35.0) / (1.0 - exp(-0.1mV * (V_m / mV + 35.0mV)))
-       function beta_m_init real = 4.0 * exp(-(V_m / mV + 60.0) / 18.0)
-       function alpha_h_init real = 0.35 * exp(-(V_m / mV + 58.0) / 20.0)
-       function beta_h_init real = 5.0 / (exp(-0.1 * (V_m / mV + 28.0)) + 1.0)
+        V_m mV = -65. mV # Membrane potential
+        Inact_h real = alpha_h_init / ( alpha_h_init + beta_h_init )    # Inactivation variable h for Na
+        Act_n real = alpha_n_init / (alpha_n_init + beta_n_init)  # Activation variable n for K
 
-       /* Act_m real =  alpha_m_init / ( alpha_m_init + beta_m_init )    Activation variable m for Na*/
-       Inact_h real = alpha_h_init / (alpha_h_init + beta_h_init) # Inactivation variable h for Na
-       Act_n real = alpha_n_init / (alpha_n_init + beta_n_init) # Activation variable n for K
-       g_AMPA nS = 0.0nS
-       g_AMPA__d nS/ms = 0.0nS / ms
-       g_NMDA nS = 0.0nS
-       g_NMDA__d nS/ms = 0.0nS / ms
-       g_GABAA nS = 0.0nS
-       g_GABAA__d nS/ms = 0.0nS / ms
-       g_GABAB nS = 0.0nS
-       g_GABAB__d nS/ms = 0.0nS / ms
-     end
-     equations:
-   recordable    function I_syn_ampa pA = -g_AMPA * (V_m - AMPA_E_rev)
-   recordable    function I_syn_nmda pA = -g_NMDA * (V_m - NMDA_E_rev) / (1 + exp((NMDA_Vact - V_m) / NMDA_Sact))
-   recordable    function I_syn_gaba_a pA = -g_GABAA * (V_m - GABA_A_E_rev)
-   recordable    function I_syn_gaba_b pA = -g_GABAB * (V_m - GABA_B_E_rev)
-   recordable    function I_syn pA = I_syn_ampa + I_syn_nmda + I_syn_gaba_a + I_syn_gaba_b
-       function alpha_n real = -0.05 * (V_m / mV + 34.0) / (exp(-0.1 * (V_m / mV + 34.0)) - 1.0)
-       function beta_n real = 0.625 * exp(-(V_m / mV + 44.0) / 80.0)
-       function alpha_m real = 0.1 * (V_m / mV + 35.0) / (1.0 - exp(-0.1mV * (V_m / mV + 35.0mV)))
-       function beta_m real = 4.0 * exp(-(V_m / mV + 60.0) / 18.0)
-       function alpha_h real = 0.35 * exp(-(V_m / mV + 58.0) / 20.0)
-       function beta_h real = 5.0 / (exp(-0.1 * (V_m / mV + 28.0)) + 1.0)
-       function Act_m_inf real = alpha_m / (alpha_m + beta_m)
-       function I_Na pA = g_Na * Act_m_inf * Act_m_inf * Act_m_inf * Inact_h * (V_m - E_Na)
-       function I_K pA = g_K * Act_n * Act_n * Act_n * Act_n * (V_m - E_K)
-       function I_L pA = g_L * (V_m - E_L)
-       Inact_h'=(alpha_h * (1 - Inact_h) - beta_h * Inact_h) / ms # h-variable
-       Act_n'=(alpha_n * (1 - Act_n) - beta_n * Act_n) / ms # n-variable
-       V_m'=(-(I_Na + I_K + I_L) + I_e + I_stim + I_syn) / C_m
-       g_AMPA__d'=-g_AMPA__d / AMPA_Tau_1
-       g_AMPA'=g_AMPA__d - g_AMPA / AMPA_Tau_2
-       g_NMDA__d'=-g_NMDA__d / NMDA_Tau_1
-       g_NMDA'=g_NMDA__d - g_NMDA / NMDA_Tau_2
-       g_GABAA__d'=-g_GABAA__d / GABA_A_Tau_1
-       g_GABAA'=g_GABAA__d - g_GABAA / GABA_A_Tau_2
-       g_GABAB__d'=-g_GABAB__d / GABA_B_Tau_1
-       g_GABAB'=g_GABAB__d - g_GABAB / GABA_B_Tau_2
-     end
+        g_AMPA real = 0
+        g_NMDA real = 0
+        g_GABAA real = 0
+        g_GABAB real = 0
+        g_AMPA$ real = AMPAInitialValue
+        g_NMDA$ real = NMDAInitialValue
+        g_GABAA$ real = GABA_AInitialValue
+        g_GABAB$ real = GABA_BInitialValue
+      end
 
-     parameters:
-       t_ref ms = 2.0ms # Refractory period 2.0
-       g_Na nS = 3500.0nS # Sodium peak conductance
-       g_K nS = 900.0nS # Potassium peak conductance
-       g_L nS = 10nS # Leak conductance
-       C_m pF = 100.0pF # Membrane Capacitance
-       E_Na mV = 55.0mV # Sodium reversal potential
-       E_K mV = -90.0mV # Potassium reversal potentia
-       E_L mV = -65.0mV # Leak reversal Potential (aka resting potential)
-       V_Tr mV = -55.0mV # Spike Threshold
+      equations:
+        recordable inline I_syn_ampa pA = -convolve(g_AMPA, AMPA) * ( V_m - AMPA_E_rev )
+        recordable inline I_syn_nmda pA = -convolve(g_NMDA, NMDA) * ( V_m - NMDA_E_rev ) / ( 1 + exp( ( NMDA_Vact - V_m ) / NMDA_Sact ) )
+        recordable inline I_syn_gaba_a pA = -convolve(g_GABAA, GABA_A) * ( V_m - GABA_A_E_rev )
+        recordable inline I_syn_gaba_b pA = -convolve(g_GABAB, GABA_B) * ( V_m - GABA_B_E_rev )
+        recordable inline I_syn pA = I_syn_ampa + I_syn_nmda + I_syn_gaba_a + I_syn_gaba_b
 
-       /* Parameters for synapse of type AMPA, GABA_A, GABA_B and NMDA*/
-       AMPA_g_peak nS = 0.1nS # peak conductance
-       AMPA_E_rev mV = 0.0mV # reversal potential
-       AMPA_Tau_1 ms = 0.5ms # rise time
-       AMPA_Tau_2 ms = 2.4ms # decay time, Tau_1 < Tau_2
-       NMDA_g_peak nS = 0.075nS # peak conductance
-       NMDA_Tau_1 ms = 4.0ms # rise time
-       NMDA_Tau_2 ms = 40.0ms # decay time, Tau_1 < Tau_2
-       NMDA_E_rev mV = 0.0mV # reversal potential
-       NMDA_Vact mV = -58.0mV # inactive for V << Vact, inflection of sigmoid
-       NMDA_Sact mV = 2.5mV # scale of inactivation
-       GABA_A_g_peak nS = 0.33nS # peak conductance
-       GABA_A_Tau_1 ms = 1.0ms # rise time
-       GABA_A_Tau_2 ms = 7.0ms # decay time, Tau_1 < Tau_2
-       GABA_A_E_rev mV = -70.0mV # reversal potential
-       GABA_B_g_peak nS = 0.0132nS # peak conductance
-       GABA_B_Tau_1 ms = 60.0ms # rise time
-       GABA_B_Tau_2 ms = 200.0ms # decay time, Tau_1 < Tau_2
-       GABA_B_E_rev mV = -90.0mV # reversal potential for intrinsic current
+        inline I_Na  pA = g_Na * Act_m_inf(V_m)**3 * Inact_h * ( V_m - E_Na )
+        inline I_K   pA = g_K * Act_n**4 * ( V_m - E_K )
+        inline I_L   pA = g_L * ( V_m - E_L )
 
-       /* constant external input current*/
-       I_e pA = 0pA
-     end
-     internals:
-       AMPAInitialValue real = compute_synapse_constant(AMPA_Tau_1,AMPA_Tau_2,AMPA_g_peak)
-       NMDAInitialValue real = compute_synapse_constant(NMDA_Tau_1,NMDA_Tau_2,NMDA_g_peak)
-       GABA_AInitialValue real = compute_synapse_constant(GABA_A_Tau_1,GABA_A_Tau_2,GABA_A_g_peak)
-       GABA_BInitialValue real = compute_synapse_constant(GABA_B_Tau_1,GABA_B_Tau_2,GABA_B_g_peak)
-       RefractoryCounts integer = steps(t_ref) # refractory time in steps
-     end
-     input:
-       AMPA nS <-spike
-       NMDA nS <-spike
-       GABA_A nS <-spike
-       GABA_B nS <-spike
-       I_stim pA <-current
-     end
+        Inact_h' = ( alpha_h(V_m) * ( 1 - Inact_h ) - beta_h(V_m) * Inact_h ) / ms # h-variable
+        Act_n' = ( alpha_n(V_m) * ( 1 - Act_n ) - beta_n(V_m) * Act_n ) / ms # n-variable
+        V_m' = ( -( I_Na + I_K + I_L ) + I_e + I_stim + I_syn ) / C_m
 
-     output: spike
 
-     update:
-       U_old mV = V_m
-       integrate_odes()
-       g_AMPA__d += AMPAInitialValue * AMPA / ms
-       g_NMDA__d += NMDAInitialValue * NMDA / ms
-       g_GABAA__d += GABA_AInitialValue * GABA_A / ms
-       g_GABAB__d += GABA_BInitialValue * GABA_B / ms
+        #############
+        # Synapses
+        #############
 
-       /* sending spikes: */
-       if r > 0: # is refractory?
-         r -= 1
-       elif V_m > V_Tr and U_old > V_m:
-         r = RefractoryCounts
-         emit_spike()
-       end
-     end
+        kernel g_AMPA' = g_AMPA$ - g_AMPA / AMPA_Tau_2,
+               g_AMPA$' = -g_AMPA$ / AMPA_Tau_1
 
-   function compute_synapse_constant(Tau_1 msTau_2 msg_peak real) real:
+        kernel g_NMDA' = g_NMDA$ - g_NMDA / NMDA_Tau_2,
+               g_NMDA$' = -g_NMDA$ / NMDA_Tau_1
 
-       /* Factor used to account for the missing 1/((1/Tau_2)-(1/Tau_1)) term*/
-       /* in the ht_neuron_dynamics integration of the synapse terms.*/
-       /* See: Exact digital simulation of time-invariant linear systems*/
-       /* with applications to neuronal modeling, Rotter and Diesmann,*/
-       /* section 3.1.2.*/
-       exact_integration_adjustment real = ((1 / Tau_2) - (1 / Tau_1)) * ms
-       t_peak real = (Tau_2 * Tau_1) * ln(Tau_2 / Tau_1) / (Tau_2 - Tau_1) / ms
-       normalisation_factor real = 1 / (exp(-t_peak / Tau_1) - exp(-t_peak / Tau_2))
-       return g_peak * normalisation_factor * exact_integration_adjustment
-   end
+        kernel g_GABAA' = g_GABAA$ - g_GABAA / GABA_A_Tau_2,
+               g_GABAA$' = -g_GABAA$ / GABA_A_Tau_1
 
-   end
+        kernel g_GABAB' = g_GABAB$ - g_GABAB / GABA_B_Tau_2,
+               g_GABAB$' = -g_GABAB$ / GABA_B_Tau_1
+      end
+
+      parameters:
+        t_ref ms = 2.0 ms      # Refractory period 2.0
+        g_Na nS = 3500.0 nS    # Sodium peak conductance
+        g_K nS = 900.0 nS      # Potassium peak conductance
+        g_L nS = 10 nS          # Leak conductance
+        C_m pF = 100.0 pF       # Membrane Capacitance
+        E_Na mV = 55.0 mV         # Sodium reversal potential
+        E_K mV = -90.0 mV        # Potassium reversal potentia
+        E_L mV = -65.0 mV     # Leak reversal Potential (aka resting potential)
+        V_Tr mV = -55.0 mV        # Spike Threshold
+
+        # Parameters for synapse of type AMPA, GABA_A, GABA_B and NMDA
+        AMPA_g_peak nS = 0.1 nS      # peak conductance
+        AMPA_E_rev mV = 0.0 mV       # reversal potential
+        AMPA_Tau_1 ms = 0.5 ms       # rise time
+        AMPA_Tau_2 ms = 2.4 ms       # decay time, Tau_1 < Tau_2
+
+        NMDA_g_peak nS = 0.075 nS    # peak conductance
+        NMDA_Tau_1 ms = 4.0 ms       # rise time
+        NMDA_Tau_2 ms = 40.0 ms      # decay time, Tau_1 < Tau_2
+        NMDA_E_rev mV = 0.0 mV       # reversal potential
+        NMDA_Vact mV = -58.0 mV      # inactive for V << Vact, inflection of sigmoid
+        NMDA_Sact mV = 2.5 mV        # scale of inactivation
+
+        GABA_A_g_peak nS = 0.33 nS   # peak conductance
+        GABA_A_Tau_1 ms = 1.0 ms     # rise time
+        GABA_A_Tau_2 ms = 7.0 ms     # decay time, Tau_1 < Tau_2
+        GABA_A_E_rev mV = -70.0 mV   # reversal potential
+
+        GABA_B_g_peak nS = 0.0132 nS # peak conductance
+        GABA_B_Tau_1 ms = 60.0 ms    # rise time
+        GABA_B_Tau_2 ms = 200.0 ms   # decay time, Tau_1 < Tau_2
+        GABA_B_E_rev mV = -90.0 mV   # reversal potential for intrinsic current
+
+        # constant external input current
+        I_e pA = 0 pA
+      end
+
+      internals:
+        AMPAInitialValue real = compute_synapse_constant( AMPA_Tau_1, AMPA_Tau_2, AMPA_g_peak )
+        NMDAInitialValue real = compute_synapse_constant( NMDA_Tau_1, NMDA_Tau_2, NMDA_g_peak )
+        GABA_AInitialValue real = compute_synapse_constant( GABA_A_Tau_1, GABA_A_Tau_2, GABA_A_g_peak )
+        GABA_BInitialValue real = compute_synapse_constant( GABA_B_Tau_1, GABA_B_Tau_2, GABA_B_g_peak )
+        RefractoryCounts integer = steps(t_ref) # refractory time in steps
+
+        alpha_n_init real = -0.05 * (V_m / mV + 34.0) / (exp(-0.1 * (V_m / mV + 34.0)) - 1.0)
+        beta_n_init  real = 0.625 * exp(-(V_m / mV + 44.0) / 80.0)
+        alpha_m_init real = 0.1 * (V_m / mV + 35.0) / (1.0 - exp(-0.1 * (V_m / mV + 35.)))
+        beta_m_init  real = 4.0 * exp(-(V_m / mV + 60.0) / 18.0)
+        alpha_h_init real = 0.35 * exp(-(V_m / mV + 58.0) / 20.0)
+        beta_h_init  real = 5.0 / (exp(-0.1 * (V_m / mV + 28.0)) + 1.0)
+      end
+
+      input:
+        AMPA nS  <- spike
+        NMDA nS  <- spike
+        GABA_A nS <- spike
+        GABA_B nS <- spike
+        I_stim pA <- current
+      end
+
+      output: spike
+
+      update:
+        U_old mV = V_m
+        integrate_odes()
+
+        # sending spikes:
+        if r > 0: # is refractory?
+          r -= 1
+        elif V_m > V_Tr and U_old > V_m: # threshold && maximum
+          r = RefractoryCounts
+          emit_spike()
+        end
+
+      end
+
+      function compute_synapse_constant(Tau_1 ms, Tau_2 ms, g_peak nS) real:
+        # Factor used to account for the missing 1/((1/Tau_2)-(1/Tau_1)) term
+        # in the ht_neuron_dynamics integration of the synapse terms.
+        # See: Exact digital simulation of time-invariant linear systems
+        # with applications to neuronal modeling, Rotter and Diesmann,
+        # section 3.1.2.
+        exact_integration_adjustment real = ( ( 1 / Tau_2 ) - ( 1 / Tau_1 ) ) * ms
+
+        t_peak ms = ( Tau_2 * Tau_1 ) * ln( Tau_2 / Tau_1 ) / ( Tau_2 - Tau_1 )
+        normalisation_factor real = 1 / ( exp( -t_peak / Tau_1 ) - exp( -t_peak / Tau_2 ) )
+
+        return (g_peak / nS) * normalisation_factor * exact_integration_adjustment
+      end
+
+      function Act_m_inf(V_m mV) real:
+        return alpha_m(V_m) / ( alpha_m(V_m) + beta_m(V_m) )
+      end
+
+      function alpha_m(V_m mV) real:
+        return 0.1 * (V_m / mV + 35.0) / (1.0 - exp(-0.1 * (V_m / mV + 35.)))
+      end
+
+      function beta_m(V_m mV) real:
+        return 4.0 * exp(-(V_m / mV + 60.0) / 18.0)
+      end
+
+      function alpha_n(V_m mV) real:
+        return -0.05 * (V_m / mV + 34.0) / (exp(-0.1 * (V_m / mV + 34.0)) - 1.0)
+      end
+
+      function beta_n(V_m mV) real:
+        return 0.625 * exp(-(V_m / mV + 44.0) / 80.0)
+      end
+
+      function alpha_h(V_m mV) real:
+        return 0.35 * exp(-(V_m / mV + 58.0) / 20.0)
+      end
+
+      function beta_h(V_m mV) real:
+        return 5.0 / (exp(-0.1 * (V_m / mV + 28.0)) + 1.0)
+      end
+
+    end
 
 
 

--- a/doc/nestml_language.rst
+++ b/doc/nestml_language.rst
@@ -677,8 +677,7 @@ Block types
 Within the top-level block, the following blocks may be defined:
 
 -  ``parameters`` - This block is composed of a list of variable declarations that are supposed to contain all parameters which remain constant during the simulation, but can vary among different simulations or instantiations of the same neuron. These variables can be set and read by the user using ``nest.SetStatus(<gid>, <variable>, <value>)`` and ``nest.GetStatus(<gid>, <variable>)``.
--  ``state`` - This block is composed of a list of variable declarations that are supposed to describe parts of the neuron which may change over time.
--  ``initial_values`` - This block describes the initial values of all stated differential equations. Only variables from this block can be further defined with differential equations. The variables in this block can be recorded using a ``multimeter``.
+-  ``state`` - This block is composed of a list of variable declarations that are supposed to describe parts of the neuron which may change over time. All the variables declared in this block must be initialized with a value.
 -  ``internals`` - This block is composed of a list of implementation-dependent helper variables that supposed to be constant during the simulation run. Therefore, their initialization expression can only reference parameters or other internal variables.
 -  ``equations`` - This block contains kernel definitions and differential equations. It will be explained in further detail `later on in the manual <#equations>`__.
 -  ``input`` - This block is composed of one or more input ports. It will be explained in further detail `later on in the manual <#input>`__.
@@ -755,7 +754,7 @@ The type of the convolution is equal to the type of the second parameter, that i
 
 When convolutions are used, additional state variables are required for each pair *(shape, spike input port)* that appears as the parameters in a convolution. These variables track the dynamical state of that kernel, for that input port. The number of variables created corresponds to the dimensionality of the kernel. For example, in the code block above, the one-dimensional kernel ``G`` is used in a convolution with spiking input port ``spikes``. During code generation, a new state variable called ``G__conv__spikes`` is created for this combination, by joining together the name of the kernel with the name of the spike buffer using (by default) the string “__conv__”. If the same kernel is used later in a convolution with another spiking input port, say ``spikes_GABA``, then the resulting generated variable would be called ``G__conv__spikes_GABA``, allowing independent synaptic integration between input ports but allowing the same kernel to be used more than once.
 
-The process of generating extra state variables for keeping track of convolution state is normally hidden from the user. For some models, however, it might be required to set or reset the state of synaptic integration, which is stored in these internally generated variables. For example, we might want to set the synaptic current (and its rate of change) to 0 when firing a dendritic action potential. Although we would like to set the generated variable ``G__conv__spikes`` to 0 in the running example, a variable by this name is only generated during code generation, and does not exist in the namespace of the NESTML model to begin with. To still allow refering to this state in the context of the model, it is recommended to use an inline expression, with only a convolution on the right-hand side.
+The process of generating extra state variables for keeping track of convolution state is normally hidden from the user. For some models, however, it might be required to set or reset the state of synaptic integration, which is stored in these internally generated variables. For example, we might want to set the synaptic current (and its rate of change) to 0 when firing a dendritic action potential. Although we would like to set the generated variable ``G__conv__spikes`` to 0 in the running example, a variable by this name is only generated during code generation, and does not exist in the namespace of the NESTML model to begin with. To still allow referring to this state in the context of the model, it is recommended to use an inline expression, with only a convolution on the right-hand side.
 
 For example, suppose we define:
 
@@ -897,7 +896,7 @@ in the ``equations`` block,
 
    V mV = 0 mV
 
-has to be stated in the ``initial_values`` block. Otherwise, an error message is generated.
+has to be defined in the ``state`` block. Otherwise, an error message is generated.
 
 The content of spike and current buffers can be used by just using their plain names. NESTML takes care behind the scenes that the buffer location at the current simulation time step is used.
 
@@ -940,11 +939,11 @@ Equivalently, the same exponentially decaying kernel can be formulated as a diff
 
    kernel g' = -g / tau
 
-In this case, initial values have to be specified up to the order of the differential equation, e.g.:
+In this case, initial values have to be specified in the ``state`` block up to the order of the differential equation, e.g.:
 
 .. code-block:: nestml
 
-   initial_values:
+   state:
      g real = 1
    end
 
@@ -969,7 +968,7 @@ An example second-order kernel is the dual exponential ("alpha") kernel, which c
 
     .. code-block:: nestml
 
-       initial_values:
+       state:
          g real = 0
          g$ real = 1
        end
@@ -986,7 +985,7 @@ An example second-order kernel is the dual exponential ("alpha") kernel, which c
 
     .. code-block:: nestml
 
-       initial_values:
+       state:
          g real = 0
          g' ms**-1 = e / tau
        end
@@ -1045,7 +1044,7 @@ In order to model refractory and non-refractory states, two variables are necess
 Setting and retrieving model properties
 ---------------------------------------
 
--  All variables in the ``state``, ``parameters`` and ``initial_values`` blocks are added to the status dictionary of the neuron.
+-  All variables in the ``state`` and ``parameters`` blocks are added to the status dictionary of the neuron.
 -  Values can be set using ``nest.SetStatus(<gid>, <variable>, <value>)`` where ``<variable>`` is the name of the corresponding NESTML variable.
 -  Values can be read using ``nest.GetStatus(<gid>, <variable>)``. This call will return the value of the corresponding NESTML variable.
 
@@ -1053,7 +1052,7 @@ Setting and retrieving model properties
 Recording values with devices
 -----------------------------
 
--  All values in the ``state`` and ``initial_values`` blocks are recordable by a ``multimeter`` in NEST.
+-  All values in the ``state`` block are recordable by a ``multimeter`` in NEST.
 -  The ``recordable`` keyword can be used to also make ``inline`` expressions in the ``equations`` block available to recording devices.
 
 .. code-block:: nestml
@@ -1067,7 +1066,7 @@ Recording values with devices
 Guards
 ------
 
-Variables which are defined in the ``state`` and ``parameters`` blocks can optionally be secured through  guards. These guards are checked during the call to ``nest.SetStatus()`` in NEST.
+Variables which are defined in the ``state`` and ``parameters`` blocks can optionally be secured through guards. These guards are checked during the call to ``nest.SetStatus()`` in NEST.
 
 ::
 

--- a/doc/nestml_language.rst
+++ b/doc/nestml_language.rst
@@ -677,7 +677,7 @@ Block types
 Within the top-level block, the following blocks may be defined:
 
 -  ``parameters`` - This block is composed of a list of variable declarations that are supposed to contain all parameters which remain constant during the simulation, but can vary among different simulations or instantiations of the same neuron. These variables can be set and read by the user using ``nest.SetStatus(<gid>, <variable>, <value>)`` and ``nest.GetStatus(<gid>, <variable>)``.
--  ``state`` - This block is composed of a list of variable declarations that are supposed to describe parts of the neuron which may change over time. All the variables declared in this block must be initialized with a value.
+-  ``state`` - This block is composed of a list of variable declarations that describe parts of the neuron which may change over time. All the variables declared in this block must be initialized with a value.
 -  ``internals`` - This block is composed of a list of implementation-dependent helper variables that supposed to be constant during the simulation run. Therefore, their initialization expression can only reference parameters or other internal variables.
 -  ``equations`` - This block contains kernel definitions and differential equations. It will be explained in further detail `later on in the manual <#equations>`__.
 -  ``input`` - This block is composed of one or more input ports. It will be explained in further detail `later on in the manual <#input>`__.

--- a/doc/tutorials/active_dendrite/nestml_active_dendrite_tutorial.ipynb
+++ b/doc/tutorials/active_dendrite/nestml_active_dendrite_tutorial.ipynb
@@ -99,7 +99,7 @@
    "source": [
     "nestml_active_dend_model = '''\n",
     "neuron iaf_psc_exp_active_dendrite:\n",
-    "  initial_values:\n",
+    "  state:\n",
     "    V_m mV = 0 mV     # membrane potential\n",
     "    t_dAP ms = 0 ms   # dendritic action potential timer\n",
     "    I_dAP pA = 0 pA   # dendritic action potential current magnitude\n",
@@ -411,7 +411,7 @@
    "source": [
     "nestml_active_dend_reset_model = '''\n",
     "neuron iaf_psc_exp_active_dendrite_resetting:\n",
-    "  initial_values:\n",
+    "  state:\n",
     "    V_m mV = 0 mV     # membrane potential\n",
     "    t_dAP ms = 0 ms   # dendritic action potential timer\n",
     "    I_dAP pA = 0 pA   # dendritic action potential current magnitude\n",

--- a/doc/tutorials/izhikevich/izhikevich_solution.nestml
+++ b/doc/tutorials/izhikevich/izhikevich_solution.nestml
@@ -1,6 +1,6 @@
 neuron izhikevich_tutorial:
 
-  initial_values:
+  state:
     v mV = -65 mV    # Membrane potential in mV
     u real = 0    # Membrane potential recovery variable
   end

--- a/doc/tutorials/izhikevich/izhikevich_task.nestml
+++ b/doc/tutorials/izhikevich/izhikevich_task.nestml
@@ -1,6 +1,6 @@
 neuron izhikevich_tutorial:
 
-  initial_values:
+  state:
     v mV = -65 mV    # Membrane potential in mV
 
     # TODO: add new variable u with the type real

--- a/doc/tutorials/ornstein_uhlenbeck_noise/nestml_ou_noise_tutorial.ipynb
+++ b/doc/tutorials/ornstein_uhlenbeck_noise/nestml_ou_noise_tutorial.ipynb
@@ -464,7 +464,7 @@
     "iaf_psc_exp = '''\n",
     "neuron iaf_psc_exp:\n",
     "\n",
-    "  initial_values:\n",
+    "  state:\n",
     "    V_m mV = E_L\n",
     "    I_noise pA = mean_noise\n",
     "  end\n",


### PR DESCRIPTION
This PR is related to the changes in #636 

- Remove the `initial_values` block from language documentation
- Modify the .rst files for the models to have the latest nestml model code