### PR TITLE
Remove help generator

### DIFF
--- a/doc/sphinx-apidoc/conf.py
+++ b/doc/sphinx-apidoc/conf.py
@@ -19,13 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-"""
+r"""
 Readthedocs configuration file
-------------------------------
-
-Use:
-sphinx-build -c ../extras/help_generator -b html . _build/html
-
 """
 
 import os

--- a/pynestml/codegeneration/resources_nest/point_neuron/setup/CMakeLists.txt.jinja2
+++ b/pynestml/codegeneration/resources_nest/point_neuron/setup/CMakeLists.txt.jinja2
@@ -277,33 +277,6 @@ set_target_properties( ${MODULE_NAME}_lib
     LINK_FLAGS "${NEST_LIBS}"
     OUTPUT_NAME ${MODULE_NAME} )
 
-# Install help.
-if ( NOT CMAKE_CROSSCOMPILING )
-  add_custom_target( generate_help ALL )
-  # Extract help from all source files in the source code, put them in
-  # doc/help and generate a local help index in the build directory containing
-  # links to the help files.
-  add_custom_command( TARGET generate_help POST_BUILD
-    COMMAND python -B generate_help.py "${PROJECT_SOURCE_DIR}" "${PROJECT_BINARY_DIR}"
-    COMMAND python -B generate_helpindex.py "${PROJECT_BINARY_DIR}/doc"
-    WORKING_DIRECTORY "${CMAKE_INSTALL_PREFIX}/${NEST_DATADIR}/help_generator"
-    COMMENT "Extracting help information; this may take a little while."
-    )
-  # Copy the local doc/help directory to the global installation
-  # directory for documentation.
-  install( DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/doc/help"
-    DESTINATION "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DOCDIR}"
-    )
-  # Update the global help index to contain all help files that are
-  # located in the global installation directory for documentation.
-  install( CODE
-    "execute_process(
-      COMMAND python -B generate_helpindex.py \"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DOCDIR}\"
-      WORKING_DIRECTORY \"${CMAKE_INSTALL_PREFIX}/${NEST_DATADIR}/help_generator\"
-    )"
-    )
-endif ()
-
 message( "" )
 message( "-------------------------------------------------------" )
 message( "${MODULE_NAME} Configuration Summary" )


### PR DESCRIPTION
``help_generator`` was renamed ``slihelp_generator`` in NEST Simulator. Instead of renaming, this PR removes all ties to this help generator entirely, as (correct me if I'm wrong) it has been superseded by ReadTheDocs/Sphinx.