### PR TITLE
Fix documentation rendering on Readthedocs

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,5 @@
 ipykernel
 nbsphinx
-sphinx
+docutils
+sphinx>=4
 sphinx_rtd_theme

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
 ipykernel
-nbsphinx==0.8.7
-sphinx==3.5.1
-sphinx_rtd_theme==0.5.1
+nbsphinx
+sphinx
+sphinx_rtd_theme


### PR DESCRIPTION
An upstream change in docutils broke compatibility with old Sphinx versions: see https://blog.readthedocs.com/build-errors-docutils-0-18/. This PR fixes that by upgrading Sphinx major version from 3 to 4.

Test build: https://nestml-sandbox.readthedocs.io/

Props to @pbabu for noticing this.