### PR TITLE
Fix accessing predefined time variable t in synapse event handlers

### DIFF
--- a/pynestml/codegeneration/resources_nest/point_neuron/common/SynapseHeader.h.jinja2
+++ b/pynestml/codegeneration/resources_nest/point_neuron/common/SynapseHeader.h.jinja2
@@ -716,6 +716,7 @@ public:
         timestep += (start->t_ + __dendritic_delay) - t_lastspike_;
 
         const double _tr_t = start->t_;
+        auto get_t = [_tr_t](){ return _tr_t; };   // do not remove, this is in case the predefined time variable ``t`` is used in the NESTML model
 
 {%- filter indent(6, True) %}
 {%- if post_ports is defined %}
@@ -759,7 +760,10 @@ public:
 #endif
     //std::cout << "r2 = " << get_tr_r2() << std::endl;
 
-{%- filter indent(4, True) %}
+    {
+        auto get_t = [__t_spike](){ return __t_spike; };    // do not remove, this is in case the predefined time variable ``t`` is used in the NESTML model
+
+{%- filter indent(8, True) %}
 {%- for pre_port in pre_ports %}
 /**
  *  NESTML generated onReceive code block for presynaptic port "{{pre_port}}" begins here!
@@ -771,6 +775,7 @@ public:
 {%-     endwith %}
 {%- endfor %}
 {%- endfilter %}
+    }
 
 #ifdef DEBUG
     std::cout <<"\t-> new w = " << S_.w << std::endl;
@@ -794,6 +799,8 @@ public:
 
     if (pre_before_post_flag)
     {
+        auto get_t = [__t_spike](){ return __t_spike; };    // do not remove, this is in case the predefined time variable ``t`` is used in the NESTML model
+
 {%- filter indent(6, True) %}
 {%- if post_ports is defined %}
 {%-     for post_port in spiking_post_ports %}


### PR DESCRIPTION
This allows using the predefined time variable ``t`` in the synapse pre and post spike event handlers (in the ``onReceive`` blocks).