### PR TITLE
Refactor redundant code in NEST synapse template

### DIFF
--- a/doc/nestml_language/synapses_in_nestml.rst
+++ b/doc/nestml_language/synapses_in_nestml.rst
@@ -533,6 +533,8 @@ Event-based updating
 
 NEST target synapses are not allowed to have any time-based internal dynamics (ODEs). This is due to the fact that synapses are, unlike nodes, not updated on a regular time grid.
 
+The synapse is allowed to contain an ``update`` block. Statements in the ``update`` block are executed whenever the internal state of the synapse is updated from one timepoint to the next; these updates are typically triggered by incoming spikes. The NESTML ``resolution()`` function will return the time that has elapsed since the last event was handled.
+
 
 Dendritic delay
 ~~~~~~~~~~~~~~~
@@ -544,6 +546,7 @@ In NEST, all synapses are expected to specify a nonzero dendritic delay, that is
    parameters:
      dend_delay ms = 1 ms     @nest::delay
    end
+
 
 Generating code
 ---------------

--- a/pynestml/codegeneration/resources_nest/point_neuron/common/SynapseHeader.h.jinja2
+++ b/pynestml/codegeneration/resources_nest/point_neuron/common/SynapseHeader.h.jinja2
@@ -284,18 +284,18 @@ private:
    {{synapse.print_parameter_comment("*")}}
    *
    * These are the parameters that can be set by the user through @c SetStatus.
