### PR TITLE
Eliminate unnecessary target from CMakeLists

### DIFF
--- a/pynestml/codegeneration/resources_nest/point_neuron/setup/CMakeLists.txt.jinja2
+++ b/pynestml/codegeneration/resources_nest/point_neuron/setup/CMakeLists.txt.jinja2
@@ -254,19 +254,6 @@ if ( BUILD_SHARED_LIBS )
       )
 endif ()
 
-# Build dynamic/static library for standard linking from NEST.
-add_library( ${MODULE_NAME}_lib ${MODULE_SOURCES} )
-if ( BUILD_SHARED_LIBS )
-  # Dynamic libraries are initiated by a `global` variable of the `SLIModule`,
-  # which is included, when the flag `LINKED_MODULE` is set.
-  target_compile_definitions( ${MODULE_NAME}_lib PRIVATE -DLINKED_MODULE )
-endif ()
-set_target_properties( ${MODULE_NAME}_lib
-    PROPERTIES
-    COMPILE_FLAGS "${NEST_CXXFLAGS}"
-    LINK_FLAGS "${NEST_LIBS}"
-    OUTPUT_NAME ${MODULE_NAME} )
-
 message( "" )
 message( "-------------------------------------------------------" )
 message( "${MODULE_NAME} Configuration Summary" )


### PR DESCRIPTION
This makes compiling/building the generated NESTML code precisely twice as fast.

@jougs: Could you comment on why the other .so was (is?) necessary?