### PR TITLE
Use nest::names::Name instead of string for recordables names

### DIFF
--- a/pynestml/codegeneration/resources_nest/NeuronClass.jinja2
+++ b/pynestml/codegeneration/resources_nest/NeuronClass.jinja2
@@ -71,6 +71,21 @@ nest::RecordablesMap<{{neuronName}}> {{neuronName}}::recordablesMap_;
 
 namespace nest
 {
+
+namespace names
+{
+{%- if recordable_state_variables|length > 0 %}
+{%- for sym in recordable_state_variables %}
+    const Name {{sym.get_symbol_name()}}( "{{sym.get_symbol_name()}}" );
+{%- endfor %}
+{%- endif %}
+{%- if recordable_inline_expressions|length > 0 %}
+{%- for sym in recordable_inline_expressions %}
+    const Name {{sym.get_symbol_name()}}( "{{sym.get_symbol_name()}}" );
+{%- endfor %}
+{%- endif %}
+}
+
   // Override the create() method with one call to RecordablesMap::insert_()
   // for each quantity to be recorded.
   template <> void RecordablesMap<{{neuronName}}>::create()
@@ -78,14 +93,14 @@ namespace nest
 {%- if recordable_state_variables|length > 0 %}
     // add state variables to recordables map
 {%- for sym in recordable_state_variables %}
-    insert_("{{sym.get_symbol_name()}}", &{{neuronName}}::{{names.getter(sym)}});
+    insert_(names::{{sym.get_symbol_name()}}, &{{neuronName}}::{{names.getter(sym)}});
 {%- endfor %}
 {%- endif %}
 {%- if recordable_inline_expressions|length > 0 %}
 
     // add recordable inline expressions to recordables map
 {%- for sym in recordable_inline_expressions %}
-	insert_("{{sym.get_symbol_name()}}", &{{neuronName}}::{{names.getter(sym)}});
+	insert_(names::{{sym.get_symbol_name()}}, &{{neuronName}}::{{names.getter(sym)}});
 {%- endfor %}
 {%- endif %}
   }

--- a/pynestml/codegeneration/resources_nest/NeuronClass.jinja2
+++ b/pynestml/codegeneration/resources_nest/NeuronClass.jinja2
@@ -76,12 +76,12 @@ namespace names
 {
 {%- if recordable_state_variables|length > 0 %}
 {%- for sym in recordable_state_variables %}
-    const Name {{sym.get_symbol_name()}}( "{{sym.get_symbol_name()}}" );
+    const Name {{neuronName}}_{{sym.get_symbol_name()}}( "{{sym.get_symbol_name()}}" );
 {%- endfor %}
 {%- endif %}
 {%- if recordable_inline_expressions|length > 0 %}
 {%- for sym in recordable_inline_expressions %}
-    const Name {{sym.get_symbol_name()}}( "{{sym.get_symbol_name()}}" );
+    const Name {{neuronName}}_{{sym.get_symbol_name()}}( "{{sym.get_symbol_name()}}" );
 {%- endfor %}
 {%- endif %}
 }
@@ -93,14 +93,14 @@ namespace names
 {%- if recordable_state_variables|length > 0 %}
     // add state variables to recordables map
 {%- for sym in recordable_state_variables %}
-    insert_(names::{{sym.get_symbol_name()}}, &{{neuronName}}::{{names.getter(sym)}});
+    insert_(names::{{neuronName}}_{{sym.get_symbol_name()}}, &{{neuronName}}::{{names.getter(sym)}});
 {%- endfor %}
 {%- endif %}
 {%- if recordable_inline_expressions|length > 0 %}
 
     // add recordable inline expressions to recordables map
 {%- for sym in recordable_inline_expressions %}
-	insert_(names::{{sym.get_symbol_name()}}, &{{neuronName}}::{{names.getter(sym)}});
+	insert_(names::{{neuronName}}_{{sym.get_symbol_name()}}, &{{neuronName}}::{{names.getter(sym)}});
 {%- endfor %}
 {%- endif %}
   }

--- a/pynestml/codegeneration/resources_nest/NeuronHeader.jinja2
+++ b/pynestml/codegeneration/resources_nest/NeuronHeader.jinja2
@@ -79,12 +79,12 @@ namespace names
 {
 {%- if recordable_state_variables|length > 0 %}
 {%- for sym in recordable_state_variables %}
-    extern const Name {{sym.get_symbol_name()}};
+    extern const Name {{neuronName}}_{{sym.get_symbol_name()}};
 {%- endfor %}
 {%- endif %}
 {%- if recordable_inline_expressions|length > 0 %}
 {%- for sym in recordable_inline_expressions %}
-    extern const Name {{sym.get_symbol_name()}};
+    extern const Name {{neuronName}}_{{sym.get_symbol_name()}};
 {%- endfor %}
 {%- endif %}
 }

--- a/pynestml/codegeneration/resources_nest/NeuronHeader.jinja2
+++ b/pynestml/codegeneration/resources_nest/NeuronHeader.jinja2
@@ -73,6 +73,23 @@ along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 // Includes from sli:
 #include "dictdatum.h"
 
+namespace nest
+{
+namespace names
+{
+{%- if recordable_state_variables|length > 0 %}
+{%- for sym in recordable_state_variables %}
+    extern const Name {{sym.get_symbol_name()}};
+{%- endfor %}
+{%- endif %}
+{%- if recordable_inline_expressions|length > 0 %}
+{%- for sym in recordable_inline_expressions %}
+    extern const Name {{sym.get_symbol_name()}};
+{%- endfor %}
+{%- endif %}
+}
+}
+
 {% if useGSL %}
 /**
  * Function computing right-hand side of ODE for GSL solver.


### PR DESCRIPTION
Fixes #625.

Before merging this, we should add a multiprocessing test to CI, that is, one where
```Python
nest.SetKernelStatus({"local_num_threads": T})
```
for T > 1. This is because nest::names::Name, but not strings, should be compatible with multithreading.