### PR TITLE
Clone Scope in all ASTNode instances

### DIFF
--- a/pynestml/meta_model/ast_neuron.py
+++ b/pynestml/meta_model/ast_neuron.py
@@ -82,6 +82,10 @@ class ASTNeuron(ASTNeuronOrSynapse):
                         post_comments=[s for s in self.post_comments],
                         implicit_conversion_factor=self.implicit_conversion_factor)
 
+        from pynestml.visitors.ast_symbol_table_visitor import ASTSymbolTableVisitor
+        symtable_vistor = ASTSymbolTableVisitor()
+        symtable_vistor = ASTSymbolTableVisitor()
+        dup.accept(symtable_vistor)
         return dup
 
     def get_name(self):

--- a/pynestml/meta_model/ast_synapse.py
+++ b/pynestml/meta_model/ast_synapse.py
@@ -80,6 +80,10 @@ class ASTSynapse(ASTNeuronOrSynapse):
                          post_comments=[s for s in self.post_comments],
                          implicit_conversion_factor=self.implicit_conversion_factor)
 
+        from pynestml.visitors.ast_symbol_table_visitor import ASTSymbolTableVisitor
+        symtable_vistor = ASTSymbolTableVisitor()
+        symtable_vistor = ASTSymbolTableVisitor()
+        dup.accept(symtable_vistor)
         return dup
 
     def set_default_weight(self, w):


### PR DESCRIPTION
Fixes [#725 ](https://github.com/nest/nestml/issues/725)

- Use `ASTSymbolTableVisitor` in the cloning function of `ASTNeuron` and `ASTSynapse`