### PR TITLE
Fix/refactor types pretty printer in code generator

### DIFF
--- a/pynestml/codegeneration/cpp_types_printer.py
+++ b/pynestml/codegeneration/cpp_types_printer.py
@@ -33,16 +33,16 @@ class CppTypesPrinter(TypesPrinter):
     def pretty_print(cls, element):
         if isinstance(element, bool) and element:
             return 'true'
-        
+
         if isinstance(element, bool) and not element:
             return 'false'
-        
+
         if isinstance(element, int):
             return str(element)
-        
+
         if isinstance(element, float):
             return "{0:E}".format(element)
-        
+
         if isinstance(element, str):
             return element
 

--- a/pynestml/codegeneration/cpp_types_printer.py
+++ b/pynestml/codegeneration/cpp_types_printer.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# cpp_types_printer.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Tuple
+
+from pynestml.codegeneration.types_printer import TypesPrinter
+
+
+class CppTypesPrinter(TypesPrinter):
+    """
+    Returns a C++ syntax version of the handed over element.
+    """
+
+    @classmethod
+    def pretty_print(cls, element):
+        if isinstance(element, bool) and element:
+            return 'true'
+        
+        if isinstance(element, bool) and not element:
+            return 'false'
+        
+        if isinstance(element, int):
+            return str(element)
+        
+        if isinstance(element, float):
+            return "{0:E}".format(element)
+        
+        if isinstance(element, str):
+            return element
+
+        raise Exception("Tried to print unknown type: " + str(type(element)) + " (string representation: " + str(element) + ")")

--- a/pynestml/codegeneration/expressions_pretty_printer.py
+++ b/pynestml/codegeneration/expressions_pretty_printer.py
@@ -21,7 +21,7 @@
 
 from typing import Tuple
 
-from pynestml.codegeneration.i_reference_converter import IReferenceConverter
+from pynestml.codegeneration.cpp_types_printer import CppTypesPrinter
 from pynestml.codegeneration.nestml_reference_converter import NestMLReferenceConverter
 from pynestml.meta_model.ast_expression import ASTExpression
 from pynestml.meta_model.ast_expression_node import ASTExpressionNode
@@ -40,8 +40,6 @@ class ExpressionsPrettyPrinter:
     """
 
     def __init__(self, reference_converter=None, types_printer=None):
-        # type: (IReferenceConverter,TypesPrinter) -> None
-        # todo by kp: this should expect a ITypesPrinter as the second arg
         if reference_converter is not None:
             self.reference_converter = reference_converter
         else:
@@ -50,7 +48,7 @@ class ExpressionsPrettyPrinter:
         if types_printer is not None:
             self.types_printer = types_printer
         else:
-            self.types_printer = TypesPrinter()
+            self.types_printer = CppTypesPrinter()
 
     def print_expression(self, node, prefix=''):
         """Print an expression.
@@ -157,22 +155,3 @@ class ExpressionsPrettyPrinter:
             ret.append(self.print_expression(arg, prefix=prefix))
 
         return tuple(ret)
-
-
-class TypesPrinter:
-    """
-    Returns a processable format of the handed over element.
-    """
-
-    @classmethod
-    def pretty_print(cls, element):
-        assert (element is not None), \
-            '(PyNestML.CodeGeneration.PrettyPrinter) No element provided (%s)!' % element
-        if isinstance(element, bool) and element:
-            return 'true'
-        elif isinstance(element, bool) and not element:
-            return 'false'
-        elif isinstance(element, int) or isinstance(element, float):
-            return str(element)
-        elif isinstance(element, str):
-            return element

--- a/pynestml/codegeneration/latex_expression_printer.py
+++ b/pynestml/codegeneration/latex_expression_printer.py
@@ -23,29 +23,13 @@ from typing import Tuple
 
 from pynestml.codegeneration.i_reference_converter import IReferenceConverter
 from pynestml.codegeneration.latex_reference_converter import LatexReferenceConverter
+from pynestml.codegeneration.latex_types_printer import LatexTypesPrinter
 from pynestml.meta_model.ast_expression import ASTExpression
 from pynestml.meta_model.ast_expression_node import ASTExpressionNode
 from pynestml.meta_model.ast_function_call import ASTFunctionCall
 from pynestml.meta_model.ast_simple_expression import ASTSimpleExpression
 from pynestml.meta_model.ast_variable import ASTVariable
 from pynestml.utils.ast_utils import ASTUtils
-
-
-class TypesPrinter:
-    """
-    Returns a processable format of the handed over element.
-    """
-
-    @classmethod
-    def pretty_print(cls, element):
-        assert (element is not None), \
-            '(PyNestML.CodeGeneration.PrettyPrinter) No element provided (%s)!' % element
-        if isinstance(element, bool) and element:
-            return 'true'
-        elif isinstance(element, bool) and not element:
-            return 'false'
-        elif isinstance(element, int) or isinstance(element, float):
-            return str(element)
 
 
 class LatexExpressionPrinter:
@@ -58,7 +42,7 @@ class LatexExpressionPrinter:
         if types_printer is not None:
             self.types_printer = types_printer
         else:
-            self.types_printer = TypesPrinter()
+            self.types_printer = LatexTypesPrinter()
 
     def print_expression(self, node: ASTExpressionNode) -> str:
         return self.__do_print(node)

--- a/pynestml/codegeneration/latex_types_printer.py
+++ b/pynestml/codegeneration/latex_types_printer.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# latex_types_printer.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Tuple
+
+from pynestml.codegeneration.types_printer import TypesPrinter
+
+
+class LatexTypesPrinter(TypesPrinter):
+    """
+    Returns a LaTeX syntax version of the handed over element.
+    """
+
+    @classmethod
+    def pretty_print(cls, element):
+        if isinstance(element, bool) and element:
+            return 'true'
+
+        if isinstance(element, bool) and not element:
+            return 'false'
+
+        if isinstance(element, int) or isinstance(element, float):
+            return str(element)
+
+        raise Exception("Tried to print unknown type: " + str(type(element)) + " (string representation: " + str(element) + ")")

--- a/pynestml/codegeneration/types_printer.py
+++ b/pynestml/codegeneration/types_printer.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# types_printer.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+import abc
+
+
+class TypesPrinter(metaclass=abc.ABCMeta):
+    """
+    Returns a processable format of the handed over element.
+    """
+
+    @classmethod
+    @abc.abstractmethod
+    def pretty_print(cls, element):
+        pass


### PR DESCRIPTION
Real-valued NESTML quantities were being printed as integers, which caused confusion for the C++ compiler.

Additionally, refactored the types printers into their own files and inheritance hierarchy.