### PR TITLE
Update python version to 3.9

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,6 +7,6 @@ sphinx:
     configuration: doc/sphinx-apidoc/conf.py
 
 python:
-    version: 3.8
+    version: 3.9
     install:
     - requirements: doc/requirements.txt

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -1,7 +1,7 @@
 Installing NESTML
 =================
 
-Please note that only Python 3.8 (and later versions) are supported. The instructions below assume that ``python`` is aliased to or refers to ``python3``, and ``pip`` to ``pip3``.
+Please note that only Python 3.9 (and later versions) are supported. The instructions below assume that ``python`` is aliased to or refers to ``python3``, and ``pip`` to ``pip3``.
 
 Installing the latest release from PyPI
 ---------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ import os
 import sys
 from setuptools import setup, find_packages
 
-assert sys.version_info.major >= 3 and sys.version_info.minor >= 8, "Python 3.8 or higher is required to run NESTML"
+assert sys.version_info.major >= 3 and sys.version_info.minor >= 9, "Python 3.9 or higher is required to run NESTML"
 
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()


### PR DESCRIPTION
With the new changes from #794, the `removesuffix()` function is available only from python version `3.9` and higher. Since we are already running the CI on python `3.9`, it is better to have the version consistent everywhere.