### PR TITLE
Fix NEST version compatibility

### DIFF
--- a/pynestml/codegeneration/resources_nest/point_neuron/common/NeuronClass.jinja2
+++ b/pynestml/codegeneration/resources_nest/point_neuron/common/NeuronClass.jinja2
@@ -189,7 +189,7 @@ template <> void RecordablesMap<{{neuronName}}>::create()
 {{neuronName}}::{{neuronName}}():{{neuron_parent_class}}(), P_(), S_(), B_(*this)
 {
   const double __resolution = nest::Time::get_resolution().get_ms();  // do not remove, this is necessary for the resolution() function
-{%- if nest_version.startswith("v2") or nest_version.startswith("v3.1") or nest_version.startswith("v3.2") or nest_version.startswith("v3.3") %}
+{%- if nest_version.startswith("v2") or nest_version.startswith("v3.0") or nest_version.startswith("v3.1") or nest_version.startswith("v3.2") or nest_version.startswith("v3.3") %}
   calibrate();
 {%- else %}
   pre_run_hook();
@@ -409,7 +409,7 @@ void {{neuronName}}::recompute_internal_variables(bool exclude_timestep) {
   }
 }
 
-{%- if nest_version.startswith("v2") or nest_version.startswith("v3.1") or nest_version.startswith("v3.2") or nest_version.startswith("v3.3") %}
+{%- if nest_version.startswith("v2") or nest_version.startswith("v3.0") or nest_version.startswith("v3.1") or nest_version.startswith("v3.2") or nest_version.startswith("v3.3") %}
 void {{neuronName}}::calibrate() {
 {%- else %}
 void {{neuronName}}::pre_run_hook() {

--- a/pynestml/codegeneration/resources_nest/point_neuron/common/NeuronHeader.jinja2
+++ b/pynestml/codegeneration/resources_nest/point_neuron/common/NeuronHeader.jinja2
@@ -400,7 +400,7 @@ private:
   /**
    * Initialize auxiliary quantities, leave parameters and state untouched.
   **/
-{%- if nest_version.startswith("v2") or nest_version.startswith("v3.1") or nest_version.startswith("v3.2") or nest_version.startswith("v3.3") %}
+{%- if nest_version.startswith("v2") or nest_version.startswith("v3.0") or nest_version.startswith("v3.1") or nest_version.startswith("v3.2") or nest_version.startswith("v3.3") %}
   void calibrate();
 {%- else %}
   void pre_run_hook();


### PR DESCRIPTION
NEST `v3.0` check is missing in some condition statements in the templates which results in compilation errors while building the code for NEST 3.0. This PR adds the missing condition.