### PR TITLE
Fix documentation page

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-    image: latest
+    os: ubuntu-20.04
     tools:
         python: "3.9"
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
     image: latest
     tools:
-        python: 3.9
+        python: "3.9"
 
 sphinx:
     configuration: doc/sphinx-apidoc/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,11 +2,12 @@ version: 2
 
 build:
     image: latest
+    tools:
+        python: 3.9
 
 sphinx:
     configuration: doc/sphinx-apidoc/conf.py
 
 python:
-    version: 3.9
     install:
     - requirements: doc/requirements.txt


### PR DESCRIPTION
The documentation is not updated with the latest doc changes after the python version was updated to `3.9`. 

Our `.readthedocs.yml` file used the legacy build specification which only supported till python version `3.8` as mentioned [here](https://docs.readthedocs.io/en/stable/config-file/v2.html#build-image-legacy). In order to support version `3.9`, the latest build specification must be used as mentioned in [the docs](https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python). This PR updates the build specification to match the latest version so that python `3.9` can be supported.

ReadtheDocs build: https://nestml-doc.readthedocs.io/en/latest/