### PR TITLE
Add wheel Python package to requirements

### DIFF
--- a/.github/workflows/nestml-build.yml
+++ b/.github/workflows/nestml-build.yml
@@ -237,3 +237,7 @@ jobs:
           rc=0
           pytest -s -o log_cli=true -o log_cli_level="DEBUG" tests/nest_tests/nest2_compat_test.py || rc=1
           exit $rc
+
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+wheel
 numpy >= 1.8.2
 sympy >= 1.1.1
 antlr4-python3-runtime >= 4.7


### PR DESCRIPTION
The CI pipeline spontaneously broke for NEST 2 due to a missing dependency. This PR is a fix.