### PR TITLE
Fix models library index page

### DIFF
--- a/doc/models_library/index.rst
+++ b/doc/models_library/index.rst
@@ -1,37 +1,377 @@
 Models library
 ==============
 
-..
-   Generated at 2022-03-15 22:45:20.959396
+Neuron models
+~~~~~~~~~~~~~
 
-Neurons
-~~~~~~~
-- izhikevich`_
-- terub_gpe`_
-- traub_cond_multisyn`_
-- iaf_cond_alpha`_
-- mat2_psc_exp`_
-- hill_tononi`_
-- hh_psc_alpha`_
-- hh_cond_exp_traub`_
-- aeif_cond_alpha`_
-- iaf_psc_alpha`_
-- aeif_cond_exp`_
-- iaf_cond_exp_sfa_rr`_
-- traub_psc_alpha`_
-- iaf_cond_beta`_
-- iaf_chxk_2008`_
-- iaf_psc_exp`_
-- iaf_psc_exp_dend`_
-- wb_cond_exp`_
-- iaf_psc_delta`_
-- hh_cond_exp_destexhe`_
-- terub_stn`_
-- iaf_psc_exp_htum`_
-- izhikevich_psc_alpha`_
-- iaf_cond_exp`_
-- wb_cond_multisyn`_
 
-Synapses
-~~~~~~~~
+:doc:`iaf_psc_delta <iaf_psc_delta>`
+------------------------------------
+
+Current-based leaky integrate-and-fire neuron model with delta-kernel post-synaptic currents
+
+Source file: `iaf_psc_delta.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/iaf_psc_delta.nestml>`_
+
+.. list-table::
+
+   * - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[iaf_psc_delta]_synaptic_response_small.png
+          :alt: iaf_psc_delta
+
+     - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[iaf_psc_delta]_f-I_curve_small.png
+          :alt: iaf_psc_delta
+
+
+:doc:`iaf_psc_exp <iaf_psc_exp>`
+--------------------------------
+
+Leaky integrate-and-fire neuron model with exponential PSCs
+
+Source file: `iaf_psc_exp.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/iaf_psc_exp.nestml>`_
+
+.. list-table::
+
+   * - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[iaf_psc_exp]_synaptic_response_small.png
+          :alt: iaf_psc_exp
+
+     - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[iaf_psc_exp]_f-I_curve_small.png
+          :alt: iaf_psc_exp
+
+
+:doc:`iaf_psc_alpha <iaf_psc_alpha>`
+------------------------------------
+
+Leaky integrate-and-fire neuron model
+
+Source file: `iaf_psc_alpha.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/iaf_psc_alpha.nestml>`_
+
+.. list-table::
+
+   * - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[iaf_psc_alpha]_synaptic_response_small.png
+          :alt: iaf_psc_alpha
+
+     - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[iaf_psc_alpha]_f-I_curve_small.png
+          :alt: iaf_psc_alpha
+
+
+:doc:`iaf_cond_exp <iaf_cond_exp>`
+----------------------------------
+
+Simple conductance based leaky integrate-and-fire neuron model
+
+Source file: `iaf_cond_exp.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/iaf_cond_exp.nestml>`_
+
+.. list-table::
+
+   * - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[iaf_cond_exp]_synaptic_response_small.png
+          :alt: iaf_cond_exp
+
+     - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[iaf_cond_exp]_f-I_curve_small.png
+          :alt: iaf_cond_exp
+
+
+:doc:`iaf_cond_alpha <iaf_cond_alpha>`
+--------------------------------------
+
+Simple conductance based leaky integrate-and-fire neuron model
+
+Source file: `iaf_cond_alpha.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/iaf_cond_alpha.nestml>`_
+
+.. list-table::
+
+   * - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[iaf_cond_alpha]_synaptic_response_small.png
+          :alt: iaf_cond_alpha
+
+     - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[iaf_cond_alpha]_f-I_curve_small.png
+          :alt: iaf_cond_alpha
+
+
+:doc:`iaf_cond_beta <iaf_cond_beta>`
+------------------------------------
+
+Simple conductance based leaky integrate-and-fire neuron model
+
+Source file: `iaf_cond_beta.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/iaf_cond_beta.nestml>`_
+
+.. list-table::
+
+   * - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[iaf_cond_beta]_synaptic_response_small.png
+          :alt: iaf_cond_beta
+
+     - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[iaf_cond_beta]_f-I_curve_small.png
+          :alt: iaf_cond_beta
+
+
+:doc:`izhikevich <izhikevich>`
+------------------------------
+
+Izhikevich neuron model
+
+Source file: `izhikevich.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/izhikevich.nestml>`_
+
+.. list-table::
+
+   * - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[izhikevich]_synaptic_response_small.png
+          :alt: izhikevich
+
+     - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[izhikevich]_f-I_curve_small.png
+          :alt: izhikevich
+
+
+:doc:`hh_psc_alpha <hh_psc_alpha>`
+----------------------------------
+
+Hodgkin-Huxley neuron model
+
+Source file: `hh_psc_alpha.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/hh_psc_alpha.nestml>`_
+
+.. list-table::
+
+   * - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[hh_psc_alpha]_synaptic_response_small.png
+          :alt: hh_psc_alpha
+
+     - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[hh_psc_alpha]_f-I_curve_small.png
+          :alt: hh_psc_alpha
+
+
+:doc:`iaf_chxk_2008 <iaf_chxk_2008>`
+------------------------------------
+
+Conductance based leaky integrate-and-fire neuron model used in Casti et al. 2008
+
+Source file: `iaf_chxk_2008.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/iaf_chxk_2008.nestml>`_
+
+.. list-table::
+
+   * - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[iaf_chxk_2008]_synaptic_response_small.png
+          :alt: iaf_chxk_2008
+
+     - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[iaf_chxk_2008]_f-I_curve_small.png
+          :alt: iaf_chxk_2008
+
+
+:doc:`aeif_cond_exp <aeif_cond_exp>`
+------------------------------------
+
+Conductance based exponential integrate-and-fire neuron model
+
+Source file: `aeif_cond_exp.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/aeif_cond_exp.nestml>`_
+
+.. list-table::
+
+   * - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[aeif_cond_exp]_synaptic_response_small.png
+          :alt: aeif_cond_exp
+
+     - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[aeif_cond_exp]_f-I_curve_small.png
+          :alt: aeif_cond_exp
+
+
+:doc:`aeif_cond_alpha <aeif_cond_alpha>`
+----------------------------------------
+
+Conductance based exponential integrate-and-fire neuron model
+
+Source file: `aeif_cond_alpha.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/aeif_cond_alpha.nestml>`_
+
+.. list-table::
+
+   * - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[aeif_cond_alpha]_synaptic_response_small.png
+          :alt: aeif_cond_alpha
+
+     - .. figure:: https://raw.githubusercontent.com/nest/nestml/master/doc/models_library/nestml_models_library_[aeif_cond_alpha]_f-I_curve_small.png
+          :alt: aeif_cond_alpha
+
+
+:doc:`terub_gpe <terub_gpe>`
+----------------------------
+
+Terman Rubin neuron model
+
+Source file: `terub_gpe.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/terub_gpe.nestml>`_
+
+
+:doc:`traub_cond_multisyn <traub_cond_multisyn>`
+------------------------------------------------
+
+Traub model according to Borgers 2017
+
+Source file: `traub_cond_multisyn.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/traub_cond_multisyn.nestml>`_
+
+
+:doc:`mat2_psc_exp <mat2_psc_exp>`
+----------------------------------
+
+Non-resetting leaky integrate-and-fire neuron model with exponential PSCs and adaptive threshold
+
+Source file: `mat2_psc_exp.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/mat2_psc_exp.nestml>`_
+
+
+:doc:`hill_tononi <hill_tononi>`
+--------------------------------
+
+Neuron model after Hill & Tononi (2005)
+
+Source file: `hill_tononi.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/hill_tononi.nestml>`_
+
+
+:doc:`hh_cond_exp_traub <hh_cond_exp_traub>`
+--------------------------------------------
+
+Hodgkin-Huxley model for Brette et al (2007) review
+
+Source file: `hh_cond_exp_traub.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/hh_cond_exp_traub.nestml>`_
+
+
+:doc:`iaf_cond_exp_sfa_rr <iaf_cond_exp_sfa_rr>`
+------------------------------------------------
+
+Conductance based leaky integrate-and-fire model with spike-frequency adaptation and relative refractory mechanisms
+
+Source file: `iaf_cond_exp_sfa_rr.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/iaf_cond_exp_sfa_rr.nestml>`_
+
+
+:doc:`traub_psc_alpha <traub_psc_alpha>`
+----------------------------------------
+
+Traub model according to Borgers 2017
+
+Source file: `traub_psc_alpha.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/traub_psc_alpha.nestml>`_
+
+
+:doc:`iaf_psc_exp_dend <iaf_psc_exp_dend>`
+------------------------------------------
+
+Leaky integrate-and-fire neuron model with exponential PSCs
+
+Source file: `iaf_psc_exp_dend.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/iaf_psc_exp_dend.nestml>`_
+
+
+:doc:`wb_cond_exp <wb_cond_exp>`
+--------------------------------
+
+Wang-Buzsaki model
+
+Source file: `wb_cond_exp.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/wb_cond_exp.nestml>`_
+
+
+:doc:`hh_cond_exp_destexhe <hh_cond_exp_destexhe>`
+--------------------------------------------------
+
+Hodgin Huxley based model, Traub, Destexhe and Mainen modified
+
+Source file: `hh_cond_exp_destexhe.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/hh_cond_exp_destexhe.nestml>`_
+
+
+:doc:`terub_stn <terub_stn>`
+----------------------------
+
+Terman Rubin neuron model
+
+Source file: `terub_stn.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/terub_stn.nestml>`_
+
+
+:doc:`iaf_psc_exp_htum <iaf_psc_exp_htum>`
+------------------------------------------
+
+Leaky integrate-and-fire model with separate relative and absolute refractory period
+
+Source file: `iaf_psc_exp_htum.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/iaf_psc_exp_htum.nestml>`_
+
+
+:doc:`izhikevich_psc_alpha <izhikevich_psc_alpha>`
+--------------------------------------------------
+
+Detailed Izhikevich neuron model with alpha-kernel post-synaptic current
+
+Source file: `izhikevich_psc_alpha.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/izhikevich_psc_alpha.nestml>`_
+
+
+:doc:`wb_cond_multisyn <wb_cond_multisyn>`
+------------------------------------------
+
+Wang-Buzsaki model with multiple synapses
+
+Source file: `wb_cond_multisyn.nestml <https://www.github.com/nest/nestml/blob/master/models/neurons/wb_cond_multisyn.nestml>`_
+
+Synapse models
+~~~~~~~~~~~~~~
+
+
+:doc:`static <static>`
+----------------------
+
+Static synapse
+
+Source file: `static_synapse.nestml <https://www.github.com/nest/nestml/blob/master/models/synapses/static_synapse.nestml>`_
+
+
+:doc:`noisy_synapse <noisy_synapse>`
+------------------------------------
+
+Static synapse with Gaussian noise
+
+Source file: `noisy_synapse.nestml <https://www.github.com/nest/nestml/blob/master/models/synapses/noisy_synapse.nestml>`_
+
+
+:doc:`stdp <stdp>`
+------------------
+
+Synapse model for spike-timing dependent plasticity
+
+Source file: `stdp_synapse.nestml <https://www.github.com/nest/nestml/blob/master/models/synapses/stdp_synapse.nestml>`_
+
+
+:doc:`stdp_nn_pre_centered <stdp_nn_pre_centered>`
+--------------------------------------------------
+
+Synapse type for spike-timing dependent plasticity, with nearest-neighbour spike pairing
+
+Source file: `stdp_nn_pre_centered.nestml <https://www.github.com/nest/nestml/blob/master/models/synapses/stdp_nn_pre_centered.nestml>`_
+
+
+:doc:`stdp_nn_restr_symm <stdp_nn_restr_symm>`
+----------------------------------------------
+
+Synapse type for spike-timing dependent plasticity with restricted symmetric nearest-neighbour spike pairing scheme
+
+Source file: `stdp_nn_restr_symm.nestml <https://www.github.com/nest/nestml/blob/master/models/synapses/stdp_nn_restr_symm.nestml>`_
+
+
+:doc:`stdp_nn_symm <stdp_nn_symm>`
+----------------------------------
+
+Synapse type for spike-timing dependent plasticity with symmetric nearest-neighbour spike pairing scheme
+
+Source file: `stdp_nn_symm.nestml <https://www.github.com/nest/nestml/blob/master/models/synapses/stdp_nn_symm.nestml>`_
+
+
+:doc:`stdp_triplet_nn <stdp_triplet_nn>`
+----------------------------------------
+
+Synapse type with triplet spike-timing dependent plasticity
+
+Source file: `triplet_stdp_synapse.nestml <https://www.github.com/nest/nestml/blob/master/models/synapses/triplet_stdp_synapse.nestml>`_
+
+
+:doc:`stdp_triplet <stdp_triplet>`
+----------------------------------
+
+Synapse type with triplet spike-timing dependent plasticity
+
+Source file: `stdp_triplet_naive.nestml <https://www.github.com/nest/nestml/blob/master/models/synapses/stdp_triplet_naive.nestml>`_
+
+
+:doc:`third_factor_stdp <third_factor_stdp>`
+--------------------------------------------
+
+Synapse model for spike-timing dependent plasticity with postsynaptic third-factor modulation
+
+Source file: `third_factor_stdp_synapse.nestml <https://www.github.com/nest/nestml/blob/master/models/synapses/third_factor_stdp_synapse.nestml>`_
+
+
+:doc:`neuromodulated_stdp <neuromodulated_stdp>`
+------------------------------------------------
+
+Synapse model for spike-timing dependent plasticity modulated by a neurotransmitter such as dopamine
+
+Source file: `neuromodulated_stdp.nestml <https://www.github.com/nest/nestml/blob/master/models/synapses/neuromodulated_stdp.nestml>`_
 


### PR DESCRIPTION
Undo accidental overwrite of models library index in 35516b65ae1db7cfeae6c5c7ae7a87748bfa3095. This PR simply rolls back that commit for ``index.rst``.