### PR TITLE
Fix code generation for while and for loops

### DIFF
--- a/pynestml/codegeneration/resources_nest/directives/CompoundStatement.jinja2
+++ b/pynestml/codegeneration/resources_nest/directives/CompoundStatement.jinja2
@@ -8,11 +8,11 @@
 {%- include "directives/IfStatement.jinja2" -%}
 {%- endwith -%}
 {%- elif stmt.is_for_stmt() -%}
-{%- with ast = stmt.get_for_stmt() -%}}
+{%- with ast = stmt.get_for_stmt() -%}
 {%- include "directives/ForStatement.jinja2" -%}
 {%- endwith -%}
 {%- elif stmt.is_while_stmt() -%}
-{%- with ast = stmt.get_while_stmt() -%}}
+{%- with ast = stmt.get_while_stmt() -%}
 {%- include "directives/WhileStatement.jinja2" -%}
 {%- endwith -%}
 {%- endif -%}

--- a/tests/nest_tests/nest_loops_integration_test.py
+++ b/tests/nest_tests/nest_loops_integration_test.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+# nest_loops_integration_test.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+import os
+import unittest
+import numpy as np
+
+import nest
+
+from pynestml.frontend.pynestml_frontend import to_nest, install_nest
+
+
+class NestLoopsIntegrationTest(unittest.TestCase):
+    """
+    Tests the code generation and working of for and while loops from NESTML to NEST
+    """
+
+    def test_for_and_while_loop(self):
+        files = ["ForLoop.nestml", "WhileLoop.nestml"]
+        input_path = [os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), "resources", s))) for s in
+                      files]
+        nest_path = nest.ll_api.sli_func("statusdict/prefix ::")
+        target_path = 'target'
+        logging_level = 'INFO'
+        module_name = 'nestmlmodule'
+        store_log = False
+        suffix = '_nestml'
+        dev = True
+        to_nest(input_path, target_path, logging_level, module_name, store_log, suffix, dev)
+        install_nest(target_path, nest_path)
+        nest.set_verbosity("M_ALL")
+
+        nest.ResetKernel()
+        nest.Install("nestmlmodule")
+
+        nrn = nest.Create("for_loop_nestml")
+        mm = nest.Create('multimeter')
+        mm.set({"record_from": ["V_m"]})
+
+        nest.Connect(mm, nrn)
+
+        nest.Simulate(5.0)
+
+        v_m = mm.get("events")["V_m"]
+        np.testing.assert_almost_equal(v_m[-1], 16.6)
+
+        nest.ResetKernel()
+        nrn = nest.Create("while_loop_nestml")
+
+        mm = nest.Create('multimeter')
+        mm.set({"record_from": ["y"]})
+
+        nest.Connect(mm, nrn)
+
+        nest.Simulate(5.0)
+        y = mm.get("events")["y"]
+        np.testing.assert_almost_equal(y[-1], 5.011)

--- a/tests/nest_tests/resources/ForLoop.nestml
+++ b/tests/nest_tests/resources/ForLoop.nestml
@@ -1,0 +1,45 @@
+"""
+ForLoop.nestml
+##############
+
+
+Copyright statement
++++++++++++++++++++
+
+This file is part of NEST.
+
+Copyright (C) 2004 The NEST Initiative
+
+NEST is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+NEST is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+neuron for_loop:
+    state:
+        V_m mV = -0.20 mV
+    end
+
+    parameters:
+      N integer = 42
+    end
+
+    update:
+      k integer = 0
+      j integer = 0
+      for j in 0 ... N step 1:
+         k = j / N
+         V_m += 0.01 mV
+       end
+    end
+
+end

--- a/tests/nest_tests/resources/WhileLoop.nestml
+++ b/tests/nest_tests/resources/WhileLoop.nestml
@@ -1,0 +1,46 @@
+"""
+WhileLoop.nestml
+################
+
+
+Copyright statement
++++++++++++++++++++
+
+This file is part of NEST.
+
+Copyright (C) 2004 The NEST Initiative
+
+NEST is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+NEST is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+neuron while_loop:
+    state:
+        y real = 0.025
+    end
+
+    parameters:
+      N integer = 5
+    end
+
+    update:
+      k integer = 3
+      j integer = 0
+      while j <= N:
+        y = max(k, j)
+        y += 0.011
+        j += 1
+      end
+    end
+
+end


### PR DESCRIPTION
- Remove an extra `}` in the templates that generated code for `while` and `for` loops.
- Add NEST integration tests for `while` and `for` loops