-  * Parameters do not change during calls to ``send()`` and are not reset by
-  * @c ResetNetwork.
-  *
-  * @note Parameters_ need neither copy constructor nor @c operator=(), since
-  *       all its members are copied properly by the default copy constructor
-  *       and assignment operator. Important:
-  *       - If Parameters_ contained @c Time members, you need to define the
-  *         assignment operator to recalibrate all members of type @c Time . You
-  *         may also want to define the assignment operator.
-  *       - If Parameters_ contained members that cannot copy themselves, such
-  *         as C-style arrays, you need to define the copy constructor and
-  *         assignment operator to copy those members.
+   * Parameters do not change during calls to ``send()`` and are not reset by
+   * @c ResetNetwork.
+   *
+   * @note Parameters_ need neither copy constructor nor @c operator=(), since
+   *       all its members are copied properly by the default copy constructor
+   *       and assignment operator. Important:
+   *       - If Parameters_ contained @c Time members, you need to define the
+   *         assignment operator to recalibrate all members of type @c Time . You
+   *         may also want to define the assignment operator.
+   *       - If Parameters_ contained members that cannot copy themselves, such
+   *         as C-style arrays, you need to define the copy constructor and
+   *         assignment operator to copy those members.
   */
   struct Parameters_{
 {%- filter indent(4,True) %}
@@ -322,11 +322,7 @@ private:
    *
    {{synapse.print_internal_comment('*')}}
    *
-   * These variables must be initialized by @c pre_run_hook (or calibrate in NEST 2.x), which is called before
-   * the first call to @c update() upon each call to @c Simulate.
-   * @node Variables_ needs neither constructor, copy constructor or assignment operator,
-   *       since it is initialized by @c pre_run_hook() (or calibrate() in NEST 2.x). If Variables_ has members that
-   *       cannot destroy themselves, Variables_ will need a destructor.
+   * These variables must be initialized by recompute_internal_variables().
   **/
   struct Variables_
   {
@@ -389,7 +385,7 @@ private:
 {%- endfilter %}
 
   /**
-   * Update internal state (``S_``) of the synapse according to the dynamical equations defined in the model
+   * Update internal state (``S_``) of the synapse according to the dynamical equations defined in the model and the statements in the ``update`` block.
   **/
   inline void
   update_internal_state_(double t_start, double timestep, const {{synapseName}}CommonSynapseProperties& cp);

--- a/pynestml/codegeneration/resources_nest/point_neuron/common/SynapseHeader.h.jinja2
+++ b/pynestml/codegeneration/resources_nest/point_neuron/common/SynapseHeader.h.jinja2
@@ -218,41 +218,33 @@ public:
     const {{synapseName}}CommonSynapseProperties& cp );
 {%- endif %}
 private:
-
-//  double *weight_;
   double t_lastspike_;
 {%- if vt_ports is defined and vt_ports|length > 0  %}
-  // time of last update, which is either time of last presyn. spike or
-  // time-driven update
+  // time of last update, which is either time of last presyn. spike or time-driven update
   double t_last_update_;
 
-  // vt_spikes_idx_ refers to the vt spike that has just been processes
-  // after trigger_update_weight a pseudo vt spike at t_trig is stored at
-  // index 0 and vt_spikes_idx_ = 0
+  // vt_spikes_idx_ refers to the vt spike that has just been processed after trigger_update_weight
+  // a pseudo vt spike at t_trig is stored at index 0 and vt_spikes_idx_ = 0
   index vt_spikes_idx_;
 {%- endif %}
 
-
-
   /**
-  * Dynamic state of the synapse.
-  *
-  *
-  * These are the state variables that are advanced in time by calls to
-  * @c update(). In many models, some or all of them can be set by the user
-  * through @c SetStatus. The state variables are initialized from the model
-  * prototype when the node is created. State variables are reset by @c ResetNetwork.
-  *
-  * @note State_ need neither copy constructor nor @c operator=(), since
-  *       all its members are copied properly by the default copy constructor
-  *       and assignment operator. Important:
-  *       - If State_ contained @c Time members, you need to define the
-  *         assignment operator to recalibrate all members of type @c Time . You
-  *         may also want to define the assignment operator.
-  *       - If State_ contained members that cannot copy themselves, such
-  *         as C-style arrays, you need to define the copy constructor and
-  *         assignment operator to copy those members.
-  */
+   * Dynamic state of the synapse.
+   *
+   * These are the state variables that are advanced in time by calls to
+   * send(). In many models, some or all of them can be set by the user
+   * through ``SetStatus()``.
+   *
+   * @note State_ need neither copy constructor nor @c operator=(), since
+   *       all its members are copied properly by the default copy constructor
+   *       and assignment operator. Important:
+   *       - If State_ contained @c Time members, you need to define the
+   *         assignment operator to recalibrate all members of type @c Time . You
+   *         may also want to define the assignment operator.
+   *       - If State_ contained members that cannot copy themselves, such
+   *         as C-style arrays, you need to define the copy constructor and
+   *         assignment operator to copy those members.
+  **/
   struct State_{
 {%- if not uses_numeric_solver %}
 {%-   filter indent(4,True) %}
@@ -286,62 +278,13 @@ private:
     State_() {};
   };
 
-  // -------------------------------------------------------------------------
-  //   Getters/setters for state block
-  // -------------------------------------------------------------------------
-
-{% filter indent(2, True) -%}
-{%- for state in synapse.get_state_symbols() %}
-{%-    with variable = state %}
-{%-       include "directives/MemberVariableGetterSetter.jinja2" %}
-{%-    endwith %}
-{%- endfor %}
-{%- endfilter %}
-  // -------------------------------------------------------------------------
-  //   Getters/setters for parameters
-  // -------------------------------------------------------------------------
-
-
-
-
-{% filter indent(2, True) -%}
-{%- for parameter in synapse.get_parameter_symbols() %}
-{%-     set isHomogeneous = PyNestMLLexer["DECORATOR_HOMOGENEOUS"] in parameter.get_decorators() %}
-{%-     if (not isHomogeneous) %}
-{%-     with variable = parameter %}
-{%-        include "directives/MemberVariableGetterSetter.jinja2" %}
-{%-     endwith %}
-{%-     endif %}
-{%- endfor %}
-{%- endfilter %}
-  // -------------------------------------------------------------------------
-  //   Getters/setters for inline expressions
-  // -------------------------------------------------------------------------
-{% filter indent(2, True) -%}
-{%- for funcsym in synapse.get_inline_expression_symbols() %}
-{%-    with variable = funcsym %}
-{%-        include "directives/MemberVariableGetterSetter.jinja2" %}
-{%-    endwith %}
-{%- endfor %}
-{%- endfilter %}
-  // -------------------------------------------------------------------------
-  //   Function declarations
-  // -------------------------------------------------------------------------
-
-{% filter indent(2) -%}
-{% for function in synapse.get_functions() %}
-  {{printer.print_function_declaration(function)}};
-{% endfor %}
-{%- endfilter %}
-
   /**
-  * Free parameters of the synapse.
-  *
-  {{synapse.print_parameter_comment("*")}}
-  *
-  * These are the parameters that can be set by the user through @c SetStatus.
-  * They are initialized from the model prototype when the node is created.
-  * Parameters do not change during calls to @c update() and are not reset by
+   * Free parameters of the synapse.
+   *
+   {{synapse.print_parameter_comment("*")}}
+   *
+   * These are the parameters that can be set by the user through @c SetStatus.
+  * Parameters do not change during calls to ``send()`` and are not reset by
   * @c ResetNetwork.
   *
   * @note Parameters_ need neither copy constructor nor @c operator=(), since
@@ -375,17 +318,18 @@ private:
   };
 
   /**
-  * Internal variables of the synapse.
-  *
-  {{synapse.print_internal_comment('*')}}
-  *
-  * These variables must be initialized by @c pre_run_hook (or calibrate in NEST 2.x), which is called before
-  * the first call to @c update() upon each call to @c Simulate.
-  * @node Variables_ needs neither constructor, copy constructor or assignment operator,
-  *       since it is initialized by @c pre_run_hook() (or calibrate() in NEST 2.x). If Variables_ has members that
-  *       cannot destroy themselves, Variables_ will need a destructor.
-  */
-  struct Variables_ {
+   * Internal variables of the synapse.
+   *
+   {{synapse.print_internal_comment('*')}}
+   *
+   * These variables must be initialized by @c pre_run_hook (or calibrate in NEST 2.x), which is called before
+   * the first call to @c update() upon each call to @c Simulate.
+   * @node Variables_ needs neither constructor, copy constructor or assignment operator,
+   *       since it is initialized by @c pre_run_hook() (or calibrate() in NEST 2.x). If Variables_ has members that
+   *       cannot destroy themselves, Variables_ will need a destructor.
+  **/
+  struct Variables_
+  {
 {%- for variable in synapse.get_internal_symbols() %}
 {%-     filter indent(4,True) %}
 {%-     include "directives/MemberDeclaration.jinja2" %}
@@ -396,6 +340,62 @@ private:
   Parameters_ P_;  //!< Free parameters.
   State_      S_;  //!< Dynamic state.
   Variables_  V_;  //!< Internal Variables
+
+  // -------------------------------------------------------------------------
+  //   Getters/setters for state block
+  // -------------------------------------------------------------------------
+
+{% filter indent(2, True) -%}
+{%- for state in synapse.get_state_symbols() %}
+{%-    with variable = state %}
+{%-       include "directives/MemberVariableGetterSetter.jinja2" %}
+{%-    endwith %}
+{%- endfor %}
+{%- endfilter %}
+  // -------------------------------------------------------------------------
+  //   Getters/setters for parameters
+  // -------------------------------------------------------------------------
+
+{% filter indent(2, True) -%}
+{%- for parameter in synapse.get_parameter_symbols() %}
+{%-     set isHomogeneous = PyNestMLLexer["DECORATOR_HOMOGENEOUS"] in parameter.get_decorators() %}
+{%-     if (not isHomogeneous) %}
+{%-     with variable = parameter %}
+{%-        include "directives/MemberVariableGetterSetter.jinja2" %}
+{%-     endwith %}
+{%-     endif %}
+{%- endfor %}
+{%- endfilter %}
+
+  // -------------------------------------------------------------------------
+  //   Getters/setters for inline expressions
+  // -------------------------------------------------------------------------
+{% filter indent(2, True) -%}
+{%- for funcsym in synapse.get_inline_expression_symbols() %}
+{%-    with variable = funcsym %}
+{%-        include "directives/MemberVariableGetterSetter.jinja2" %}
+{%-    endwith %}
+{%- endfor %}
+{%- endfilter %}
+
+  // -------------------------------------------------------------------------
+  //   Function declarations
+  // -------------------------------------------------------------------------
+
+{% filter indent(2) -%}
+{% for function in synapse.get_functions() %}
+  {{printer.print_function_declaration(function)}};
+{% endfor %}
+{%- endfilter %}
+
+  /**
+   * Update internal state (``S_``) of the synapse according to the dynamical equations defined in the model
+  **/
+  inline void
+  update_internal_state_(double t_start, double timestep, const {{synapseName}}CommonSynapseProperties& cp);
+
+  void recompute_internal_variables();
+
 {#
   /**
    * All parameters marked as homogeneous will go into a CommonPropertiesDictionary
@@ -418,7 +418,6 @@ private:
 #}
 
 public:
-
   // this line determines which common properties to use
   typedef {{synapseName}}CommonSynapseProperties CommonPropertiesType;
 
@@ -433,7 +432,6 @@ public:
   */
   {{synapseName}}();
 
-
   /**
   * Copy constructor from a property object.
   *
@@ -443,19 +441,13 @@ public:
   */
   {{synapseName}}( const {{synapseName}}& rhs );
 
-
 {%- if vt_ports is defined and vt_ports|length > 0  %}
 {%- set vt_port = vt_ports[0] %}
   void process_{{vt_port}}_spikes_( const std::vector< spikecounter >& vt_spikes,
       double t0,
       double t1,
       const {{synapseName}}CommonSynapseProperties& cp );
-
-  inline void
-  update_internal_state_(double t_start, double timestep, const {{synapseName}}CommonSynapseProperties& cp);
 {%- endif %}
-
-    void recompute_internal_variables();
 
   // Explicitly declare all methods inherited from the dependent base
   // ConnectionBase. This avoids explicit name prefixes in all places these
@@ -517,26 +509,11 @@ public:
     }
   };
 
-
-  /**
-   * Get named parameter from the `Parameter_` struct
-  **/
-/*  template < typename T >
-  T* get_named_parameter(const Name &n) {
-{%- for parameter in synapse.get_parameter_symbols() %}
-{%-     set namespaceName = parameter.get_namespace_decorator("nest") %}
-    if (n == names::{{namespaceName}}) {
-      return &{{printer.print_origin(parameter)}}{{names.name(parameter)}}; // type: {- {declarations.print_variable_type(parameter)} -}
-    }
-{%- endfor %}
-
-    assert(false);    // unknown name requested
-  }
-*/
   /**
    *  special case for weights in NEST: only in case a NESTML state variable was decorated by @nest::weight
   **/
-  inline void set_weight(double w) {
+  inline void set_weight(double w)
+  {
 {%- for init in synapse.get_state_symbols() %}
 {%-     with variable = init %}
 {%-         if variable.get_namespace_decorator("nest")|length > 0 %}
@@ -705,32 +682,11 @@ public:
          * update synapse internal state from `t_lastspike_` to `start->t_`
         **/
 
-        const double old___h = V_.__h;
-        V_.__h = (start->t_ + __dendritic_delay) - t_lastspike_;
-        timestep += V_.__h;
-        recompute_internal_variables();
-{%- filter indent(8, True) %}
-{%- with analytic_state_variables_ = analytic_state_variables %}
-{%-     include "directives/AnalyticIntegrationStep_begin.jinja2" %}
-{%- endwith %}
-{%- if uses_numeric_solver %}
-{%-     include "directives/GSLIntegrationStep.jinja2" %}
-{%- endif %}
-{%- with analytic_state_variables_ = analytic_state_variables %}
-{%-     include "directives/AnalyticIntegrationStep_end.jinja2" %}
-{%- endwith %}
-{%- endfilter %}
-        V_.__h = old___h;
-        recompute_internal_variables();  // XXX: can be skipped?
+        update_internal_state_(t_lastspike_, (start->t_ + __dendritic_delay) - t_lastspike_, cp);
+
+        timestep += (start->t_ + __dendritic_delay) - t_lastspike_;
 
         const double _tr_t = start->t_;
-
-// #ifdef DEBUG
-//         std::cout << "\tFacilitating, old w = " << S_.w << "\n";
-// #endif
-#ifdef DEBUG
-        std::cout << "\tFacilitating from c = " << S_.c << " (using trace = " << S_.pre_tr << ")";
-#endif
 
 {%- filter indent(6, True) %}
 {%- if post_ports is defined %}
@@ -746,13 +702,6 @@ public:
 {%-     endfor %}
 {%- endif %}
 {%- endfilter %}
-
-// #ifdef DEBUG
-//       std::cout << "\t--> new w = " << S_.w << std::endl;
-// #endif
-#ifdef DEBUG
-      std::cout << " to " << S_.c << std::endl;
-#endif
 
         /**
          * internal state has now been fully updated to `start->t_ + __dendritic_delay`
@@ -772,24 +721,7 @@ public:
     process_{{vt_port}}_spikes_( vt_spikes, t_lastspike_, __t_spike, cp );
 {%- endif %}
 
-    const double old___h = V_.__h;
-    V_.__h = __t_spike - t_lastspike_;
-    if (V_.__h > 1E-12) {
-      recompute_internal_variables();
-{%- filter indent(6, True) %}
-{%- with analytic_state_variables_ = analytic_state_variables %}
-{%-     include "directives/AnalyticIntegrationStep_begin.jinja2" %}
-{%- endwith %}
-{%- if uses_numeric_solver %}
-{%-     include "directives/GSLIntegrationStep.jinja2" %}
-{%- endif %}
-{%- with analytic_state_variables_ = analytic_state_variables %}
-{%-     include "directives/AnalyticIntegrationStep_end.jinja2" %}
-{%- endwith %}
-{%- endfilter %}
-    }
-    V_.__h = old___h;
-    recompute_internal_variables();  // XXX: can be skipped?
+    update_internal_state_(t_lastspike_, __t_spike - t_lastspike_, cp);
 
     const double _tr_t = __t_spike - __dendritic_delay;
 
@@ -1196,24 +1128,22 @@ template < typename targetidentifierT >
     set_delay(rhs.get_delay());
 }
 
-{%- if vt_ports is defined and vt_ports|length > 0  %}
 template < typename targetidentifierT >
 inline void
 {{synapseName}}< targetidentifierT >::update_internal_state_(double t_start, double timestep, const {{synapseName}}CommonSynapseProperties& cp)
 {
   if (timestep < 1E-12)
   {
-  #ifdef DEBUG
-  std::cout << "\tupdate_internal_state_() called with dt = 0\n" ;
-  #endif
+#ifdef DEBUG
+    std::cout << "\tupdate_internal_state_() called with dt < 1E-12; skipping update\n" ;
+#endif
     return;
   }
 
   const double __resolution = timestep;  // do not remove, this is necessary for the resolution() function
 
 #ifdef DEBUG
-std::cout<<"\tUpdating internal state: t_start = " << t_start << ", dt = " << timestep << "\n";
-std::cout << "\tUpdating state from pre_tr = " << S_.pre_tr << " to " ;
+  std::cout<< "\tUpdating internal state: t_start = " << t_start << ", dt = " << timestep << "\n";
 #endif
   const double old___h = V_.__h;
   V_.__h = timestep;
@@ -1231,10 +1161,7 @@ std::cout << "\tUpdating state from pre_tr = " << S_.pre_tr << " to " ;
 {%- endfilter %}
     V_.__h = old___h;
     recompute_internal_variables();  // XXX: can be skipped?
-#ifdef DEBUG
- std::cout << S_.pre_tr << "\n";
- std::cout << "\tUpdating state from w = " << S_.w << " (with c = " << S_.c << ", n = " << S_.n << ", dt = " << __resolution << ") to ";
-#endif
+
 {%- if synapse.get_update_blocks() %}
 {%- filter indent(2) %}
 {%- set dynamics = synapse.get_update_blocks() %}
@@ -1249,6 +1176,7 @@ std::cout << "\tUpdating state from pre_tr = " << S_.pre_tr << " to " ;
 {%- endif %}
 }
 
+{%- if vt_ports is defined and vt_ports|length > 0  %}
 /**
  * Update to end of timestep ``t_trig``, while processing vt spikes and post spikes
 **/


### PR DESCRIPTION
This PR refactors eliminates redundant code by consistently using the ``update_internal_state_()`` method in the NEST C++ synapse template.

Additionally, fix some whitespace and remove debug print statements.

# Todo:

- [x] Add documentation about the semantics of the ``update`` block within synapses