### PR TITLE
Fix case where function has no parameters defined

### DIFF
--- a/pynestml/meta_model/ast_function.py
+++ b/pynestml/meta_model/ast_function.py
@@ -19,9 +19,14 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List, Optional
+
 from copy import copy
 
+from pynestml.meta_model.ast_block import ASTBlock
+from pynestml.meta_model.ast_data_type import ASTDataType
 from pynestml.meta_model.ast_node import ASTNode
+from pynestml.meta_model.ast_parameter import ASTParameter
 
 
 class ASTFunction(ASTNode):
@@ -50,20 +55,16 @@ class ASTFunction(ASTNode):
         type_symbol = None
     """
 
-    def __init__(self, name, parameters, return_type, block, type_symbol=None, *args, **kwargs):
+    def __init__(self, name: str, parameters: List[ASTParameter], return_type: Optional[ASTDataType], block: ASTBlock, type_symbol=None, *args, **kwargs):
         """
         Standard constructor.
 
         Parameters for superclass (ASTNode) can be passed through :python:`*args` and :python:`**kwargs`.
 
         :param name: the name of the defined function.
-        :type name: str
         :param parameters: (Optional) Set of parameters.
-        :type parameters: List[ASTParameter]
         :param return_type: (Optional) Return type.
-        :type return_type: ASTDataType
         :param block: a block of declarations.
-        :type block: ASTBlock
         """
         super(ASTFunction, self).__init__(*args, **kwargs)
         self.block = block
@@ -86,8 +87,7 @@ class ASTFunction(ASTNode):
         if self.return_type:
             return_type_dup = self.return_type.clone()
         parameters_dup = None
-        if self.parameters:
-            parameters_dup = [parameter.clone() for parameter in self.parameters]
+        parameters_dup = [parameter.clone() for parameter in self.parameters]
         dup = ASTFunction(name=self.name,
                           parameters=parameters_dup,
                           return_type=return_type_dup,
@@ -112,19 +112,17 @@ class ASTFunction(ASTNode):
         """
         return self.name
 
-    def has_parameters(self):
+    def has_parameters(self) -> bool:
         """
         Returns whether parameters have been defined.
         :return: True if parameters defined, otherwise False.
-        :rtype: bool
         """
-        return (self.parameters is not None) and (len(self.parameters) > 0)
+        return len(self.parameters) > 0
 
-    def get_parameters(self):
+    def get_parameters(self) -> List[ASTParameter]:
         """
         Returns the list of parameters.
         :return: a parameters object containing the list.
-        :rtype: list(ASTParameter)
         """
         return self.parameters
 

--- a/pynestml/meta_model/ast_parameter.py
+++ b/pynestml/meta_model/ast_parameter.py
@@ -19,7 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-
 from pynestml.meta_model.ast_data_type import ASTDataType
 from pynestml.meta_model.ast_node import ASTNode
 
@@ -27,9 +26,7 @@ from pynestml.meta_model.ast_node import ASTNode
 class ASTParameter(ASTNode):
     """
     This class is used to store a single function parameter definition.
-    ASTParameter represents singe:
-      output: spike
-    @attribute compartments Lists with compartments.
+
     Grammar:
         parameter : NAME datatype;
     Attributes:
@@ -37,7 +34,7 @@ class ASTParameter(ASTNode):
         data_type (ASTDataType): The data type of the parameter.
     """
 
-    def __init__(self, name=None, data_type=None, *args, **kwargs):
+    def __init__(self, name: str, data_type: ASTDataType, *args, **kwargs):
         """
         Standard constructor.
         :param name: the name of the parameter.
@@ -45,10 +42,6 @@ class ASTParameter(ASTNode):
         :param data_type: the type of the parameter.
         :type data_type: ASTDataType
         """
-        assert (name is not None and isinstance(name, str)), \
-            '(PyNestML.AST.Parameter) No or wrong type of name provided (%s)!' % type(name)
-        assert (data_type is not None and isinstance(data_type, ASTDataType)), \
-            '(PyNestML.AST.Parameter) No or wrong type of datatype provided (%s)!' % type(data_type)
         super(ASTParameter, self).__init__(*args, **kwargs)
         self.data_type = data_type
         self.name = name

--- a/pynestml/visitors/ast_builder_visitor.py
+++ b/pynestml/visitors/ast_builder_visitor.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 import ntpath
 import re
 
@@ -26,6 +28,7 @@ from pynestml.cocos.co_cos_manager import CoCosManager
 from pynestml.frontend.frontend_configuration import FrontendConfiguration
 from pynestml.generated.PyNestMLParserVisitor import PyNestMLParserVisitor
 from pynestml.meta_model.ast_node_factory import ASTNodeFactory
+from pynestml.meta_model.ast_parameter import ASTParameter
 from pynestml.utils.ast_source_location import ASTSourceLocation
 from pynestml.utils.logger import Logger
 from pynestml.utils.port_signal_type import PortSignalType
@@ -704,7 +707,7 @@ class ASTBuilderVisitor(PyNestMLParserVisitor):
     # Visit a parse tree produced by PyNESTMLParser#function.
     def visitFunction(self, ctx):
         name = str(ctx.NAME()) if ctx.NAME() is not None else None
-        parameters = list()
+        parameters: List[ASTParameter] = []
         if type(ctx.parameter()) is list:
             for par in ctx.parameter():
                 parameters.append(self.visit(par))

--- a/pynestml/visitors/ast_visitor.py
+++ b/pynestml/visitors/ast_visitor.py
@@ -1243,9 +1243,8 @@ class ASTVisitor:
         return
 
     def traverse_function(self, node):
-        if node.get_parameters() is not None:
-            for sub_node in node.get_parameters():
-                sub_node.accept(self.get_real_self())
+        for sub_node in node.get_parameters():
+            sub_node.accept(self.get_real_self())
         if node.get_return_type() is not None:
             node.get_return_type().accept(self.get_real_self())
         if node.get_block() is not None:


### PR DESCRIPTION
The code handling NESTML model function declarations had a special case when the function has no parameters, which is to store this not as an empty list but as ``None``. This caused a bug when trying to iterate ``None``. Instead of adding extra if-statements everywhere ``get_parameters()`` is called to check for ``None``, this PR simplifies things so that function parameters are always stored as a list, and no parameters corresponds simply to the empty list.
