### PR TITLE
Omit `FrontendConfiguration.suffix` while extracting neuron name

### DIFF
--- a/pynestml/transformers/synapse_post_neuron_transformer.py
+++ b/pynestml/transformers/synapse_post_neuron_transformer.py
@@ -464,8 +464,9 @@ class SynapsePostNeuronTransformer(Transformer):
         new_synapse.paired_neuron = new_neuron
         new_neuron.paired_synapse = new_synapse
 
-        base_neuron_name = neuron.get_name()
-        base_synapse_name = synapse.get_name()
+        base_neuron_name = neuron.get_name().removesuffix(FrontendConfiguration.suffix)
+        base_synapse_name = synapse.get_name().removesuffix(FrontendConfiguration.suffix)
+
         new_synapse.post_port_names = self.get_post_port_names(synapse, base_neuron_name, base_synapse_name)
         new_synapse.spiking_post_port_names = self.get_spiking_post_port_names(synapse, base_neuron_name, base_synapse_name)
         new_synapse.vt_port_names = self.get_vt_port_names(synapse, base_neuron_name, base_synapse_name)

--- a/pynestml/transformers/synapse_post_neuron_transformer.py
+++ b/pynestml/transformers/synapse_post_neuron_transformer.py
@@ -464,8 +464,8 @@ class SynapsePostNeuronTransformer(Transformer):
         new_synapse.paired_neuron = new_neuron
         new_neuron.paired_synapse = new_synapse
 
-        base_neuron_name = neuron.get_name()[:-len(FrontendConfiguration.suffix)]
-        base_synapse_name = synapse.get_name()[:-len(FrontendConfiguration.suffix)]
+        base_neuron_name = neuron.get_name()
+        base_synapse_name = synapse.get_name()
         new_synapse.post_port_names = self.get_post_port_names(synapse, base_neuron_name, base_synapse_name)
         new_synapse.spiking_post_port_names = self.get_spiking_post_port_names(synapse, base_neuron_name, base_synapse_name)
         new_synapse.vt_port_names = self.get_vt_port_names(synapse, base_neuron_name, base_synapse_name)

--- a/tests/nest_tests/stdp_window_test.py
+++ b/tests/nest_tests/stdp_window_test.py
@@ -46,6 +46,7 @@ def nestml_generate_target():
                          target_path="/tmp/nestml-jit",
                          logging_level="INFO",
                          module_name="nestml_jit_module",
+                         suffix="_nestml",
                          codegen_opts={"neuron_parent_class": "StructuralPlasticityNode",
                                        "neuron_parent_class_include": "structural_plasticity_node.h",
                                        "neuron_synapse_pairs": [{"neuron": "iaf_psc_delta",

--- a/tests/nest_tests/stdp_window_test.py
+++ b/tests/nest_tests/stdp_window_test.py
@@ -46,7 +46,6 @@ def nestml_generate_target():
                          target_path="/tmp/nestml-jit",
                          logging_level="INFO",
                          module_name="nestml_jit_module",
-                         suffix="_nestml",
                          codegen_opts={"neuron_parent_class": "StructuralPlasticityNode",
                                        "neuron_parent_class_include": "structural_plasticity_node.h",
                                        "neuron_synapse_pairs": [{"neuron": "iaf_psc_delta",

--- a/tests/nest_tests/third_factor_stdp_synapse_test.py
+++ b/tests/nest_tests/third_factor_stdp_synapse_test.py
@@ -41,13 +41,13 @@ sim_ref = False
 
 class NestThirdFactorSTDPSynapseTest(unittest.TestCase):
 
-    neuron_model_name = "iaf_psc_exp_dend_nestml__with_third_factor_stdp_nestml"
+    neuron_model_name = "iaf_psc_exp_dend__with_third_factor_stdp"
     ref_neuron_model_name = "iaf_psc_exp_nestml_non_jit"
 
-    synapse_model_name = "third_factor_stdp_nestml__with_iaf_psc_exp_dend_nestml"
+    synapse_model_name = "third_factor_stdp__with_iaf_psc_exp_dend"
     ref_synapse_model_name = "third_factor_stdp_synapse"
 
-    post_trace_var = "I_dend"  # "post_trace_kernel__for_stdp_nestml__X__post_spikes__for_stdp_nestml"
+    post_trace_var = "I_dend"
 
     def setUp(self):
         r"""Generate the neuron model code"""
@@ -57,7 +57,6 @@ class NestThirdFactorSTDPSynapseTest(unittest.TestCase):
                              target_path="/tmp/nestml-jit",
                              logging_level="INFO",
                              module_name="nestml_jit_module",
-                             suffix="_nestml",
                              codegen_opts={"neuron_parent_class": "StructuralPlasticityNode",
                                            "neuron_parent_class_include": "structural_plasticity_node.h",
                                            "neuron_synapse_pairs": [{"neuron": "iaf_psc_exp_dend",


### PR DESCRIPTION
Fixes #793 by not considering the `suffix` while extracting the neuron name. This doesn't affect further execution as neuron name with and without a suffix is checked in the function `is_special_port()` in `synapse_post_neuron_transformer.py`