### PR TITLE
Decrease verbosity of type system

### DIFF
--- a/pynestml/symbols/predefined_types.py
+++ b/pynestml/symbols/predefined_types.py
@@ -243,9 +243,6 @@ class PredefinedTypes:
         """
         if not symbol.is_primitive() and symbol.unit.get_name() not in cls.name2type.keys():
             cls.name2type[symbol.unit.get_name()] = symbol
-            code, message = Messages.get_new_type_registered(symbol.unit.get_name())
-            Logger.log_message(code=code, message=message, log_level=LoggingLevel.INFO)
-        return
 
     @classmethod
     def register_unit(cls, unit):

--- a/pynestml/utils/messages.py
+++ b/pynestml/utils/messages.py
@@ -27,38 +27,37 @@ class MessageCode(Enum):
     A mapping between codes and the corresponding messages.
     """
     START_PROCESSING_FILE = 0
-    TYPE_REGISTERED = 1
-    START_SYMBOL_TABLE_BUILDING = 2
-    FUNCTION_CALL_TYPE_ERROR = 3
-    TYPE_NOT_DERIVABLE = 4
-    IMPLICIT_CAST = 5
-    CAST_NOT_POSSIBLE = 6
-    TYPE_DIFFERENT_FROM_EXPECTED = 7
-    ADD_SUB_TYPE_MISMATCH = 8
-    BUFFER_SET_TO_CONDUCTANCE_BASED = 9
-    ODE_UPDATED = 10
-    NO_VARIABLE_FOUND = 11
-    SPIKE_INPUT_PORT_TYPE_NOT_DEFINED = 12
-    NEURON_CONTAINS_ERRORS = 13
-    START_PROCESSING_NEURON = 14
-    CODE_SUCCESSFULLY_GENERATED = 15
-    MODULE_SUCCESSFULLY_GENERATED = 16
-    NO_CODE_GENERATED = 17
-    VARIABLE_USED_BEFORE_DECLARATION = 18
-    VARIABLE_DEFINED_RECURSIVELY = 19
-    VALUE_ASSIGNED_TO_BUFFER = 20
-    ARG_NOT_KERNEL_OR_EQUATION = 21
-    ARG_NOT_SPIKE_INPUT = 22
-    NUMERATOR_NOT_ONE = 23
-    ORDER_NOT_DECLARED = 24
-    CONTINUOUS_INPUT_PORT_WITH_QUALIFIERS = 25
-    BLOCK_NOT_CORRECT = 26
-    VARIABLE_NOT_IN_STATE_BLOCK = 27
-    WRONG_NUMBER_OF_ARGS = 28
-    NO_RHS = 29
-    SEVERAL_LHS = 30
-    FUNCTION_REDECLARED = 31
-    FUNCTION_NOT_DECLARED = 52
+    START_SYMBOL_TABLE_BUILDING = 1
+    FUNCTION_CALL_TYPE_ERROR = 2
+    TYPE_NOT_DERIVABLE = 3
+    IMPLICIT_CAST = 4
+    CAST_NOT_POSSIBLE = 5
+    TYPE_DIFFERENT_FROM_EXPECTED = 6
+    ADD_SUB_TYPE_MISMATCH = 7
+    BUFFER_SET_TO_CONDUCTANCE_BASED = 8
+    ODE_UPDATED = 9
+    NO_VARIABLE_FOUND = 10
+    SPIKE_INPUT_PORT_TYPE_NOT_DEFINED = 11
+    NEURON_CONTAINS_ERRORS = 12
+    START_PROCESSING_NEURON = 13
+    CODE_SUCCESSFULLY_GENERATED = 14
+    MODULE_SUCCESSFULLY_GENERATED = 15
+    NO_CODE_GENERATED = 16
+    VARIABLE_USED_BEFORE_DECLARATION = 17
+    VARIABLE_DEFINED_RECURSIVELY = 18
+    VALUE_ASSIGNED_TO_BUFFER = 19
+    ARG_NOT_KERNEL_OR_EQUATION = 20
+    ARG_NOT_SPIKE_INPUT = 21
+    NUMERATOR_NOT_ONE = 22
+    ORDER_NOT_DECLARED = 23
+    CONTINUOUS_INPUT_PORT_WITH_QUALIFIERS = 24
+    BLOCK_NOT_CORRECT = 25
+    VARIABLE_NOT_IN_STATE_BLOCK = 26
+    WRONG_NUMBER_OF_ARGS = 27
+    NO_RHS = 28
+    SEVERAL_LHS = 29
+    FUNCTION_REDECLARED = 30
+    FUNCTION_NOT_DECLARED = 31
     NO_ODE = 32
     NO_INIT_VALUE = 33
     NEURON_REDECLARED = 34
@@ -125,18 +124,6 @@ class Messages:
         """
         message = 'Start processing \'' + file_path + '\'!'
         return MessageCode.START_PROCESSING_FILE, message
-
-    @classmethod
-    def get_new_type_registered(cls, type_name):
-        """
-        Returns a message which indicates that a new type has been registered.
-        :param type_name: a type name
-        :type type_name: str
-        :return: message code tuple
-        :rtype: (MessageCode,str)
-        """
-        message = 'New type registered \'%s\'!' % type_name
-        return MessageCode.TYPE_REGISTERED, message
 
     @classmethod
     def get_input_path_not_found(cls, path):


### PR DESCRIPTION
This eliminates messages about "new type registered" as there are usually quite many of these messages generated, but they are not terribly useful in debugging a model.

```
[6,iaf_psc_exp_dend_nestml, INFO]: New type registered '1 / ms'!
[7,iaf_psc_exp_dend_nestml, INFO]: New type registered 'mV / s'!
[8,iaf_psc_exp_dend_nestml, INFO]: New type registered 'mV / ms'!
[9,iaf_psc_exp_dend_nestml, INFO]: New type registered 'pA / pF'!
```