### PR TITLE
Make ``get_blocks()`` functions consistently return lists

### DIFF
--- a/pynestml/cocos/co_co_all_variables_defined.py
+++ b/pynestml/cocos/co_co_all_variables_defined.py
@@ -76,7 +76,7 @@ class CoCoAllVariablesDefined(CoCo):
                         inline_exprs = []
                         for equations_block in node.get_equations_blocks():
                             inline_expr_names.extend([inline_expr.variable_name for inline_expr in equations_block.get_inline_expressions()])
-                            inline_exprs.extend([inline_expr for inline_expr in equations_block.get_inline_expressions()])
+                            inline_exprs.extend(equations_block.get_inline_expressions())
 
                         if var.get_name() in inline_expr_names:
                             inline_expr_idx = inline_expr_names.index(var.get_name())

--- a/pynestml/cocos/co_co_all_variables_defined.py
+++ b/pynestml/cocos/co_co_all_variables_defined.py
@@ -60,8 +60,6 @@ class CoCoAllVariablesDefined(CoCo):
 
             for var in vars:
                 symbol = var.get_scope().resolve_to_symbol(var.get_complete_name(), SymbolKind.VARIABLE)
-                # this part is required to check that we handle invariants differently
-                expr_par = node.get_parent(expr)
 
                 # test if the symbol has been defined at least
                 if symbol is None:
@@ -73,18 +71,23 @@ class CoCoAllVariablesDefined(CoCo):
                                 continue
                     else:
                         # for kernels, also allow derivatives of that kernel to appear
+
+                        inline_expr_names = []
+                        inline_exprs = []
                         for equations_block in node.get_equations_blocks():
-                            inline_expr_names = [inline_expr.variable_name for inline_expr in equations_block.get_inline_expressions()]
-                            if var.get_name() in inline_expr_names:
-                                inline_expr_idx = inline_expr_names.index(var.get_name())
-                                inline_expr = equations_block.get_inline_expressions()[inline_expr_idx]
-                                from pynestml.utils.ast_utils import ASTUtils
-                                if ASTUtils.inline_aliases_convolution(inline_expr):
-                                    symbol2 = node.get_scope().resolve_to_symbol(var.get_name(), SymbolKind.VARIABLE)
-                                    if symbol2 is not None:
-                                        # actually, no problem detected, skip error
-                                        # XXX: TODO: check that differential order is less than or equal to that of the kernel
-                                        continue
+                            inline_expr_names.extend([inline_expr.variable_name for inline_expr in equations_block.get_inline_expressions()])
+                            inline_exprs.extend([inline_expr for inline_expr in equations_block.get_inline_expressions()])
+
+                        if var.get_name() in inline_expr_names:
+                            inline_expr_idx = inline_expr_names.index(var.get_name())
+                            inline_expr = inline_exprs[inline_expr_idx]
+                            from pynestml.utils.ast_utils import ASTUtils
+                            if ASTUtils.inline_aliases_convolution(inline_expr):
+                                symbol2 = node.get_scope().resolve_to_symbol(var.get_name(), SymbolKind.VARIABLE)
+                                if symbol2 is not None:
+                                    # actually, no problem detected, skip error
+                                    # XXX: TODO: check that differential order is less than or equal to that of the kernel
+                                    continue
 
                     # check if this symbol is actually a type, e.g. "mV" in the expression "(1 + 2) * mV"
                     symbol2 = var.get_scope().resolve_to_symbol(var.get_complete_name(), SymbolKind.TYPE)
@@ -99,6 +102,7 @@ class CoCoAllVariablesDefined(CoCo):
                 # check if it is part of an invariant
                 # if it is the case, there is no "recursive" declaration
                 # so check if the parent is a declaration and the expression the invariant
+                expr_par = node.get_parent(expr)
                 if isinstance(expr_par, ASTDeclaration) and expr_par.get_invariant() == expr:
                     # in this case its ok if it is recursive or defined later on
                     continue

--- a/pynestml/cocos/co_co_all_variables_defined.py
+++ b/pynestml/cocos/co_co_all_variables_defined.py
@@ -73,11 +73,11 @@ class CoCoAllVariablesDefined(CoCo):
                                 continue
                     else:
                         # for kernels, also allow derivatives of that kernel to appear
-                        if node.get_equations_block() is not None:
-                            inline_expr_names = [inline_expr.variable_name for inline_expr in node.get_equations_block().get_inline_expressions()]
+                        for equations_block in node.get_equations_blocks():
+                            inline_expr_names = [inline_expr.variable_name for inline_expr in equations_block.get_inline_expressions()]
                             if var.get_name() in inline_expr_names:
                                 inline_expr_idx = inline_expr_names.index(var.get_name())
-                                inline_expr = node.get_equations_block().get_inline_expressions()[inline_expr_idx]
+                                inline_expr = equations_block.get_inline_expressions()[inline_expr_idx]
                                 from pynestml.utils.ast_utils import ASTUtils
                                 if ASTUtils.inline_aliases_convolution(inline_expr):
                                     symbol2 = node.get_scope().resolve_to_symbol(var.get_name(), SymbolKind.VARIABLE)

--- a/pynestml/cocos/co_co_each_block_defined_at_most_once.py
+++ b/pynestml/cocos/co_co_each_block_defined_at_most_once.py
@@ -51,53 +51,45 @@ class CoCoEachBlockDefinedAtMostOnce(CoCo):
         Checks whether each block is define at most once.
         :param node: a single neuron or synapse.
         """
-        if isinstance(node.get_state_blocks(), list) and len(node.get_state_blocks()) > 1:
+        if len(node.get_state_blocks()) > 1:
             code, message = Messages.get_block_not_defined_correctly('State', False)
             Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.ERROR)
         # check that update block is defined at most once
-        if isinstance(node.get_update_blocks(), list) and len(node.get_update_blocks()) > 1:
+        if len(node.get_update_blocks()) > 1:
             code, message = Messages.get_block_not_defined_correctly('Update', False)
             Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.ERROR)
         # check that parameters block is defined at most once
-        if isinstance(node.get_parameter_blocks(), list) and len(node.get_parameter_blocks()) > 1:
+        if len(node.get_parameters_blocks()) > 1:
             code, message = Messages.get_block_not_defined_correctly('Parameters', False)
             Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.ERROR)
         # check that internals block is defined at most once
-        if isinstance(node.get_internals_blocks(), list) and len(node.get_internals_blocks()) > 1:
+        if len(node.get_internals_blocks()) > 1:
             code, message = Messages.get_block_not_defined_correctly('Internals', False)
             Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.ERROR)
         # check that equations block is defined at most once
-        if isinstance(node.get_equations_blocks(), list) and len(node.get_equations_blocks()) > 1:
+        if len(node.get_equations_blocks()) > 1:
             code, message = Messages.get_block_not_defined_correctly('Equations', False)
             Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.ERROR)
         # check that input block is defined at most once
-        if isinstance(node.get_input_blocks(), list) and len(node.get_input_blocks()) > 1:
+        if len(node.get_input_blocks()) > 1:
             code, message = Messages.get_block_not_defined_correctly('Input', False)
             Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.ERROR)
-        elif isinstance(node.get_input_blocks(), list) and len(node.get_input_blocks()) == 0:
-            code, message = Messages.get_block_not_defined_correctly('Input', True)
-            Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
-                               log_level=LoggingLevel.WARNING)
-        elif node.get_input_blocks() is None:
+        elif len(node.get_input_blocks()) == 0:
             code, message = Messages.get_block_not_defined_correctly('Input', True)
             Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.WARNING)
         # check that output block is defined at most once
-        if isinstance(node.get_output_blocks(), list) and len(node.get_output_blocks()) > 1:
+        if len(node.get_output_blocks()) > 1:
             code, message = Messages.get_block_not_defined_correctly('Output', False)
             Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.ERROR)
-        elif isinstance(node.get_output_blocks(), list) and len(node.get_output_blocks()) == 0:
-            code, message = Messages.get_block_not_defined_correctly('Output', True)
-            Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
-                               log_level=LoggingLevel.WARNING)
-        elif node.get_output_blocks() is None:
+        elif len(node.get_output_blocks()) == 0:
             code, message = Messages.get_block_not_defined_correctly('Output', True)
             Logger.log_message(code=code, message=message, node=node, error_position=node.get_source_position(),
                                log_level=LoggingLevel.WARNING)

--- a/pynestml/cocos/co_co_function_argument_template_types_consistent.py
+++ b/pynestml/cocos/co_co_function_argument_template_types_consistent.py
@@ -19,22 +19,14 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-from pynestml.utils.ast_source_location import ASTSourceLocation
-from pynestml.meta_model.ast_declaration import ASTDeclaration
 from pynestml.cocos.co_co import CoCo
-from pynestml.symbols.error_type_symbol import ErrorTypeSymbol
-from pynestml.symbols.predefined_types import PredefinedTypes
 from pynestml.utils.ast_utils import ASTUtils
 from pynestml.utils.logger import LoggingLevel, Logger
-from pynestml.utils.logging_helper import LoggingHelper
 from pynestml.utils.messages import Messages
-from pynestml.utils.type_caster import TypeCaster
 from pynestml.visitors.ast_visitor import ASTVisitor
 from pynestml.meta_model.ast_simple_expression import ASTSimpleExpression
 from pynestml.symbols.symbol import SymbolKind
 from pynestml.symbols.template_type_symbol import TemplateTypeSymbol
-from pynestml.symbols.predefined_functions import PredefinedFunctions
-from pynestml.symbols.void_type_symbol import VoidTypeSymbol
 
 
 class CoCoFunctionArgumentTemplateTypesConsistent(CoCo):
@@ -88,7 +80,6 @@ class CorrectTemplatedArgumentTypesVisitor(ASTVisitor):
                                log_level=LoggingLevel.ERROR)
             self._failure_occurred = True
             return
-        return_type = method_symbol.get_return_type()
 
         template_symbol_to_actual_symbol = {}
         template_symbol_to_parameter_indices = {}

--- a/pynestml/cocos/co_co_function_calls_consistent.py
+++ b/pynestml/cocos/co_co_function_calls_consistent.py
@@ -18,13 +18,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
 from pynestml.cocos.co_co import CoCo
-from pynestml.meta_model.ast_expression import ASTExpression
-from pynestml.meta_model.ast_function_call import ASTFunctionCall
 from pynestml.symbols.error_type_symbol import ErrorTypeSymbol
 from pynestml.symbols.template_type_symbol import TemplateTypeSymbol
 from pynestml.symbols.symbol import SymbolKind
-from pynestml.symbols.variable_symbol import BlockType
 from pynestml.utils.ast_utils import ASTUtils
 from pynestml.utils.logger import Logger, LoggingLevel
 from pynestml.utils.messages import Messages

--- a/pynestml/cocos/co_co_kernel_type.py
+++ b/pynestml/cocos/co_co_kernel_type.py
@@ -26,7 +26,6 @@ from pynestml.codegeneration.printers.debug_types_printer import DebugTypesPrint
 from pynestml.meta_model.ast_neuron import ASTNeuron
 from pynestml.symbols.integer_type_symbol import IntegerTypeSymbol
 from pynestml.symbols.real_type_symbol import RealTypeSymbol
-from pynestml.symbols.predefined_units import PredefinedUnits
 from pynestml.symbols.predefined_types import PredefinedTypes
 from pynestml.utils.ast_utils import ASTUtils
 from pynestml.utils.logger import LoggingLevel, Logger
@@ -89,8 +88,7 @@ class KernelTypeVisitor(ASTVisitor):
                     Logger.log_message(node=self._neuron, code=code, message=message, log_level=LoggingLevel.ERROR,
                                        error_position=node.get_source_position())
                     continue
-                assert len(self._neuron.get_state_blocks().get_declarations()[0].get_variables(
-                )) == 1, "Only single variables are supported as targets of an assignment."
+                assert len(decl.get_variables()) == 1, "Only single variables are supported as targets of an assignment."
                 iv = decl.get_variables()[0]
                 if not iv.get_type_symbol().get_value().is_castable_to(PredefinedTypes.get_type("ms")**-order):
                     actual_type_str = DebugTypesPrinter().convert(iv.get_type_symbol())

--- a/pynestml/cocos/co_co_no_duplicate_compilation_unit_names.py
+++ b/pynestml/cocos/co_co_no_duplicate_compilation_unit_names.py
@@ -18,8 +18,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
 from pynestml.cocos.co_co import CoCo
-from pynestml.utils.ast_utils import ASTUtils
 from pynestml.utils.logger import LoggingLevel, Logger
 from pynestml.utils.messages import Messages
 

--- a/pynestml/cocos/co_co_ode_functions_have_consistent_units.py
+++ b/pynestml/cocos/co_co_ode_functions_have_consistent_units.py
@@ -18,12 +18,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
 from pynestml.cocos.co_co import CoCo
 from pynestml.utils.logger import LoggingLevel, Logger
 from pynestml.utils.messages import Messages
 from pynestml.visitors.ast_visitor import ASTVisitor
-from pynestml.symbols.symbol import SymbolKind
-from astropy import units
 
 
 class CoCoOdeFunctionsHaveConsistentUnits(CoCo):

--- a/pynestml/cocos/co_co_output_port_defined_if_emit_call.py
+++ b/pynestml/cocos/co_co_output_port_defined_if_emit_call.py
@@ -24,12 +24,8 @@ from typing import Optional
 from pynestml.cocos.co_co import CoCo
 from pynestml.meta_model.ast_function_call import ASTFunctionCall
 from pynestml.meta_model.ast_neuron import ASTNeuron
-from pynestml.symbols.error_type_symbol import ErrorTypeSymbol
-from pynestml.symbols.template_type_symbol import TemplateTypeSymbol
-from pynestml.symbols.symbol import SymbolKind
 from pynestml.utils.logger import Logger, LoggingLevel
 from pynestml.utils.messages import Messages
-from pynestml.utils.type_caster import TypeCaster
 from pynestml.visitors.ast_visitor import ASTVisitor
 
 
@@ -58,21 +54,27 @@ class OutputPortDefinedIfEmitCalledVisitor(ASTVisitor):
 
     def visit_function_call(self, node: ASTFunctionCall):
         """
-        Check consistency for a single function call: check if the called function has been declared, whether the number and types of arguments correspond to the declaration, etc.
+        If an emit_spike() function is found, check output block exists and has spike type.
 
         :param node: a single function call.
         """
         assert self.neuron is not None
         func_name = node.get_name()
         if func_name == 'emit_spike':
-            output_block = self.neuron.get_output_blocks()
-            if output_block is None:
+            output_blocks = self.neuron.get_output_blocks()
+            if not output_blocks:
                 code, message = Messages.get_block_not_defined_correctly('output', missing=True)
                 Logger.log_message(error_position=node.get_source_position(), log_level=LoggingLevel.ERROR,
                                    code=code, message=message)
                 return
 
-            if not output_block.is_spike():
+            spike_output_exists = False
+            for output_block in output_blocks:
+                if output_block.is_spike():
+                    spike_output_exists = True
+                    break
+
+            if not spike_output_exists:
                 code, message = Messages.get_emit_spike_function_but_no_output_port()
                 Logger.log_message(code=code, message=message, log_level=LoggingLevel.ERROR,
                                    error_position=node.get_source_position())

--- a/pynestml/cocos/co_co_priorities_correctly_specified.py
+++ b/pynestml/cocos/co_co_priorities_correctly_specified.py
@@ -22,8 +22,6 @@
 from typing import Dict
 
 from pynestml.cocos.co_co import CoCo
-from pynestml.symbols.symbol import SymbolKind
-from pynestml.meta_model.ast_neuron import ASTNeuron
 from pynestml.meta_model.ast_synapse import ASTSynapse
 from pynestml.utils.logger import LoggingLevel, Logger
 from pynestml.utils.messages import Messages

--- a/pynestml/cocos/co_co_resolution_func_legally_used.py
+++ b/pynestml/cocos/co_co_resolution_func_legally_used.py
@@ -23,7 +23,6 @@ from pynestml.cocos.co_co import CoCo
 from pynestml.meta_model.ast_equations_block import ASTEquationsBlock
 from pynestml.meta_model.ast_function import ASTFunction
 from pynestml.meta_model.ast_simple_expression import ASTSimpleExpression
-from pynestml.symbols.symbol import SymbolKind
 from pynestml.utils.logger import LoggingLevel, Logger
 from pynestml.utils.messages import Messages
 from pynestml.visitors.ast_visitor import ASTVisitor

--- a/pynestml/cocos/co_co_simple_delta_function.py
+++ b/pynestml/cocos/co_co_simple_delta_function.py
@@ -18,13 +18,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
 from pynestml.cocos.co_co import CoCo
-from pynestml.meta_model.ast_declaration import ASTDeclaration
-from pynestml.symbols.symbol import SymbolKind
-from pynestml.symbols.variable_symbol import BlockType
 from pynestml.utils.logger import Logger, LoggingLevel
 from pynestml.utils.messages import Messages
-from pynestml.visitors.ast_visitor import ASTVisitor
 from pynestml.visitors.ast_higher_order_visitor import ASTHigherOrderVisitor
 from pynestml.meta_model.ast_simple_expression import ASTSimpleExpression
 from pynestml.meta_model.ast_kernel import ASTKernel

--- a/pynestml/cocos/co_co_vector_parameter_declared_in_right_block.py
+++ b/pynestml/cocos/co_co_vector_parameter_declared_in_right_block.py
@@ -18,10 +18,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
 from pynestml.cocos.co_co import CoCo
 from pynestml.meta_model.ast_declaration import ASTDeclaration
 from pynestml.meta_model.ast_neuron import ASTNeuron
-from pynestml.meta_model.ast_variable import ASTVariable
 from pynestml.symbols.integer_type_symbol import IntegerTypeSymbol
 from pynestml.symbols.symbol import SymbolKind
 from pynestml.symbols.variable_symbol import BlockType

--- a/pynestml/codegeneration/nest_code_generator.py
+++ b/pynestml/codegeneration/nest_code_generator.py
@@ -40,7 +40,6 @@ from pynestml.codegeneration.printers.nest_reference_converter import NESTRefere
 from pynestml.codegeneration.printers.ode_toolbox_reference_converter import ODEToolboxReferenceConverter
 from pynestml.frontend.frontend_configuration import FrontendConfiguration
 from pynestml.meta_model.ast_assignment import ASTAssignment
-from pynestml.meta_model.ast_equations_block import ASTEquationsBlock
 from pynestml.meta_model.ast_input_port import ASTInputPort
 from pynestml.meta_model.ast_neuron import ASTNeuron
 from pynestml.meta_model.ast_kernel import ASTKernel
@@ -64,9 +63,7 @@ from pynestml.visitors.ast_random_number_generator_visitor import ASTRandomNumbe
 def find_spiking_post_port(synapse, namespace):
     if "paired_neuron" in dir(synapse):
         for post_port_name in namespace["post_ports"]:
-            if synapse.get_input_blocks() \
-                    and synapse.get_input_blocks().get_input_ports() \
-                    and ASTUtils.get_input_port_by_name(synapse.get_input_blocks(), post_port_name).is_spike():
+            if ASTUtils.get_input_port_by_name(synapse.get_input_blocks(), post_port_name).is_spike():
                 return post_port_name
     return None
 
@@ -232,15 +229,18 @@ class NESTCodeGenerator(CodeGenerator):
         code, message = Messages.get_start_processing_model(neuron.get_name())
         Logger.log_message(neuron, code, message, neuron.get_source_position(), LoggingLevel.INFO)
 
-        equations_block = neuron.get_equations_block()
-
-        if equations_block is None:
+        if not neuron.get_equations_blocks():
             # add all declared state variables as none of them are used in equations block
             self.non_equations_state_variables[neuron.get_name()] = []
             self.non_equations_state_variables[neuron.get_name()].extend(
                 ASTUtils.all_variables_defined_in_block(neuron.get_state_blocks()))
 
             return [], [], []
+
+        if len(neuron.get_equations_blocks()) > 1:
+            raise Exception("Only one equations block per model supported for now")
+
+        equations_block = neuron.get_equations_blocks()[0]
 
         delta_factors = ASTUtils.get_delta_factors_(neuron, equations_block)
         kernel_buffers = ASTUtils.generate_kernel_buffers_(neuron, equations_block)
@@ -259,26 +259,23 @@ class NESTCodeGenerator(CodeGenerator):
         self.numeric_solver[neuron.get_name()] = numeric_solver
 
         self.non_equations_state_variables[neuron.get_name()] = []
-        for decl in neuron.get_state_blocks().get_declarations():
-            for var in decl.get_variables():
-                # check if this variable is not in equations
-                if not neuron.get_equations_blocks():
-                    self.non_equations_state_variables[neuron.get_name()].append(var)
-                    continue
+        for block in neuron.get_state_blocks():
+            for decl in block.get_declarations():
+                for var in decl.get_variables():
+                    used_in_eq = False
+                    for equations_block in neuron.get_equations_blocks():
+                        for ode_eq in equations_block.get_ode_equations():
+                            if ode_eq.get_lhs().get_name() == var.get_name():
+                                used_in_eq = True
+                                break
+                        for kern in equations_block.get_kernels():
+                            for kern_var in kern.get_variables():
+                                if kern_var.get_name() == var.get_name():
+                                    used_in_eq = True
+                                    break
 
-                used_in_eq = False
-                for ode_eq in neuron.get_equations_blocks().get_ode_equations():
-                    if ode_eq.get_lhs().get_name() == var.get_name():
-                        used_in_eq = True
-                        break
-                for kern in neuron.get_equations_blocks().get_kernels():
-                    for kern_var in kern.get_variables():
-                        if kern_var.get_name() == var.get_name():
-                            used_in_eq = True
-                            break
-
-                if not used_in_eq:
-                    self.non_equations_state_variables[neuron.get_name()].append(var)
+                    if not used_in_eq:
+                        self.non_equations_state_variables[neuron.get_name()].append(var)
 
         ASTUtils.remove_initial_values_for_kernels(neuron)
         kernels = ASTUtils.remove_kernel_definitions_from_equations_block(neuron)
@@ -312,9 +309,13 @@ class NESTCodeGenerator(CodeGenerator):
         code, message = Messages.get_start_processing_model(synapse.get_name())
         Logger.log_message(synapse, code, message, synapse.get_source_position(), LoggingLevel.INFO)
 
-        equations_block = synapse.get_equations_block()
         spike_updates = {}
-        if equations_block is not None:
+        if synapse.get_equations_blocks():
+            if len(synapse.get_equations_blocks()) > 1:
+                raise Exception("Only one equations block per model supported for now")
+
+            equations_block = synapse.get_equations_blocks()[0]
+
             delta_factors = ASTUtils.get_delta_factors_(synapse, equations_block)
             kernel_buffers = ASTUtils.generate_kernel_buffers_(synapse, equations_block)
             ASTUtils.replace_convolve_calls_with_buffers_(synapse, equations_block)
@@ -360,19 +361,20 @@ class NESTCodeGenerator(CodeGenerator):
 
         namespace["nest_version"] = self.get_option("nest_version")
 
+        all_input_port_names = []
+        for input_block in synapse.get_input_blocks():
+            all_input_port_names.extend([p.name for p in input_block.get_input_ports()])
+
         if "paired_neuron" in dir(synapse):
             # synapse is being co-generated with neuron
             namespace["paired_neuron"] = synapse.paired_neuron.get_name()
             namespace["post_ports"] = synapse.post_port_names
-
             namespace["spiking_post_ports"] = synapse.spiking_post_port_names
             namespace["vt_ports"] = synapse.vt_port_names
-            all_input_port_names = [p.name for p in synapse.get_input_blocks().get_input_ports()]
             namespace["pre_ports"] = list(set(all_input_port_names)
                                           - set(namespace["post_ports"]) - set(namespace["vt_ports"]))
         else:
             # separate (not neuron+synapse co-generated)
-            all_input_port_names = [p.name for p in synapse.get_input_blocks().get_input_ports()]
             namespace["pre_ports"] = all_input_port_names
 
         assert len(namespace["pre_ports"]) <= 1, "Synapses only support one spiking input port"
@@ -423,7 +425,7 @@ class NESTCodeGenerator(CodeGenerator):
             and self.analytic_solver[synapse.get_name()] is not None
         if namespace["uses_analytic_solver"]:
             namespace["analytic_state_variables"] = self.analytic_solver[synapse.get_name()]["state_variables"]
-            namespace["variable_symbols"].update({sym: synapse.get_equations_block().get_scope().resolve_to_symbol(
+            namespace["variable_symbols"].update({sym: synapse.get_equations_blocks()[0].get_scope().resolve_to_symbol(
                 sym, SymbolKind.VARIABLE) for sym in namespace["analytic_state_variables"]})
             namespace["update_expressions"] = {}
             for sym, expr in self.analytic_solver[synapse.get_name()]["initial_values"].items():
@@ -433,7 +435,7 @@ class NESTCodeGenerator(CodeGenerator):
                 expr_ast = ModelParser.parse_expression(expr_str)
                 # pretend that update expressions are in "equations" block, which should always be present,
                 # as differential equations must have been defined to get here
-                expr_ast.update_scope(synapse.get_equations_blocks().get_scope())
+                expr_ast.update_scope(synapse.get_equations_blocks()[0].get_scope())
                 expr_ast.accept(ASTSymbolTableVisitor())
                 namespace["update_expressions"][sym] = expr_ast
 
@@ -443,7 +445,7 @@ class NESTCodeGenerator(CodeGenerator):
             and self.numeric_solver[synapse.get_name()] is not None
         if namespace["uses_numeric_solver"]:
             namespace["numeric_state_variables"] = self.numeric_solver[synapse.get_name()]["state_variables"]
-            namespace["variable_symbols"].update({sym: synapse.get_equations_block().get_scope().resolve_to_symbol(
+            namespace["variable_symbols"].update({sym: synapse.get_equations_blocks()[0].get_scope().resolve_to_symbol(
                 sym, SymbolKind.VARIABLE) for sym in namespace["numeric_state_variables"]})
             assert not any([sym is None for sym in namespace["variable_symbols"].values()])
             namespace["numeric_update_expressions"] = {}
@@ -454,7 +456,7 @@ class NESTCodeGenerator(CodeGenerator):
                 expr_ast = ModelParser.parse_expression(expr_str)
                 # pretend that update expressions are in "equations" block, which should always be present,
                 # as differential equations must have been defined to get here
-                expr_ast.update_scope(synapse.get_equations_blocks().get_scope())
+                expr_ast.update_scope(synapse.get_equations_blocks()[0].get_scope())
                 expr_ast.accept(ASTSymbolTableVisitor())
                 namespace["numeric_update_expressions"][sym] = expr_ast
 
@@ -549,11 +551,11 @@ class NESTCodeGenerator(CodeGenerator):
                                 moved = True
                     if not moved:
                         namespace["analytic_state_variables"].append(sv)
-                namespace["variable_symbols"].update({sym: neuron.get_equations_block().get_scope().resolve_to_symbol(
+                namespace["variable_symbols"].update({sym: neuron.get_equations_blocks()[0].get_scope().resolve_to_symbol(
                     sym, SymbolKind.VARIABLE) for sym in namespace["analytic_state_variables_moved"]})
             else:
                 namespace["analytic_state_variables"] = self.analytic_solver[neuron.get_name()]["state_variables"]
-            namespace["variable_symbols"].update({sym: neuron.get_equations_block().get_scope().resolve_to_symbol(
+            namespace["variable_symbols"].update({sym: neuron.get_equations_blocks()[0].get_scope().resolve_to_symbol(
                 sym, SymbolKind.VARIABLE) for sym in namespace["analytic_state_variables"]})
 
             namespace["update_expressions"] = {}
@@ -564,7 +566,7 @@ class NESTCodeGenerator(CodeGenerator):
                 expr_ast = ModelParser.parse_expression(expr_str)
                 # pretend that update expressions are in "equations" block, which should always be present,
                 # as differential equations must have been defined to get here
-                expr_ast.update_scope(neuron.get_equations_blocks().get_scope())
+                expr_ast.update_scope(neuron.get_equations_blocks()[0].get_scope())
                 expr_ast.accept(ASTSymbolTableVisitor())
                 namespace["update_expressions"][sym] = expr_ast
 
@@ -605,13 +607,19 @@ class NESTCodeGenerator(CodeGenerator):
                                 moved = True
                     if not moved:
                         namespace["numeric_state_variables"].append(sv)
-                namespace["variable_symbols"].update({sym: neuron.get_equations_block().get_scope().resolve_to_symbol(
+                namespace["variable_symbols"].update({sym: neuron.get_equations_blocks()[0].get_scope().resolve_to_symbol(
                     sym, SymbolKind.VARIABLE) for sym in namespace["numeric_state_variables_moved"]})
             else:
                 namespace["numeric_state_variables"] = self.numeric_solver[neuron.get_name()]["state_variables"]
 
-            namespace["variable_symbols"].update({sym: neuron.get_equations_block().get_scope().resolve_to_symbol(
-                sym, SymbolKind.VARIABLE) for sym in namespace["numeric_state_variables"]})
+            namespace["variable_symbols"] = {}
+            for var_name in namespace["numeric_state_variables"]:
+                for equations_block in neuron.get_equations_blocks():
+                    sym = equations_block.get_scope().resolve_to_symbol(var_name, SymbolKind.VARIABLE)
+                    if sym:
+                        namespace["variable_symbols"].update({var_name: sym})
+                        break
+
             assert not any([sym is None for sym in namespace["variable_symbols"].values()])
             for sym, expr in self.numeric_solver[neuron.get_name()]["initial_values"].items():
                 namespace["initial_values"][sym] = expr
@@ -665,16 +673,16 @@ class NESTCodeGenerator(CodeGenerator):
         """
         Prepare data for ODE-toolbox input format, invoke ODE-toolbox analysis via its API, and return the output.
         """
-        assert isinstance(neuron.get_equations_blocks(), ASTEquationsBlock), "only one equation block should be present"
+        assert len(neuron.get_equations_blocks()) <= 1, "Only one equations block supported for now."
+        assert len(neuron.get_parameters_blocks()) <= 1, "Only one parameters block supported for now."
 
-        equations_block = neuron.get_equations_block()
+        equations_block = neuron.get_equations_blocks()[0]
 
         if len(equations_block.get_kernels()) == 0 and len(equations_block.get_ode_equations()) == 0:
             # no equations defined -> no changes to the neuron
             return None, None
 
-        parameters_block = neuron.get_parameter_blocks()
-        odetoolbox_indict = ASTUtils.transform_ode_and_kernels_to_json(neuron, parameters_block, kernel_buffers, printer=self._ode_toolbox_printer)
+        odetoolbox_indict = ASTUtils.transform_ode_and_kernels_to_json(neuron, neuron.get_parameters_blocks(), kernel_buffers, printer=self._ode_toolbox_printer)
         odetoolbox_indict["options"] = {}
         odetoolbox_indict["options"]["output_timestep_symbol"] = "__h"
         solver_result = odetoolbox.analysis(odetoolbox_indict,

--- a/pynestml/codegeneration/nest_code_generator.py
+++ b/pynestml/codegeneration/nest_code_generator.py
@@ -629,7 +629,7 @@ class NESTCodeGenerator(CodeGenerator):
                 expr_ast = ModelParser.parse_expression(expr_str)
                 # pretend that update expressions are in "equations" block, which should always be present,
                 # as differential equations must have been defined to get here
-                expr_ast.update_scope(neuron.get_equations_blocks().get_scope())
+                expr_ast.update_scope(neuron.get_equations_blocks()[0].get_scope())
                 expr_ast.accept(ASTSymbolTableVisitor())
                 namespace["numeric_update_expressions"][sym] = expr_ast
 

--- a/pynestml/codegeneration/printers/nest_printer.py
+++ b/pynestml/codegeneration/printers/nest_printer.py
@@ -64,7 +64,6 @@ from pynestml.meta_model.ast_update_block import ASTUpdateBlock
 from pynestml.meta_model.ast_variable import ASTVariable
 from pynestml.meta_model.ast_while_stmt import ASTWhileStmt
 from pynestml.symbols.symbol import SymbolKind
-from pynestml.symbols.variable_symbol import VariableSymbol
 
 
 class NestPrinter(Printer):

--- a/pynestml/codegeneration/resources_autodoc/nestml_neuron_model.jinja2
+++ b/pynestml/codegeneration/resources_autodoc/nestml_neuron_model.jinja2
@@ -7,40 +7,39 @@
 Parameters
 ++++++++++
 
-{{ neuron.print_parameter_comment() }}
-
-{% with block = neuron.get_parameter_blocks() %}
+{% for block in neuron.get_parameters_blocks() %}
+{{ block.print_comment() }}
 {%- include "block_decl_table.jinja2" %}
-{% endwith %}
+{%- endfor %}
 
 
 
 State variables
 +++++++++++++++
 
-{% with block = neuron.get_state_blocks() %}
+{% for block in neuron.get_state_blocks() %}
 {%- include "block_decl_table.jinja2" %}
-{% endwith %}
+{% endfor %}
 
 
 
 Equations
 +++++++++
 
-{% with block = neuron.get_equations_block() %}
-{% for eq in block.get_ode_equations() %}
+{%  for block in neuron.get_equations_blocks() %}
+{%-     for eq in block.get_ode_equations() %}
 
 .. math::
-{%- if eq.get_lhs().differential_order == 1 %}
+{%-         if eq.get_lhs().differential_order == 1 %}
    \frac{ d{{ printer.print_expression(eq.get_lhs()) | replace("'", "") }} } { dt }
-{%- elif eq.get_lhs().differential_order > 1 %}
+{%-         elif eq.get_lhs().differential_order > 1 %}
    \frac{ d^{{ eq.get_lhs().differential_order }} {{ printer.print_expression(eq.get_lhs()) | replace("'", "") }} } { dt^{{ eq.get_lhs().differential_order }} }
-{%- else %} {# differential_order == 0 #}
+{%-         else %} {# differential_order == 0 #}
    {{ eq.get_lhs().get_name() }}
-{%- endif -%}
+{%-         endif -%}
    = {{ printer.print_expression(eq.get_rhs()) }}
-{% endfor %}
-{% endwith %}
+{%-     endfor %}
+{%- endfor %}
 
 
 

--- a/pynestml/codegeneration/resources_autodoc/nestml_synapse_model.jinja2
+++ b/pynestml/codegeneration/resources_autodoc/nestml_synapse_model.jinja2
@@ -7,21 +7,20 @@
 Parameters
 ++++++++++
 
-{{ synapse.print_parameter_comment() }}
-
-{% with block = synapse.get_parameter_blocks() %}
+{% for block in synapse.get_parameters_blocks() %}
+{{ block.print_comment() }}
 {%- include "block_decl_table.jinja2" %}
-{% endwith %}
+{%- endfor %}
 
-{%- if synapse.get_state_blocks() is not none %}
+{%- if synapse.get_state_blocks() %}
 
 
 State variables
 +++++++++++++++
 
-{% with block = synapse.get_state_blocks() %}
+{% for block in synapse.get_state_blocks() %}
 {%- include "block_decl_table.jinja2" %}
-{%- endwith %}
+{%- endfor %}
 {%- endif %}
 Source code
 +++++++++++

--- a/pynestml/codegeneration/resources_nest/point_neuron/common/NeuronClass.jinja2
+++ b/pynestml/codegeneration/resources_nest/point_neuron/common/NeuronClass.jinja2
@@ -475,9 +475,9 @@ double {{neuronName}}::get_delayed_{{variable.get_symbol_name()}}() const
 {%-   endfor %}
 
 {%- endif %}
-{%- if neuron.print_dynamics_comment('*')|length > 1 %}
+{%- if neuron.print_comment('*')|length > 1 %}
 /*
- {{neuron.print_dynamics_comment('*')}}
+ {{neuron.print_comment('*')}}
  */
 {%- endif %}
 void {{neuronName}}::update(nest::Time const & origin,const long from, const long to)
@@ -509,12 +509,17 @@ void {{neuronName}}::update(nest::Time const & origin,const long from, const lon
     // NESTML generated code for the update block:
 
 {%- if neuron.get_update_blocks() %}
-{%- filter indent(2) %}
-{%- set dynamics = neuron.get_update_blocks() %}
-{%- with ast = dynamics.get_block() %}
-{%-   include "directives/Block.jinja2" %}
-{%- endwith %}
-{%- endfilter %}
+{%-     filter indent(2) %}
+{%-         for block in neuron.get_update_blocks() %}
+{%-             set ast = block.get_block() %}
+{%-             if ast.print_comment('*')|length > 1 %}
+/*
+ {{ast.print_comment('*')}}
+ */
+{%-             endif %}
+{%-             include "directives/Block.jinja2" %}
+{%-         endfor %}
+{%-     endfilter %}
 {%- endif %}
 
     // voltage logging
@@ -690,18 +695,18 @@ void
             assert(history_.back().t_ == last_spike_);
 
 {%- for var in purely_numeric_state_variables_moved|sort %}
-            S_.{{names.name(neuron.get_equations_block().get_scope().resolve_to_symbol(var, SymbolKind.VARIABLE))}} = history_.back().{{var}}_;
+            S_.{{names.name(neuron.get_equations_blocks()[0].get_scope().resolve_to_symbol(var, SymbolKind.VARIABLE))}} = history_.back().{{var}}_;
 {%- endfor %}
 {%- for var in analytic_state_variables_moved|sort %}
-            S_.{{names.name(neuron.get_equations_block().get_scope().resolve_to_symbol(var, SymbolKind.VARIABLE))}} = history_.back().{{var}}_;
+            S_.{{names.name(neuron.get_equations_blocks()[0].get_scope().resolve_to_symbol(var, SymbolKind.VARIABLE))}} = history_.back().{{var}}_;
 {%- endfor %}
         }
         else {
 {%- for var in purely_numeric_state_variables_moved|sort %}
-            S_.{{names.name(neuron.get_equations_block().get_scope().resolve_to_symbol(var, SymbolKind.VARIABLE))}} = 0.; // initial value for convolution is always 0
+            S_.{{names.name(neuron.get_equations_blocks()[0].get_scope().resolve_to_symbol(var, SymbolKind.VARIABLE))}} = 0.; // initial value for convolution is always 0
 {%- endfor %}
 {%- for var in analytic_state_variables_moved|sort %}
-            S_.{{names.name(neuron.get_equations_block().get_scope().resolve_to_symbol(var, SymbolKind.VARIABLE))}} = 0.; // initial value for convolution is always 0
+            S_.{{names.name(neuron.get_equations_blocks()[0].get_scope().resolve_to_symbol(var, SymbolKind.VARIABLE))}} = 0.; // initial value for convolution is always 0
 {%- endfor %}
         }
 
@@ -768,7 +773,7 @@ S_.ode_state[State_::{{variable_name}}] = ode_state_bak[State_::{{variable_name}
 {%- endfor %}
 
 {%- for _, spike_update in post_spike_updates.items() %}
-        S_.{{names.name(neuron.get_equations_block().get_scope().resolve_to_symbol(spike_update.get_variable().get_complete_name(), SymbolKind.VARIABLE))}} += 1.;
+        S_.{{names.name(neuron.get_equations_blocks()[0].get_scope().resolve_to_symbol(spike_update.get_variable().get_complete_name(), SymbolKind.VARIABLE))}} += 1.;
 {%- endfor %}
 
     last_spike_ = t_sp_ms;
@@ -840,10 +845,10 @@ double
 #endif
 
 {%- for var_ in purely_numeric_state_variables_moved %}
-      S_.{{names.name(neuron.get_equations_block().get_scope().resolve_to_symbol(var_, SymbolKind.VARIABLE))}} = history_[ i ].{{var_}}_;
+      S_.{{names.name(neuron.get_equations_blocks()[0].get_scope().resolve_to_symbol(var_, SymbolKind.VARIABLE))}} = history_[ i ].{{var_}}_;
 {%- endfor %}
 {%- for var_ in analytic_state_variables_moved %}
-      S_.{{names.name(neuron.get_equations_block().get_scope().resolve_to_symbol(var_, SymbolKind.VARIABLE))}} = history_[ i ].{{var_}}_;
+      S_.{{names.name(neuron.get_equations_blocks()[0].get_scope().resolve_to_symbol(var_, SymbolKind.VARIABLE))}} = history_[ i ].{{var_}}_;
 {%- endfor %}
 
       /**
@@ -904,10 +909,10 @@ S_.ode_state[State_::{{variable_name}}] = ode_state_tmp[State_::{{variable_name}
   if ( (!before_increment) && t == history_[ 0 ].t_)
   {
 {%- for var_ in purely_numeric_state_variables_moved %}
-    S_.{{names.name(neuron.get_equations_block().get_scope().resolve_to_symbol(var_, SymbolKind.VARIABLE))}} = history_[ 0 ].{{var_}}_;
+    S_.{{names.name(neuron.get_equations_blocks()[0].get_scope().resolve_to_symbol(var_, SymbolKind.VARIABLE))}} = history_[ 0 ].{{var_}}_;
 {%- endfor %}
 {%- for var_ in analytic_state_variables_moved %}
-    S_.{{names.name(neuron.get_equations_block().get_scope().resolve_to_symbol(var_, SymbolKind.VARIABLE))}} = history_[ 0 ].{{var_}}_;
+    S_.{{names.name(neuron.get_equations_blocks()[0].get_scope().resolve_to_symbol(var_, SymbolKind.VARIABLE))}} = history_[ 0 ].{{var_}}_;
 {%- endfor %}
 
 #ifdef DEBUG
@@ -928,10 +933,10 @@ S_.ode_state[State_::{{variable_name}}] = ode_state_tmp[State_::{{variable_name}
 
   // set to initial value
 {%- for var_ in purely_numeric_state_variables_moved %}
-  S_.{{names.name(neuron.get_equations_block().get_scope().resolve_to_symbol(var_, SymbolKind.VARIABLE))}} = 0.;  // initial value for convolution is always 0
+  S_.{{names.name(neuron.get_equations_blocks()[0].get_scope().resolve_to_symbol(var_, SymbolKind.VARIABLE))}} = 0.;  // initial value for convolution is always 0
 {%- endfor %}
 {%- for var_ in analytic_state_variables_moved %}
-  S_.{{names.name(neuron.get_equations_block().get_scope().resolve_to_symbol(var_, SymbolKind.VARIABLE))}} = 0.;  // initial value for convolution is always 0
+  S_.{{names.name(neuron.get_equations_blocks()[0].get_scope().resolve_to_symbol(var_, SymbolKind.VARIABLE))}} = 0.;  // initial value for convolution is always 0
 {%- endfor %}
 
   // propagate in time

--- a/pynestml/codegeneration/resources_nest/point_neuron/common/NeuronHeader.jinja2
+++ b/pynestml/codegeneration/resources_nest/point_neuron/common/NeuronHeader.jinja2
@@ -429,7 +429,9 @@ private:
   /**
    * Free parameters of the neuron.
    *
-   {{neuron.print_parameter_comment("*")}}
+{% for block in neuron.get_parameters_blocks() %}
+{{ block.print_comment() }}
+{%- endfor %}
    *
    * These are the parameters that can be set by the user through @c `node.set()`.
    * They are initialized from the model prototype when the node is created.
@@ -467,7 +469,9 @@ private:
   /**
    * Dynamic state of the neuron.
    *
-   {{neuron.print_state_comment('*')}}
+{%- for state_block in neuron.get_state_blocks() %}
+   {{ state_block.print_comment('*') }}
+{%- endfor %}
    *
    * These are the state variables that are advanced in time by calls to
    * @c update(). In many models, some or all of them can be set by the user
@@ -551,7 +555,9 @@ private:
   /**
    * Internal variables of the neuron.
    *
-   {{neuron.print_internal_comment('*')}}
+{%- for internals_block in neuron.get_internals_blocks() %}
+   {{ internals_block.print_comment('*') }}
+{%- endfor %}
    *
    * These variables must be initialized by @c pre_run_hook (or calibrate in NEST 3.3 and older), which is called before
    * the first call to @c update() upon each call to @c Simulate.

--- a/pynestml/codegeneration/resources_nest/point_neuron/common/SynapseHeader.h.jinja2
+++ b/pynestml/codegeneration/resources_nest/point_neuron/common/SynapseHeader.h.jinja2
@@ -290,7 +290,9 @@ private:
   /**
    * Free parameters of the synapse.
    *
-   {{synapse.print_parameter_comment("*")}}
+{% for block in synapse.get_parameters_blocks() %}
+{{ block.print_comment() }}
+{%- endfor %}
    *
    * These are the parameters that can be set by the user through @c SetStatus.
    * Parameters do not change during calls to ``send()`` and are not reset by
@@ -329,7 +331,9 @@ private:
   /**
    * Internal variables of the synapse.
    *
-   {{synapse.print_internal_comment('*')}}
+{%- for internals_block in synapse.get_internals_blocks() %}
+   {{ internals_block.print_comment('*') }}
+{%- endfor %}
    *
    * These variables must be initialized by recompute_internal_variables().
   **/
@@ -785,7 +789,7 @@ public:
 {%- for spike_updates_for_port in spike_updates.values() %}
 {%-     for spike_update in spike_updates_for_port -%}
     // XXX: TODO: increment with initial value instead of 1
-    S_.{{names.name(synapse.get_state_blocks().get_scope().resolve_to_symbol(spike_update.get_variable().get_complete_name(), SymbolKind.VARIABLE))}} += 1.;
+    S_.{{names.name(utils.resolve_to_variable_symbol_in_blocks(spike_update.get_variable().get_complete_name(), synapse.get_state_blocks()))}} += 1.;
 {%-     endfor %}
 {%- endfor %}
 
@@ -1192,12 +1196,11 @@ inline void
     recompute_internal_variables();  // XXX: can be skipped?
 
 {%- if synapse.get_update_blocks() %}
-{%- filter indent(2) %}
-{%- set dynamics = synapse.get_update_blocks() %}
-{%- with ast = dynamics.get_block() %}
-{%-   include "directives/Block.jinja2" %}
-{%- endwith %}
-{%- endfilter %}
+{%-     filter indent(2) %}
+{%-         for ast in synapse.get_update_blocks() %}
+{%-             include "directives/Block.jinja2" %}
+{%-         endfor %}
+{%-     endfilter %}
 {%- endif %}
 
 {%- if vt_ports is defined and vt_ports|length > 0  %}

--- a/pynestml/codegeneration/resources_nest/point_neuron/common/SynapseHeader.h.jinja2
+++ b/pynestml/codegeneration/resources_nest/point_neuron/common/SynapseHeader.h.jinja2
@@ -1195,9 +1195,17 @@ inline void
     V_.__h = old___h;
     recompute_internal_variables();  // XXX: can be skipped?
 
+    // NESTML generated code for the update block:
+
 {%- if synapse.get_update_blocks() %}
 {%-     filter indent(2) %}
-{%-         for ast in synapse.get_update_blocks() %}
+{%-         for block in synapse.get_update_blocks() %}
+{%-             set ast = block.get_block() %}
+{%-             if ast.print_comment('*')|length > 1 %}
+/*
+ {{ast.print_comment('*')}}
+ */
+{%-             endif %}
 {%-             include "directives/Block.jinja2" %}
 {%-         endfor %}
 {%-     endfilter %}

--- a/pynestml/codegeneration/resources_nest/point_neuron/directives/GSLDifferentiationFunction.jinja2
+++ b/pynestml/codegeneration/resources_nest/point_neuron/directives/GSLDifferentiationFunction.jinja2
@@ -30,12 +30,12 @@ extern "C" inline int {{neuronName}}_dynamics(double, const double ode_state[], 
 {%- if paired_synapse is defined %}
 {%- for variable_name in numeric_state_variables_moved %}
 {%-   set update_expr = numeric_update_expressions[variable_name] %}
-{%-   set variable_sym = utils.resolve_to_variable_symbol_in_blocks(variable_name, synapse.get_state_blocks()) %}
+{%-   set variable_sym = utils.resolve_to_variable_symbol_in_blocks(variable_name, neuron.get_state_blocks()) %}
   f[{{names.array_index(variable_sym)}}] = {{printerGSL.print_expression(update_expr, prefix="node.")}};
 {%- endfor %}
 {%- endif %}
 {%- for variable_name in non_equations_state_variables %}
-{%-   set variable_sym = utils.resolve_to_variable_symbol_in_blocks(variable_name, synapse.get_state_blocks()) %}
+{%-   set variable_sym = utils.resolve_to_variable_symbol_in_blocks(variable_name, neuron.get_state_blocks()) %}
   f[{{names.array_index(variable_sym)}}] = 0.;
 {%- endfor %}
 

--- a/pynestml/codegeneration/resources_nest/point_neuron/directives/GSLDifferentiationFunction.jinja2
+++ b/pynestml/codegeneration/resources_nest/point_neuron/directives/GSLDifferentiationFunction.jinja2
@@ -11,13 +11,15 @@ extern "C" inline int {{neuronName}}_dynamics(double, const double ode_state[], 
   // ode_state[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.ode_state[].
 
-{%- for ode in neuron.get_equations_blocks().get_declarations() %}
-{%-   for inline_expr in utils.get_inline_expression_symbols(ode) %}
-{%-     if not inline_expr.is_equation() %}
-{%-       set declaring_expr = inline_expr.get_declaring_expression() %}
+{%- for eq_block in neuron.get_equations_blocks() %}
+{%-     for ode in eq_block.get_declarations() %}
+{%-         for inline_expr in utils.get_inline_expression_symbols(ode) %}
+{%-             if not inline_expr.is_equation() %}
+{%-                 set declaring_expr = inline_expr.get_declaring_expression() %}
   double {{names.name(inline_expr)}} = {{printerGSL.print_expression(declaring_expr, prefix="node.")}};
-{%-     endif %}
-{%-   endfor %}
+{%-             endif %}
+{%-         endfor %}
+{%-     endfor %}
 {%- endfor %}
 
 {%- for variable_name in numeric_state_variables %}
@@ -28,12 +30,12 @@ extern "C" inline int {{neuronName}}_dynamics(double, const double ode_state[], 
 {%- if paired_synapse is defined %}
 {%- for variable_name in numeric_state_variables_moved %}
 {%-   set update_expr = numeric_update_expressions[variable_name] %}
-{%-   set variable_sym = neuron.get_state_blocks().get_scope().resolve_to_symbol(variable_name, SymbolKind.VARIABLE) %}
+{%-   set variable_sym = utils.resolve_to_variable_symbol_in_blocks(variable_name, synapse.get_state_blocks()) %}
   f[{{names.array_index(variable_sym)}}] = {{printerGSL.print_expression(update_expr, prefix="node.")}};
 {%- endfor %}
 {%- endif %}
 {%- for variable_name in non_equations_state_variables %}
-{%-   set variable_sym = neuron.get_state_blocks().get_scope().resolve_to_symbol(variable_name, SymbolKind.VARIABLE) %}
+{%-   set variable_sym = utils.resolve_to_variable_symbol_in_blocks(variable_name, synapse.get_state_blocks()) %}
   f[{{names.array_index(variable_sym)}}] = 0.;
 {%- endfor %}
 

--- a/pynestml/frontend/pynestml_frontend.py
+++ b/pynestml/frontend/pynestml_frontend.py
@@ -31,7 +31,7 @@ from pynestml.exceptions.code_generator_options_exception import CodeGeneratorOp
 from pynestml.frontend.frontend_configuration import FrontendConfiguration, InvalidPathException, \
     qualifier_store_log_arg, qualifier_module_name_arg, qualifier_logging_level_arg, \
     qualifier_target_platform_arg, qualifier_target_path_arg, qualifier_input_path_arg, qualifier_suffix_arg, \
-    qualifier_dev_arg, qualifier_codegen_opts_arg, qualifier_install_path_arg
+    qualifier_dev_arg, qualifier_install_path_arg
 from pynestml.meta_model.ast_neuron import ASTNeuron
 from pynestml.meta_model.ast_synapse import ASTSynapse
 from pynestml.symbols.predefined_functions import PredefinedFunctions

--- a/pynestml/meta_model/ast_declaration.py
+++ b/pynestml/meta_model/ast_declaration.py
@@ -21,13 +21,10 @@
 
 from typing import Optional, List
 
-import copy
-
 from pynestml.meta_model.ast_data_type import ASTDataType
 from pynestml.meta_model.ast_expression import ASTExpression
 from pynestml.meta_model.ast_node import ASTNode
 from pynestml.meta_model.ast_variable import ASTVariable
-from pynestml.meta_model.ast_namespace_decorator import ASTNamespaceDecorator
 
 
 class ASTDeclaration(ASTNode):

--- a/pynestml/meta_model/ast_external_variable.py
+++ b/pynestml/meta_model/ast_external_variable.py
@@ -21,8 +21,6 @@
 
 from typing import Optional
 
-from copy import copy
-
 from pynestml.meta_model.ast_variable import ASTVariable
 
 

--- a/pynestml/meta_model/ast_for_stmt.py
+++ b/pynestml/meta_model/ast_for_stmt.py
@@ -18,8 +18,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
 from pynestml.meta_model.ast_node import ASTNode
-from pynestml.meta_model.ast_expression import ASTExpression
 
 
 class ASTForStmt(ASTNode):

--- a/pynestml/meta_model/ast_inline_expression.py
+++ b/pynestml/meta_model/ast_inline_expression.py
@@ -19,8 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-
-from pynestml.meta_model.ast_expression_node import ASTExpressionNode
 from pynestml.meta_model.ast_node import ASTNode
 
 

--- a/pynestml/meta_model/ast_namespace_decorator.py
+++ b/pynestml/meta_model/ast_namespace_decorator.py
@@ -18,9 +18,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
 from pynestml.meta_model.ast_node import ASTNode
-from pynestml.utils.ast_source_location import ASTSourceLocation
-from pynestml.meta_model.ast_variable import ASTVariable
 
 
 class ASTNamespaceDecorator(ASTNode):

--- a/pynestml/meta_model/ast_neuron.py
+++ b/pynestml/meta_model/ast_neuron.py
@@ -19,19 +19,19 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Dict, List, Optional, Union
+from typing import List, Optional
 
-from pynestml.meta_model.ast_input_block import ASTInputBlock
-from pynestml.meta_model.ast_node import ASTNode
-from pynestml.meta_model.ast_neuron_or_synapse import ASTNeuronOrSynapse
-from pynestml.meta_model.ast_kernel import ASTKernel
-from pynestml.meta_model.ast_neuron_or_synapse_body import ASTNeuronOrSynapseBody
+from pynestml.meta_model.ast_declaration import ASTDeclaration
 from pynestml.meta_model.ast_equations_block import ASTEquationsBlock
-from pynestml.symbols.symbol import SymbolKind
+from pynestml.meta_model.ast_kernel import ASTKernel
+from pynestml.meta_model.ast_neuron_or_synapse import ASTNeuronOrSynapse
+from pynestml.meta_model.ast_neuron_or_synapse_body import ASTNeuronOrSynapseBody
+from pynestml.meta_model.ast_node import ASTNode
+from pynestml.meta_model.ast_ode_equation import ASTOdeEquation
+from pynestml.meta_model.ast_output_block import ASTOutputBlock
 from pynestml.symbols.variable_symbol import BlockType, VariableSymbol
 from pynestml.utils.logger import LoggingLevel, Logger
 from pynestml.utils.messages import Messages
-from pynestml.utils.ast_source_location import ASTSourceLocation
 
 
 class ASTNeuron(ASTNeuronOrSynapse):
@@ -84,116 +84,26 @@ class ASTNeuron(ASTNeuronOrSynapse):
 
         return dup
 
-    def get_name(self):
+    def get_name(self) -> str:
         """
         Returns the name of the neuron.
         :return: the name of the neuron.
-        :rtype: str
         """
         return self.name
 
-    def get_body(self):
+    def get_body(self) -> ASTNeuronOrSynapseBody:
         """
         Return the body of the neuron.
         :return: the body containing the definitions.
-        :rtype: ASTNeuronOrSynapseBody
         """
         return self.body
 
-    def get_artifact_name(self):
+    def get_artifact_name(self) -> str:
         """
         Returns the name of the artifact this neuron has been stored in.
         :return: the name of the file
-        :rtype: str
         """
         return self.artifact_name
-
-    def get_functions(self):
-        """
-        Returns a list of all function block declarations in this body.
-        :return: a list of function declarations.
-        :rtype: list(ASTFunction)
-        """
-        ret = list()
-        from pynestml.meta_model.ast_function import ASTFunction
-        for elem in self.get_body().get_body_elements():
-            if isinstance(elem, ASTFunction):
-                ret.append(elem)
-        return ret
-
-    def get_state_blocks(self):
-        """
-        Returns a list of all state blocks defined in this body.
-        :return: a list of state-blocks.
-        :rtype: list(ASTBlockWithVariables)
-        """
-        ret = list()
-        from pynestml.meta_model.ast_block_with_variables import ASTBlockWithVariables
-        for elem in self.get_body().get_body_elements():
-            if isinstance(elem, ASTBlockWithVariables) and elem.is_state:
-                ret.append(elem)
-        if isinstance(ret, list) and len(ret) == 1:
-            return ret[0]
-        if isinstance(ret, list) and len(ret) == 0:
-            return None
-        return ret
-
-    def get_parameter_blocks(self):
-        """
-        Returns a list of all parameter blocks defined in this body.
-        :return: a list of parameters-blocks.
-        :rtype: list(ASTBlockWithVariables)
-        """
-        ret = list()
-        from pynestml.meta_model.ast_block_with_variables import ASTBlockWithVariables
-        for elem in self.get_body().get_body_elements():
-            if isinstance(elem, ASTBlockWithVariables) and elem.is_parameters:
-                ret.append(elem)
-        if isinstance(ret, list) and len(ret) == 1:
-            return ret[0]
-        if isinstance(ret, list) and len(ret) == 0:
-            return None
-        return ret
-
-    def get_internals_blocks(self):
-        """
-        Returns a list of all internals blocks defined in this body.
-        :return: a list of internals-blocks.
-        :rtype: list(ASTBlockWithVariables)
-        """
-        ret = list()
-        from pynestml.meta_model.ast_block_with_variables import ASTBlockWithVariables
-        for elem in self.get_body().get_body_elements():
-            if isinstance(elem, ASTBlockWithVariables) and elem.is_internals:
-                ret.append(elem)
-        if isinstance(ret, list) and len(ret) == 1:
-            return ret[0]
-        if isinstance(ret, list) and len(ret) == 0:
-            return None
-        return ret
-
-    def get_equations_blocks(self) -> Optional[Union[ASTEquationsBlock, List[ASTEquationsBlock]]]:
-        """
-        Returns a list of all ``equations`` blocks defined in this body.
-        :return: a list of equations-blocks.
-        """
-        ret = list()
-        for elem in self.get_body().get_body_elements():
-            if isinstance(elem, ASTEquationsBlock):
-                ret.append(elem)
-        if isinstance(ret, list) and len(ret) == 1:
-            return ret[0]
-        if isinstance(ret, list) and len(ret) == 0:
-            return None
-        return ret
-
-    def get_equations_block(self):
-        """
-        Returns the unique equations block defined in this body.
-        :return: a  equations-block.
-        :rtype: ASTEquationsBlock
-        """
-        return self.get_equations_blocks()
 
     def remove_equations_block(self) -> None:
         """
@@ -204,46 +114,16 @@ class ASTNeuron(ASTNeuronOrSynapse):
             if isinstance(elem, ASTEquationsBlock):
                 self.get_body().get_body_elements().remove(elem)
 
-    def get_initial_value(self, variable_name):
-        assert type(variable_name) is str
-
-        for decl in self.get_state_blocks().get_declarations():
-            for var in decl.variables:
-                if var.get_complete_name() == variable_name:
-                    return decl.get_expression()
-
-        return None
-
-    def get_equations(self):
+    def get_equations(self) -> List[ASTOdeEquation]:
         """
         Returns all ode equations as defined in this neuron.
         :return list of ode-equations
-        :rtype list(ASTOdeEquation)
         """
         ret = list()
-        blocks = self.get_equations_blocks()
-        # the get equations block is not deterministic method, it can return a list or a single object.
-        if isinstance(blocks, list):
-            for block in blocks:
-                ret.extend(block.get_ode_equations())
-        if isinstance(blocks, ASTEquationsBlock):
-            return blocks.get_ode_equations()
-        return ret
 
-    def get_input_blocks(self):
-        """
-        Returns a list of all input-blocks defined.
-        :return: a list of defined input-blocks.
-        :rtype: list(ASTInputBlock)
-        """
-        ret = list()
-        for elem in self.get_body().get_body_elements():
-            if isinstance(elem, ASTInputBlock):
-                ret.append(elem)
-        if isinstance(ret, list) and len(ret) == 1:
-            return ret[0]
-        if isinstance(ret, list) and len(ret) == 0:
-            return None
+        for block in self.get_equations_blocks():
+            ret.extend(block.get_ode_equations())
+
         return ret
 
     def get_input_ports(self) -> List[VariableSymbol]:
@@ -278,11 +158,10 @@ class ASTNeuron(ASTNeuronOrSynapse):
                 ret.append(port)
         return ret
 
-    def get_parameter_symbols(self):
+    def get_parameter_symbols(self) -> List[VariableSymbol]:
         """
         Returns a list of all parameter symbol defined in the model.
         :return: a list of parameter symbols.
-        :rtype: list(VariableSymbol)
         """
         symbols = self.get_scope().get_symbols_in_this_scope()
         ret = list()
@@ -335,11 +214,10 @@ class ASTNeuron(ASTNeuronOrSynapse):
 
         return vector_symbols
 
-    def get_internal_symbols(self):
+    def get_internal_symbols(self) -> List[VariableSymbol]:
         """
         Returns a list of all internals symbol defined in the model.
         :return: a list of internals symbols.
-        :rtype: list(VariableSymbol)
         """
         from pynestml.symbols.variable_symbol import BlockType
         symbols = self.get_scope().get_symbols_in_this_scope()
@@ -362,23 +240,6 @@ class ASTNeuron(ASTNeuronOrSynapse):
                     and (symbol.block_type == BlockType.EQUATION or symbol.block_type == BlockType.STATE) \
                     and symbol.is_inline_expression:
                 ret.append(symbol)
-        return ret
-
-    def get_output_blocks(self):
-        """
-        Returns a list of all output-blocks defined.
-        :return: a list of defined output-blocks.
-        :rtype: list(ASTOutputBlock)
-        """
-        ret = list()
-        from pynestml.meta_model.ast_output_block import ASTOutputBlock
-        for elem in self.get_body().get_body_elements():
-            if isinstance(elem, ASTOutputBlock):
-                ret.append(elem)
-        if isinstance(ret, list) and len(ret) == 1:
-            return ret[0]
-        if isinstance(ret, list) and len(ret) == 0:
-            return None
         return ret
 
     def is_multisynapse_spikes(self) -> bool:
@@ -415,27 +276,30 @@ class ASTNeuron(ASTNeuronOrSynapse):
         assert type(kernel_name) is str
         kernel_name = kernel_name.split("__X__")[0]
 
-        if not self.get_equations_block():
+        if not self.get_equations_blocks():
             return None
 
         # check if defined as a direct function of time
-        for decl in self.get_equations_block().get_declarations():
-            if type(decl) is ASTKernel and kernel_name in decl.get_variable_names():
-                return decl
+        for equations_block in self.get_equations_blocks():
+            for decl in equations_block.get_declarations():
+                if type(decl) is ASTKernel and kernel_name in decl.get_variable_names():
+                    return decl
 
         # check if defined for a higher order of differentiation
-        for decl in self.get_equations_block().get_declarations():
-            if type(decl) is ASTKernel and kernel_name in [s.replace("$", "__DOLLAR").replace("'", "") for s in
-                                                           decl.get_variable_names()]:
-                return decl
+        for equations_block in self.get_equations_blocks():
+            for decl in equations_block.get_declarations():
+                if type(decl) is ASTKernel and kernel_name in [s.replace("$", "__DOLLAR").replace("'", "") for s in
+                                                               decl.get_variable_names()]:
+                    return decl
 
         return None
 
     def get_all_kernels(self):
         kernels = []
-        for decl in self.get_equations_block().get_declarations():
-            if type(decl) is ASTKernel:
-                kernels.append(decl)
+        for equations_block in self.get_equations_blocks():
+            for decl in equations_block.get_declarations():
+                if type(decl) is ASTKernel:
+                    kernels.append(decl)
         return kernels
 
     def get_non_inline_state_symbols(self) -> List[VariableSymbol]:
@@ -509,65 +373,24 @@ class ASTNeuron(ASTNeuronOrSynapse):
         :return: a list of rhs representing invariants
         :rtype: list(ASTExpression)
         """
-        from pynestml.meta_model.ast_block_with_variables import ASTBlockWithVariables
         ret = list()
-        blocks = self.get_parameter_blocks()
-        # the get parameters block is not deterministic method, it can return a list or a single object.
-        if isinstance(blocks, list):
-            for block in blocks:
-                for decl in block.get_declarations():
-                    if decl.has_invariant():
-                        ret.append(decl.get_invariant())
-        elif isinstance(blocks, ASTBlockWithVariables):
-            for decl in blocks.get_declarations():
+        for block in self.get_parameters_blocks():
+            for decl in block.get_declarations():
                 if decl.has_invariant():
                     ret.append(decl.get_invariant())
+
         return ret
 
-    def create_empty_update_block(self):
+    def add_to_state_block(self, declaration: ASTDeclaration):
         """
-        Create an empty update block. Only makes sense if one does not already exist.
-        """
-        assert self.get_update_blocks() is None or len(self.get_update_blocks(
-        )) == 0, "create_empty_update_block() called although update block already present"
-        from pynestml.meta_model.ast_node_factory import ASTNodeFactory
-        block = ASTNodeFactory.create_ast_block([], ASTSourceLocation.get_predefined_source_position())
-        update_block = ASTNodeFactory.create_ast_update_block(block, ASTSourceLocation.get_predefined_source_position())
-        self.get_body().get_body_elements().append(update_block)
-
-    def add_to_internal_block(self, declaration, index=-1):
-        """
-        Adds the handed over declaration the internal block
-        :param declaration: a single declaration
-        :type declaration: ast_declaration
-        """
-        from pynestml.utils.ast_utils import ASTUtils
-        if self.get_internals_blocks() is None:
-            ASTUtils.create_internal_block(self)
-        n_declarations = len(self.get_internals_blocks().get_declarations())
-        if n_declarations == 0:
-            index = 0
-        else:
-            index = 1 + (index % len(self.get_internals_blocks().get_declarations()))
-        self.get_internals_blocks().get_declarations().insert(index, declaration)
-        declaration.update_scope(self.get_internals_blocks().get_scope())
-        from pynestml.visitors.ast_symbol_table_visitor import ASTSymbolTableVisitor
-        symtable_vistor = ASTSymbolTableVisitor()
-        symtable_vistor.block_type_stack.push(BlockType.INTERNALS)
-        declaration.accept(symtable_vistor)
-        symtable_vistor.block_type_stack.pop()
-
-    def add_to_state_block(self, declaration):
-        """
-        Adds the handed over declaration to the state block.
+        Adds the handed over declaration an arbitrary state block.
         :param declaration: a single declaration.
-        :type declaration: ast_declaration
         """
         from pynestml.utils.ast_utils import ASTUtils
-        if self.get_state_blocks() is None:
+        if not self.get_state_blocks():
             ASTUtils.create_state_block(self)
-        self.get_state_blocks().get_declarations().append(declaration)
-        declaration.update_scope(self.get_state_blocks().get_scope())
+        self.get_state_blocks()[0].get_declarations().append(declaration)
+        declaration.update_scope(self.get_state_blocks()[0].get_scope())
         from pynestml.visitors.ast_symbol_table_visitor import ASTSymbolTableVisitor
 
         symtable_vistor = ASTSymbolTableVisitor()
@@ -580,94 +403,12 @@ class ASTNeuron(ASTNeuronOrSynapse):
         assert declaration.get_scope().resolve_to_symbol(declaration.get_variables()[0].get_name(),
                                                          SymbolKind.VARIABLE) is not None
 
-    def add_kernel(self, kernel: ASTKernel) -> None:
-        """
-        Adds the handed over declaration to the state block.
-        :param kernel: a single declaration.
-        """
-        assert self.get_equations_block() is not None
-        self.get_equations_block().get_declarations().append(kernel)
-        kernel.update_scope(self.get_equations_blocks().get_scope())
-
-    """
-    The following print methods are used by the backend and represent the comments as stored at the corresponding
-    parts of the neuron definition.
-    """
-
-    def print_dynamics_comment(self, prefix=None):
-        """
-        Prints the dynamic block comment.
-        :param prefix: a prefix string
-        :type prefix: str
-        :return: the corresponding comment.
-        :rtype: str
-        """
-        block = self.get_update_blocks()
-        if block is None:
-            return prefix if prefix is not None else ''
-        return block.print_comment(prefix)
-
-    def print_parameter_comment(self, prefix=None):
-        """
-        Prints the update block comment.
-        :param prefix: a prefix string
-        :type prefix: str
-        :return: the corresponding comment.
-        :rtype: str
-        """
-        block = self.get_parameter_blocks()
-        if block is None:
-            return prefix if prefix is not None else ''
-        return block.print_comment(prefix)
-
-    def print_state_comment(self, prefix=None):
-        """
-        Prints the state block comment.
-        :param prefix: a prefix string
-        :type prefix: str
-        :return: the corresponding comment.
-        :rtype: str
-        """
-        block = self.get_state_blocks()
-        if block is None:
-            return prefix if prefix is not None else ''
-        return block.print_comment(prefix)
-
-    def print_internal_comment(self, prefix=None):
-        """
-        Prints the internal block comment.
-        :param prefix: a prefix string
-        :type prefix: str
-        :return: the corresponding comment.
-        :rtype: str
-        """
-        block = self.get_internals_blocks()
-        if block is None:
-            return prefix if prefix is not None else ''
-        return block.print_comment(prefix)
-
-    def print_comment(self, prefix=None):
-        """
-        Prints the header information of this neuron.
-        :param prefix: a prefix string
-        :type prefix: str
-        :return: the comment.
-        :rtype: str
-        """
-        ret = ''
-        if self.get_comment() is None or len(self.get_comment()) == 0:
-            return prefix if prefix is not None else ''
-        for comment in self.get_comment():
-            ret += (prefix if prefix is not None else '') + comment + '\n'
-        return ret
-
-    def get_parent(self, ast):
+    def get_parent(self, ast) -> Optional[ASTNode]:
         """
         Indicates whether a this node contains the handed over node.
         :param ast: an arbitrary meta_model node.
         :type ast: AST_
         :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
         """
         if self.get_body() is ast:
             return self
@@ -675,13 +416,12 @@ class ASTNeuron(ASTNeuronOrSynapse):
             return self.get_body().get_parent(ast)
         return None
 
-    def equals(self, other):
+    def equals(self, other) -> bool:
         """
         The equals method.
         :param other: a different object.
         :type other: object
         :return: True if equal, otherwise False.
-        :rtype: bool
         """
         if not isinstance(other, ASTNeuron):
             return False

--- a/pynestml/meta_model/ast_neuron_or_synapse.py
+++ b/pynestml/meta_model/ast_neuron_or_synapse.py
@@ -19,14 +19,18 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Dict, List, Optional, Union
+from typing import List, Optional
 
+from pynestml.meta_model.ast_block_with_variables import ASTBlockWithVariables
+from pynestml.meta_model.ast_declaration import ASTDeclaration
 from pynestml.meta_model.ast_equations_block import ASTEquationsBlock
+from pynestml.meta_model.ast_function import ASTFunction
+from pynestml.meta_model.ast_kernel import ASTKernel
+from pynestml.meta_model.ast_input_block import ASTInputBlock
+from pynestml.meta_model.ast_output_block import ASTOutputBlock
 from pynestml.meta_model.ast_neuron_or_synapse_body import ASTNeuronOrSynapseBody
 from pynestml.meta_model.ast_node import ASTNode
-from pynestml.meta_model.ast_kernel import ASTKernel
-from pynestml.meta_model.ast_equations_block import ASTEquationsBlock
-from pynestml.symbols.symbol import SymbolKind
+from pynestml.meta_model.ast_update_block import ASTUpdateBlock
 from pynestml.symbols.variable_symbol import BlockType, VariableSymbol
 from pynestml.utils.logger import LoggingLevel, Logger
 from pynestml.utils.messages import Messages
@@ -116,11 +120,11 @@ class ASTNeuronOrSynapse(ASTNode):
         """
         return self.artifact_name
 
-    def get_functions(self):
+
+    def get_functions(self) -> List[ASTFunction]:
         """
         Returns a list of all function block declarations in this body.
         :return: a list of function declarations.
-        :rtype: list(ASTFunction)
         """
         ret = list()
         from pynestml.meta_model.ast_function import ASTFunction
@@ -129,96 +133,40 @@ class ASTNeuronOrSynapse(ASTNode):
                 ret.append(elem)
         return ret
 
-    def get_update_blocks(self):
-        """
-        Returns a list of all update blocks defined in this body.
-        :return: a list of update-block elements.
-        :rtype: list(ASTUpdateBlock)
-        """
-        ret = list()
-        from pynestml.meta_model.ast_update_block import ASTUpdateBlock
-        for elem in self.get_body().get_body_elements():
-            if isinstance(elem, ASTUpdateBlock):
-                ret.append(elem)
-        if isinstance(ret, list) and len(ret) == 1:
-            return ret[0]
-        if isinstance(ret, list) and len(ret) == 0:
-            return None
-        return ret
-
-    def get_state_blocks(self):
+    def get_state_blocks(self) -> List[ASTBlockWithVariables]:
         """
         Returns a list of all state blocks defined in this body.
         :return: a list of state-blocks.
-        :rtype: list(ASTBlockWithVariables)
         """
-        ret = list()
-        from pynestml.meta_model.ast_block_with_variables import ASTBlockWithVariables
-        for elem in self.get_body().get_body_elements():
-            if isinstance(elem, ASTBlockWithVariables) and elem.is_state:
-                ret.append(elem)
-        if isinstance(ret, list) and len(ret) == 1:
-            return ret[0]
-        if isinstance(ret, list) and len(ret) == 0:
-            return None
-        return ret
+        return self.get_body().get_state_blocks()
 
-    def get_parameter_blocks(self):
+    def get_parameters_blocks(self) -> List[ASTBlockWithVariables]:
         """
         Returns a list of all parameter blocks defined in this body.
         :return: a list of parameters-blocks.
-        :rtype: list(ASTBlockWithVariables)
         """
-        ret = list()
-        from pynestml.meta_model.ast_block_with_variables import ASTBlockWithVariables
-        for elem in self.get_body().get_body_elements():
-            if isinstance(elem, ASTBlockWithVariables) and elem.is_parameters:
-                ret.append(elem)
-        if isinstance(ret, list) and len(ret) == 1:
-            return ret[0]
-        if isinstance(ret, list) and len(ret) == 0:
-            return None
-        return ret
+        return self.get_body().get_parameters_blocks()
 
-    def get_internals_blocks(self):
+    def get_internals_blocks(self) -> List[ASTBlockWithVariables]:
         """
         Returns a list of all internals blocks defined in this body.
         :return: a list of internals-blocks.
-        :rtype: list(ASTBlockWithVariables)
         """
-        ret = list()
-        from pynestml.meta_model.ast_block_with_variables import ASTBlockWithVariables
-        for elem in self.get_body().get_body_elements():
-            if isinstance(elem, ASTBlockWithVariables) and elem.is_internals:
-                ret.append(elem)
-        if isinstance(ret, list) and len(ret) == 1:
-            return ret[0]
-        if isinstance(ret, list) and len(ret) == 0:
-            return None
-        return ret
+        return self.get_body().get_internals_blocks()
 
-    def get_equations_blocks(self) -> Optional[Union[ASTEquationsBlock, List[ASTEquationsBlock]]]:
+    def get_equations_blocks(self) -> List[ASTEquationsBlock]:
         """
         Returns a list of all ``equations`` blocks defined in this body.
         :return: a list of equations-blocks.
         """
-        ret = list()
-        for elem in self.get_body().get_body_elements():
-            if isinstance(elem, ASTEquationsBlock):
-                ret.append(elem)
-        if isinstance(ret, list) and len(ret) == 1:
-            return ret[0]
-        if isinstance(ret, list) and len(ret) == 0:
-            return None
-        return ret
+        return self.get_body().get_equations_blocks()
 
-    def get_equations_block(self):
+    def get_update_blocks(self) -> List[ASTUpdateBlock]:
         """
-        Returns the unique equations block defined in this body.
-        :return: a  equations-block.
-        :rtype: ASTEquationsBlock
+        Returns a list of all update blocks defined in this body.
+        :return: a list of update-block elements.
         """
-        return self.get_equations_blocks()
+        return self.get_body().get_update_blocks()
 
     def remove_equations_block(self) -> None:
         """
@@ -228,16 +176,6 @@ class ASTNeuronOrSynapse(ASTNode):
         for elem in self.get_body().get_body_elements():
             if isinstance(elem, ASTEquationsBlock):
                 self.get_body().get_body_elements().remove(elem)
-
-    def get_initial_value(self, variable_name):
-        assert type(variable_name) is str
-
-        for decl in self.get_state_blocks().get_declarations():
-            for var in decl.variables:
-                if var.get_complete_name() == variable_name:
-                    return decl.get_expression()
-
-        return None
 
     def get_state_declarations(self):
         """
@@ -259,30 +197,23 @@ class ASTNeuronOrSynapse(ASTNode):
         :rtype list(ASTOdeEquation)
         """
         ret = list()
-        blocks = self.get_equations_blocks()
-        # the get equations block is not deterministic method, it can return a list or a single object.
-        if isinstance(blocks, list):
-            for block in blocks:
-                ret.extend(block.get_ode_equations())
-        if isinstance(blocks, ASTEquationsBlock):
-            return blocks.get_ode_equations()
+        for block in self.get_equations_blocks():
+            ret.extend(block.get_ode_equations())
         return ret
 
-    def get_input_blocks(self):
+    def get_input_blocks(self) -> List[ASTInputBlock]:
         """
         Returns a list of all input-blocks defined.
         :return: a list of defined input-blocks.
-        :rtype: list(ASTInputBlock)
         """
-        ret = list()
-        for elem in self.get_body().get_body_elements():
-            if isinstance(elem, ASTInputBlock):
-                ret.append(elem)
-        if isinstance(ret, list) and len(ret) == 1:
-            return ret[0]
-        if isinstance(ret, list) and len(ret) == 0:
-            return None
-        return ret
+        return self.get_body().get_input_blocks()
+
+    def get_output_blocks(self) -> List[ASTOutputBlock]:
+        """
+        Returns a list of all output-blocks defined.
+        :return: a list of defined output-blocks.
+        """
+        return self.get_body().get_output_blocks()
 
     def get_input_buffers(self):
         """
@@ -378,23 +309,6 @@ class ASTNeuronOrSynapse(ASTNode):
                 ret.append(symbol)
         return ret
 
-    def get_output_blocks(self):
-        """
-        Returns a list of all output-blocks defined.
-        :return: a list of defined output-blocks.
-        :rtype: list(ASTOutputBlock)
-        """
-        ret = list()
-        from pynestml.meta_model.ast_output_block import ASTOutputBlock
-        for elem in self.get_body().get_body_elements():
-            if isinstance(elem, ASTOutputBlock):
-                ret.append(elem)
-        if isinstance(ret, list) and len(ret) == 1:
-            return ret[0]
-        if isinstance(ret, list) and len(ret) == 0:
-            return None
-        return ret
-
     def is_multisynapse_spikes(self):
         """
         Returns whether this neuron uses multi-synapse spikes.
@@ -431,26 +345,29 @@ class ASTNeuronOrSynapse(ASTNode):
         assert type(kernel_name) is str
         kernel_name = kernel_name.split("__X__")[0]
 
-        if not self.get_equations_block():
+        if not self.get_equations_blocks():
             return None
 
         # check if defined as a direct function of time
-        for decl in self.get_equations_block().get_declarations():
-            if type(decl) is ASTKernel and kernel_name in decl.get_variable_names():
-                return decl
+        for equations_block in self.get_equations_blocks():
+            for decl in equations_block.get_declarations():
+                if type(decl) is ASTKernel and kernel_name in decl.get_variable_names():
+                    return decl
 
-        # check if defined for a higher order of differentiation
-        for decl in self.get_equations_block().get_declarations():
-            if type(decl) is ASTKernel and kernel_name in [s.replace("$", "__DOLLAR").replace("'", "") for s in decl.get_variable_names()]:
-                return decl
+            # check if defined for a higher order of differentiation
+            for decl in equations_block.get_declarations():
+                if type(decl) is ASTKernel and kernel_name in [s.replace("$", "__DOLLAR").replace("'", "") for s in decl.get_variable_names()]:
+                    return decl
 
         return None
 
     def get_all_kernels(self):
         kernels = []
-        for decl in self.get_equations_block().get_declarations():
-            if type(decl) is ASTKernel:
-                kernels.append(decl)
+        for equations_block in self.get_equations_blocks():
+            for decl in equations_block.get_declarations():
+                if type(decl) is ASTKernel:
+                    kernels.append(decl)
+
         return kernels
 
     def get_non_inline_state_symbols(self) -> List[VariableSymbol]:
@@ -513,48 +430,40 @@ class ASTNeuronOrSynapse(ASTNode):
         :return: a list of rhs representing invariants
         :rtype: list(ASTExpression)
         """
-        from pynestml.meta_model.ast_block_with_variables import ASTBlockWithVariables
         ret = list()
-        blocks = self.get_parameter_blocks()
-        # the get parameters block is not deterministic method, it can return a list or a single object.
-        if isinstance(blocks, list):
-            for block in blocks:
-                for decl in block.get_declarations():
-                    if decl.has_invariant():
-                        ret.append(decl.get_invariant())
-        elif isinstance(blocks, ASTBlockWithVariables):
-            for decl in blocks.get_declarations():
+        for block in self.get_parameters_blocks():
+            for decl in block.get_declarations():
                 if decl.has_invariant():
                     ret.append(decl.get_invariant())
+
         return ret
 
     def create_empty_update_block(self):
         """
         Create an empty update block. Only makes sense if one does not already exist.
         """
-        assert self.get_update_blocks() is None or len(self.get_update_blocks(
-        )) == 0, "create_empty_update_block() called although update block already present"
+        assert not self.get_update_blocks(), "create_empty_update_block() called although update block already present"
         from pynestml.meta_model.ast_node_factory import ASTNodeFactory
         block = ASTNodeFactory.create_ast_block([], ASTSourceLocation.get_predefined_source_position())
         update_block = ASTNodeFactory.create_ast_update_block(block, ASTSourceLocation.get_predefined_source_position())
         self.get_body().get_body_elements().append(update_block)
 
-    def add_to_internal_block(self, declaration, index=-1):
+    def add_to_internals_block(self, declaration: ASTDeclaration, index: int = -1) -> None:
         """
-        Adds the handed over declaration the internal block
+        Adds the handed over declaration the internals block
         :param declaration: a single declaration
-        :type declaration: ast_declaration
         """
+        assert len(self.get_internals_blocks()) <= 1, "Only one internals block supported for now"
         from pynestml.utils.ast_utils import ASTUtils
-        if self.get_internals_blocks() is None:
+        if not self.get_internals_blocks():
             ASTUtils.create_internal_block(self)
-        n_declarations = len(self.get_internals_blocks().get_declarations())
+        n_declarations = len(self.get_internals_blocks()[0].get_declarations())
         if n_declarations == 0:
             index = 0
         else:
-            index = 1 + (index % len(self.get_internals_blocks().get_declarations()))
-        self.get_internals_blocks().get_declarations().insert(index, declaration)
-        declaration.update_scope(self.get_internals_blocks().get_scope())
+            index = 1 + (index % len(self.get_internals_blocks()[0].get_declarations()))
+        self.get_internals_blocks()[0].get_declarations().insert(index, declaration)
+        declaration.update_scope(self.get_internals_blocks()[0].get_scope())
         from pynestml.visitors.ast_symbol_table_visitor import ASTSymbolTableVisitor
         symtable_vistor = ASTSymbolTableVisitor()
         symtable_vistor.block_type_stack.push(BlockType.INTERNALS)
@@ -584,85 +493,19 @@ class ASTNeuronOrSynapse(ASTNode):
         assert declaration.get_scope().resolve_to_symbol(declaration.get_variables()[0].get_name(),
                                                          SymbolKind.VARIABLE) is not None
 
-    def add_kernel(self, kernel: ASTKernel) -> None:
+    def print_comment(self, prefix: str = "") -> str:
         """
-        Adds the handed over declaration to the state block.
-        :param kernel: a single declaration.
-        """
-        assert self.get_equations_block() is not None
-        self.get_equations_block().get_declarations().append(kernel)
-        kernel.update_scope(self.get_equations_blocks().get_scope())
-
-    """
-    The following print methods are used by the backend and represent the comments as stored at the corresponding
-    parts of the neuron definition.
-    """
-
-    def print_dynamics_comment(self, prefix=None):
-        """
-        Prints the dynamic block comment.
+        Prints the header comment of this neuron.
         :param prefix: a prefix string
-        :type prefix: str
-        :return: the corresponding comment.
-        :rtype: str
-        """
-        block = self.get_update_blocks()
-        if block is None:
-            return prefix if prefix is not None else ''
-        return block.print_comment(prefix)
-
-    def print_parameter_comment(self, prefix=None):
-        """
-        Prints the update block comment.
-        :param prefix: a prefix string
-        :type prefix: str
-        :return: the corresponding comment.
-        :rtype: str
-        """
-        block = self.get_parameter_blocks()
-        if block is None:
-            return prefix if prefix is not None else ''
-        return block.print_comment(prefix)
-
-    def print_state_comment(self, prefix=None):
-        """
-        Prints the state block comment.
-        :param prefix: a prefix string
-        :type prefix: str
-        :return: the corresponding comment.
-        :rtype: str
-        """
-        block = self.get_state_blocks()
-        if block is None:
-            return prefix if prefix is not None else ''
-        return block.print_comment(prefix)
-
-    def print_internal_comment(self, prefix=None):
-        """
-        Prints the internal block comment.
-        :param prefix: a prefix string
-        :type prefix: str
-        :return: the corresponding comment.
-        :rtype: str
-        """
-        block = self.get_internals_blocks()
-        if block is None:
-            return prefix if prefix is not None else ''
-        return block.print_comment(prefix)
-
-    def print_comment(self, prefix=None):
-        """
-        Prints the header information of this neuron.
-        :param prefix: a prefix string
-        :type prefix: str
         :return: the comment.
-        :rtype: str
         """
-        ret = ''
         if self.get_comment() is None or len(self.get_comment()) == 0:
-            return prefix if prefix is not None else ''
+            return prefix
+
+        ret = ''
         for comment in self.get_comment():
-            ret += (prefix if prefix is not None else '') + comment + '\n'
+            ret += prefix + comment + '\n'
+
         return ret
 
     def get_parent(self, ast):
@@ -687,46 +530,20 @@ class ASTNeuronOrSynapse(ASTNode):
         :return: True if equal, otherwise False.
         :rtype: bool
         """
-        if not isinstance(other, ASTNeuron):
+        if not isinstance(other, ASTNeuronOrSynapse):
             return False
         return self.get_name() == other.get_name() and self.get_body().equals(other.get_body())
 
-    def get_initial_value(self, variable_name):
+    def get_initial_value(self, variable_name: str):
         assert type(variable_name) is str
 
-        if self.get_state_blocks() is None:
-            return None
-
-        for decl in self.get_state_blocks().get_declarations():
-            for var in decl.variables:
-                if var.get_complete_name() == variable_name:
-                    return decl.get_expression()
+        for state_block in self.get_state_blocks():
+            for decl in state_block.get_declarations():
+                for var in decl.variables:
+                    if var.get_complete_name() == variable_name:
+                        return decl.get_expression()
 
         return None
-
-    def get_kernel_by_name(self, kernel_name) -> Optional[ASTKernel]:
-        assert type(kernel_name) is str
-        kernel_name = kernel_name.split("__X__")[0]
-
-        # check if defined as a direct function of time
-        if self.get_equations_block():
-            for decl in self.get_equations_block().get_declarations():
-                if type(decl) is ASTKernel and kernel_name in decl.get_variable_names():
-                    return decl
-
-            # check if defined for a higher order of differentiation
-            for decl in self.get_equations_block().get_declarations():
-                if type(decl) is ASTKernel and kernel_name in [s.replace("$", "__DOLLAR").replace("'", "") for s in decl.get_variable_names()]:
-                    return decl
-
-        return None
-
-    def get_all_kernels(self):
-        kernels = []
-        for decl in self.get_equations_block().get_declarations():
-            if type(decl) is ASTKernel:
-                kernels.append(decl)
-        return kernels
 
     def has_delay_variables(self) -> bool:
         """

--- a/pynestml/meta_model/ast_neuron_or_synapse_body.py
+++ b/pynestml/meta_model/ast_neuron_or_synapse_body.py
@@ -21,9 +21,14 @@
 
 from typing import List, Optional
 
+from pynestml.meta_model.ast_block_with_variables import ASTBlockWithVariables
+from pynestml.meta_model.ast_equations_block import ASTEquationsBlock
+from pynestml.meta_model.ast_input_block import ASTInputBlock
 from pynestml.meta_model.ast_node import ASTNode
 from pynestml.meta_model.ast_input_port import ASTInputPort
 from pynestml.meta_model.ast_on_receive_block import ASTOnReceiveBlock
+from pynestml.meta_model.ast_output_block import ASTOutputBlock
+from pynestml.meta_model.ast_update_block import ASTUpdateBlock
 
 
 class ASTNeuronOrSynapseBody(ASTNode):
@@ -93,46 +98,44 @@ class ASTNeuronOrSynapseBody(ASTNode):
                 ret.append(elem)
         return ret
 
-    def get_update_blocks(self):
+    def get_update_blocks(self) -> List[ASTUpdateBlock]:
         """
         Returns a list of all update blocks defined in this body.
         :return: a list of update-block elements.
-        :rtype: list(ASTUpdateBlock)
         """
         ret = list()
-        from pynestml.meta_model.ast_update_block import ASTUpdateBlock
         for elem in self.get_body_elements():
             if isinstance(elem, ASTUpdateBlock):
                 ret.append(elem)
+
         return ret
 
-    def get_state_blocks(self):
+    def get_state_blocks(self) -> List[ASTBlockWithVariables]:
         """
         Returns a list of all state blocks defined in this body.
         :return: a list of state-blocks.
-        :rtype: list(ASTBlockWithVariables)
         """
         ret = list()
-        from pynestml.meta_model.ast_block_with_variables import ASTBlockWithVariables
         for elem in self.get_body_elements():
             if isinstance(elem, ASTBlockWithVariables) and elem.is_state:
                 ret.append(elem)
+
         return ret
 
-    def get_parameter_blocks(self):
+    def get_parameters_blocks(self) -> List[ASTBlockWithVariables]:
         """
         Returns a list of all parameter blocks defined in this body.
         :return: a list of parameters-blocks.
-        :rtype: list(ASTBlockWithVariables)
         """
         ret = list()
         from pynestml.meta_model.ast_block_with_variables import ASTBlockWithVariables
         for elem in self.get_body_elements():
             if isinstance(elem, ASTBlockWithVariables) and elem.is_parameters:
                 ret.append(elem)
+
         return ret
 
-    def get_internals_blocks(self):
+    def get_internals_blocks(self) -> List[ASTBlockWithVariables]:
         """
         Returns a list of all internals blocks defined in this body.
         :return: a list of internals-blocks.
@@ -143,6 +146,7 @@ class ASTNeuronOrSynapseBody(ASTNode):
         for elem in self.get_body_elements():
             if isinstance(elem, ASTBlockWithVariables) and elem.is_internals:
                 ret.append(elem)
+
         return ret
 
     def get_on_receive_block(self, port_name) -> Optional[ASTOnReceiveBlock]:
@@ -158,43 +162,41 @@ class ASTNeuronOrSynapseBody(ASTNode):
                 on_receive_blocks.append(elem)
         return on_receive_blocks
 
-    def get_equations_blocks(self):
+    def get_equations_blocks(self) -> List[ASTEquationsBlock]:
         """
         Returns a list of all equations blocks defined in this body.
         :return: a list of equations-blocks.
-        :rtype: list(ASTEquationsBlock)
         """
         ret = list()
-        from pynestml.meta_model.ast_equations_block import ASTEquationsBlock
         for elem in self.get_body_elements():
             if isinstance(elem, ASTEquationsBlock):
                 ret.append(elem)
+
         return ret
 
-    def get_input_blocks(self):
+    def get_input_blocks(self) -> List[ASTInputBlock]:
         """
         Returns a list of all input-blocks defined.
         :return: a list of defined input-blocks.
-        :rtype: list(ASTInputBlock)
         """
         ret = list()
-        from pynestml.meta_model.ast_input_block import ASTInputBlock
         for elem in self.get_body_elements():
             if isinstance(elem, ASTInputBlock):
                 ret.append(elem)
+
         return ret
 
-    def get_output_blocks(self):
+    def get_output_blocks(self) -> List[ASTOutputBlock]:
         """
         Returns a list of all output-blocks defined.
         :return: a list of defined output-blocks.
         :rtype: list(ASTOutputBlock)
         """
         ret = list()
-        from pynestml.meta_model.ast_output_block import ASTOutputBlock
         for elem in self.get_body_elements():
             if isinstance(elem, ASTOutputBlock):
                 ret.append(elem)
+
         return ret
 
     def get_parent(self, ast=None):
@@ -219,11 +221,10 @@ class ASTNeuronOrSynapseBody(ASTNode):
         """
         ret = list()
         blocks = self.get_input_blocks()
-        if isinstance(blocks, list):
-            for block in blocks:
-                for port in block.get_input_ports():
-                    if port.is_spike():
-                        ret.append(port)
+        for block in blocks:
+            for port in block.get_input_ports():
+                if port.is_spike():
+                    ret.append(port)
         return ret
 
     def equals(self, other):

--- a/pynestml/meta_model/ast_node.py
+++ b/pynestml/meta_model/ast_node.py
@@ -180,13 +180,11 @@ class ASTNode(metaclass=ABCMeta):
         """
         return self.comment is not None and len(self.comment) > 0
 
-    def print_comment(self, prefix):
+    def print_comment(self, prefix: str = "") -> str:
         """
         Prints the comment of this meta_model element.
         :param prefix: a prefix string
-        :type prefix: str
         :return: a comment
-        :rtype: str
         """
         ret = ''
         if not self.has_comment():

--- a/pynestml/meta_model/ast_node_factory.py
+++ b/pynestml/meta_model/ast_node_factory.py
@@ -21,52 +21,49 @@
 
 from typing import Optional, Union
 
-from pynestml.utils.ast_source_location import ASTSourceLocation
 from pynestml.meta_model.ast_arithmetic_operator import ASTArithmeticOperator
-from pynestml.meta_model.ast_expression import ASTExpression
-from pynestml.meta_model.ast_simple_expression import ASTSimpleExpression
-from pynestml.meta_model.ast_variable import ASTVariable
 from pynestml.meta_model.ast_assignment import ASTAssignment
 from pynestml.meta_model.ast_bit_operator import ASTBitOperator
-from pynestml.meta_model.ast_small_stmt import ASTSmallStmt
-from pynestml.meta_model.ast_compound_stmt import ASTCompoundStmt
 from pynestml.meta_model.ast_block import ASTBlock
-from pynestml.meta_model.ast_declaration import ASTDeclaration
 from pynestml.meta_model.ast_block_with_variables import ASTBlockWithVariables
 from pynestml.meta_model.ast_comparison_operator import ASTComparisonOperator
-from pynestml.meta_model.ast_on_receive_block import ASTOnReceiveBlock
-from pynestml.meta_model.ast_if_stmt import ASTIfStmt
-from pynestml.meta_model.ast_while_stmt import ASTWhileStmt
-from pynestml.meta_model.ast_for_stmt import ASTForStmt
-from pynestml.meta_model.ast_unit_type import ASTUnitType
+from pynestml.meta_model.ast_compound_stmt import ASTCompoundStmt
 from pynestml.meta_model.ast_data_type import ASTDataType
+from pynestml.meta_model.ast_declaration import ASTDeclaration
 from pynestml.meta_model.ast_elif_clause import ASTElifClause
 from pynestml.meta_model.ast_else_clause import ASTElseClause
 from pynestml.meta_model.ast_equations_block import ASTEquationsBlock
-from pynestml.meta_model.ast_unary_operator import ASTUnaryOperator
-from pynestml.meta_model.ast_logical_operator import ASTLogicalOperator
-from pynestml.meta_model.ast_parameter import ASTParameter
+from pynestml.meta_model.ast_expression import ASTExpression
+from pynestml.meta_model.ast_for_stmt import ASTForStmt
 from pynestml.meta_model.ast_function import ASTFunction
 from pynestml.meta_model.ast_function_call import ASTFunctionCall
-from pynestml.meta_model.ast_if_clause import ASTIfClause
+from pynestml.meta_model.ast_inline_expression import ASTInlineExpression
 from pynestml.meta_model.ast_input_block import ASTInputBlock
 from pynestml.meta_model.ast_input_port import ASTInputPort
 from pynestml.meta_model.ast_input_qualifier import ASTInputQualifier
-from pynestml.utils.port_signal_type import PortSignalType
-from pynestml.meta_model.ast_neuron import ASTNeuron
-from pynestml.meta_model.ast_neuron_or_synapse_body import ASTNeuronOrSynapseBody
-from pynestml.meta_model.ast_synapse import ASTSynapse
+from pynestml.meta_model.ast_if_clause import ASTIfClause
+from pynestml.meta_model.ast_if_stmt import ASTIfStmt
+from pynestml.meta_model.ast_kernel import ASTKernel
+from pynestml.meta_model.ast_logical_operator import ASTLogicalOperator
 from pynestml.meta_model.ast_namespace_decorator import ASTNamespaceDecorator
 from pynestml.meta_model.ast_nestml_compilation_unit import ASTNestMLCompilationUnit
+from pynestml.meta_model.ast_neuron import ASTNeuron
+from pynestml.meta_model.ast_neuron_or_synapse_body import ASTNeuronOrSynapseBody
 from pynestml.meta_model.ast_ode_equation import ASTOdeEquation
-from pynestml.meta_model.ast_inline_expression import ASTInlineExpression
-from pynestml.meta_model.ast_kernel import ASTKernel
+from pynestml.meta_model.ast_on_receive_block import ASTOnReceiveBlock
 from pynestml.meta_model.ast_output_block import ASTOutputBlock
+from pynestml.meta_model.ast_parameter import ASTParameter
 from pynestml.meta_model.ast_return_stmt import ASTReturnStmt
+from pynestml.meta_model.ast_simple_expression import ASTSimpleExpression
+from pynestml.meta_model.ast_small_stmt import ASTSmallStmt
 from pynestml.meta_model.ast_stmt import ASTStmt
 from pynestml.meta_model.ast_synapse import ASTSynapse
+from pynestml.meta_model.ast_unary_operator import ASTUnaryOperator
 from pynestml.meta_model.ast_update_block import ASTUpdateBlock
-from pynestml.meta_model.ast_stmt import ASTStmt
+from pynestml.meta_model.ast_unit_type import ASTUnitType
+from pynestml.meta_model.ast_variable import ASTVariable
+from pynestml.meta_model.ast_while_stmt import ASTWhileStmt
+from pynestml.utils.ast_source_location import ASTSourceLocation
 from pynestml.utils.port_signal_type import PortSignalType
 
 
@@ -276,8 +273,7 @@ class ASTNodeFactory:
         return instance
 
     @classmethod
-    def create_ast_neuron(cls, name, body, source_position, artifact_name):
-        # type: (str,ASTBody,ASTSourceLocation,str) -> ASTNeuron
+    def create_ast_neuron(cls, name: str, body: ASTNeuronOrSynapseBody, source_position: ASTSourceLocation, artifact_name: str) -> ASTNeuron:
         return ASTNeuron(name, body, artifact_name, source_position=source_position)
 
     @classmethod

--- a/pynestml/meta_model/ast_return_stmt.py
+++ b/pynestml/meta_model/ast_return_stmt.py
@@ -19,9 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-from pynestml.meta_model.ast_expression import ASTExpression
 from pynestml.meta_model.ast_node import ASTNode
-from pynestml.meta_model.ast_simple_expression import ASTSimpleExpression
 
 
 class ASTReturnStmt(ASTNode):

--- a/pynestml/meta_model/ast_simple_expression.py
+++ b/pynestml/meta_model/ast_simple_expression.py
@@ -21,11 +21,8 @@
 
 from typing import Optional, Union
 
-import numpy as np
-
 from pynestml.meta_model.ast_expression_node import ASTExpressionNode
 from pynestml.meta_model.ast_function_call import ASTFunctionCall
-from pynestml.meta_model.ast_node import ASTNode
 from pynestml.meta_model.ast_variable import ASTVariable
 from pynestml.utils.cloning_helpers import clone_numeric_literal
 

--- a/pynestml/meta_model/ast_stmt.py
+++ b/pynestml/meta_model/ast_stmt.py
@@ -21,9 +21,7 @@
 
 from typing import Optional
 
-from pynestml.meta_model.ast_compound_stmt import ASTCompoundStmt
 from pynestml.meta_model.ast_node import ASTNode
-from pynestml.meta_model.ast_small_stmt import ASTSmallStmt
 
 
 class ASTStmt(ASTNode):

--- a/pynestml/meta_model/ast_synapse.py
+++ b/pynestml/meta_model/ast_synapse.py
@@ -101,14 +101,6 @@ class ASTSynapse(ASTNeuronOrSynapse):
     def get_default_weight(self):
         return self._default_weight
 
-    def get_body(self):
-        """
-        Return the body of the synapse.
-        :return: the body containing the definitions.
-        :rtype: ASTNeuronOrSynapseBody
-        """
-        return self.body
-
     def get_on_receive_blocks(self) -> List[ASTOnReceiveBlock]:
         if not self.get_body():
             return []

--- a/pynestml/meta_model/ast_synapse.py
+++ b/pynestml/meta_model/ast_synapse.py
@@ -21,14 +21,10 @@
 
 from typing import List, Optional
 
-from pynestml.meta_model.ast_equations_block import ASTEquationsBlock
 from pynestml.meta_model.ast_neuron_or_synapse import ASTNeuronOrSynapse
-from pynestml.meta_model.ast_node import ASTNode
 from pynestml.meta_model.ast_on_receive_block import ASTOnReceiveBlock
 from pynestml.symbols.variable_symbol import BlockType
 from pynestml.symbols.variable_symbol import VariableSymbol
-from pynestml.utils.logger import LoggingLevel, Logger
-from pynestml.utils.messages import Messages
 
 
 class ASTSynapse(ASTNeuronOrSynapse):
@@ -123,31 +119,12 @@ class ASTSynapse(ASTNeuronOrSynapse):
             return None
         return self.get_body().get_on_receive_block(port_name)
 
-    def get_input_blocks(self):
-        """
-        Returns a list of all input-blocks defined.
-        :return: a list of defined input-blocks.
-        :rtype: list(ASTInputBlock)
-        """
-        ret = list()
-        from pynestml.meta_model.ast_input_block import ASTInputBlock
-        for elem in self.get_body().get_body_elements():
-            if isinstance(elem, ASTInputBlock):
-                ret.append(elem)
-        if isinstance(ret, list) and len(ret) == 1:
-            return ret[0]
-        elif isinstance(ret, list) and len(ret) == 0:
-            return None
-        else:
-            return ret
-
     def get_input_buffers(self):
         """
         Returns a list of all defined input buffers.
         :return: a list of all input buffers.
         :rtype: list(VariableSymbol)
         """
-        from pynestml.symbols.variable_symbol import BlockType
         symbols = self.get_scope().get_symbols_in_this_scope()
         ret = list()
         for symbol in symbols:

--- a/pynestml/meta_model/ast_variable.py
+++ b/pynestml/meta_model/ast_variable.py
@@ -25,7 +25,6 @@ from copy import copy
 
 from pynestml.meta_model.ast_node import ASTNode
 from pynestml.symbols.type_symbol import TypeSymbol
-from pynestml.utils.either import Either
 
 
 class ASTVariable(ASTNode):

--- a/pynestml/symbol_table/scope.py
+++ b/pynestml/symbol_table/scope.py
@@ -21,6 +21,8 @@
 
 from __future__ import annotations
 
+from typing import List, Optional, Union
+
 from enum import Enum
 
 from pynestml.symbols.symbol import Symbol, SymbolKind

--- a/pynestml/symbols/predefined_types.py
+++ b/pynestml/symbols/predefined_types.py
@@ -21,8 +21,6 @@
 
 from typing import Mapping
 
-from copy import copy
-
 from astropy.units.core import CompositeUnit
 from astropy.units.quantity import Quantity
 
@@ -30,8 +28,6 @@ from pynestml.symbols.predefined_units import PredefinedUnits
 from pynestml.symbols.template_type_symbol import TemplateTypeSymbol
 from pynestml.symbols.type_symbol import TypeSymbol
 from pynestml.symbols.unit_type_symbol import UnitTypeSymbol
-from pynestml.utils.logger import LoggingLevel, Logger
-from pynestml.utils.messages import Messages
 from pynestml.utils.type_dictionary import TypeDictionary
 from pynestml.utils.unit_type import UnitType
 

--- a/pynestml/symbols/variable_symbol.py
+++ b/pynestml/symbols/variable_symbol.py
@@ -127,6 +127,7 @@ class VariableSymbol(Symbol):
         self.namespace_decorators = namespace_decorators
 
     def is_homogeneous(self):
+        from pynestml.generated.PyNestMLLexer import PyNestMLLexer
         return PyNestMLLexer.DECORATOR_HOMOGENEOUS in self.decorators
 
     def has_decorators(self):
@@ -436,11 +437,10 @@ class VariableSymbol(Symbol):
                 and self.is_conductance_based == other.is_conductance_based
                 and self.is_recordable == other.is_recordable)
 
-    def print_comment(self, prefix=None):
+    def print_comment(self, prefix: str = "") -> str:
         """
         Prints the stored comment.
         :return: the corresponding comment.
-        :rtype: str
         """
         ret = ''
         if not self.has_comment():
@@ -448,6 +448,5 @@ class VariableSymbol(Symbol):
         # in the last part, delete the new line if it is the last comment, otherwise there is an ugly gap
         # between the comment and the element
         for comment in self.get_comment():
-            ret += (prefix if prefix is not None else '') + comment + \
-                   ('\n' if self.get_comment().index(comment) < len(self.get_comment()) - 1 else '')
+            ret += prefix + comment + ('\n' if self.get_comment().index(comment) < len(self.get_comment()) - 1 else '')
         return ret

--- a/pynestml/transformers/synapse_post_neuron_transformer.py
+++ b/pynestml/transformers/synapse_post_neuron_transformer.py
@@ -325,6 +325,9 @@ class SynapsePostNeuronTransformer(Transformer):
         #   move defining equations for variables from synapse to neuron
         #
 
+        if not new_synapse.get_equations_blocks():
+            ASTUtils.create_equations_block(new_synapse)
+
         for state_var in syn_to_neuron_state_vars:
             Logger.log_message(None, -1, "Moving state var defining equation(s) " + str(state_var),
                                None, LoggingLevel.INFO)

--- a/pynestml/transformers/synapse_post_neuron_transformer.py
+++ b/pynestml/transformers/synapse_post_neuron_transformer.py
@@ -222,12 +222,12 @@ class SynapsePostNeuronTransformer(Transformer):
         new_neuron = neuron.clone()
         new_synapse = synapse.clone()
 
-        assert len(new_neuron.get_equations_blocks()) <= 1, "Only one equations block supported for now."
-        assert len(new_synapse.get_equations_blocks()) <= 1, "Only one equations block supported for now."
-        assert len(new_neuron.get_state_blocks()) <= 1, "Only one state block supported for now."
-        assert len(new_synapse.get_state_blocks()) <= 1, "Only one state block supported for now."
-        assert len(new_neuron.get_update_blocks()) <= 1, "Only one update block supported for now."
-        assert len(new_synapse.get_update_blocks()) <= 1, "Only one update block supported for now."
+        assert len(new_neuron.get_equations_blocks()) <= 1, "Only one equations block per neuron supported for now."
+        assert len(new_synapse.get_equations_blocks()) <= 1, "Only one equations block per synapse supported for now."
+        assert len(new_neuron.get_state_blocks()) <= 1, "Only one state block supported per neuron for now."
+        assert len(new_synapse.get_state_blocks()) <= 1, "Only one state block supported per synapse for now."
+        assert len(new_neuron.get_update_blocks()) <= 1, "Only one update block supported per neuron for now."
+        assert len(new_synapse.get_update_blocks()) <= 1, "Only one update block supported per synapse for now."
 
         #
         #   suffix for variables that will be transferred to neuron

--- a/pynestml/utils/ast_utils.py
+++ b/pynestml/utils/ast_utils.py
@@ -460,18 +460,6 @@ class ASTUtils:
         return False
 
     @classmethod
-    def add_to_state_block(cls, model: ASTNeuronOrSynapse, declaration: ASTDeclaration) -> None:
-        """
-        Adds the handed over declaration to an arbitrary state block in the model.
-        :param neuron: a single neuron instance
-        :param declaration: a single declaration
-        """
-        if not model.get_state_blocks():
-            ASTUtils.create_state_block(model)
-
-        model.get_state_blocks()[0].get_declarations().append(declaration)
-
-    @classmethod
     def get_declaration_by_name(cls, blocks: Union[ASTBlock, List[ASTBlock]], var_name: str) -> Optional[ASTDeclaration]:
         """
         Get a declaration by variable name.
@@ -1725,7 +1713,7 @@ class ASTUtils:
             "__h") is None, "\"__h\" is a reserved name, please do not use variables by this name in your NESTML file"
         assert not "__h" in [sym.name for sym in neuron.get_internal_symbols(
         )], "\"__h\" is a reserved name, please do not use variables by this name in your NESTML file"
-        neuron.add_to_internal_block(ModelParser.parse_declaration('__h ms = resolution()'), index=0)
+        neuron.add_to_internals_block(ModelParser.parse_declaration('__h ms = resolution()'), index=0)
 
     @classmethod
     def generate_kernel_buffers_(cls, neuron: ASTNeuron, equations_block: Union[ASTEquationsBlock, List[ASTEquationsBlock]]) -> Mapping[ASTKernel, ASTInputPort]:

--- a/pynestml/utils/ast_utils.py
+++ b/pynestml/utils/ast_utils.py
@@ -446,13 +446,11 @@ class ASTUtils:
         return neuron
 
     @classmethod
-    def create_equations_block(cls, neuron):
+    def create_equations_block(cls, neuron: ASTNeuron) -> ASTNeuron:
         """
         Creates a single equations block in the handed over neuron.
         :param neuron: a single neuron
-        :type neuron: ast_neuron
         :return: the modified neuron
-        :rtype: ast_neuron
         """
         # local import since otherwise circular dependency
         from pynestml.meta_model.ast_node_factory import ASTNodeFactory
@@ -493,7 +491,7 @@ class ASTUtils:
         return None
 
     @classmethod
-    def all_variables_defined_in_block(cls, blocks: Optional[ASTBlock]) -> List[ASTVariable]:
+    def all_variables_defined_in_block(cls, blocks: Union[ASTBlock, List[ASTBlock]]) -> List[ASTVariable]:
         """return a list of all variable declarations in a block or blocks"""
         if isinstance(blocks, ASTNode):
             blocks = [blocks]
@@ -1905,8 +1903,7 @@ class ASTUtils:
     def get_convolve_function_calls(cls, nodes: Union[ASTNode, List[ASTNode]]):
         """
         Returns all sum function calls in the handed over meta_model node or one of its children.
-        :param ast: a single meta_model node.
-        :type ast: ASTNode
+        :param nodes: a single or list of AST nodes.
         """
         if isinstance(nodes, ASTNode):
             nodes = [nodes]
@@ -1918,26 +1915,21 @@ class ASTUtils:
         return function_calls
 
     @classmethod
-    def contains_convolve_function_call(cls, ast):
+    def contains_convolve_function_call(cls, ast: ASTNode) -> bool:
         """
         Indicates whether _ast or one of its child nodes contains a sum call.
         :param ast: a single meta_model
-        :type ast: ASTNode
         :return: True if sum is contained, otherwise False.
-        :rtype: bool
         """
         return len(cls.get_function_calls(ast, PredefinedFunctions.CONVOLVE)) > 0
 
     @classmethod
-    def get_function_calls(cls, ast_node, function_list):
+    def get_function_calls(cls, ast_node: ASTNode, function_list: List[str]) -> List[ASTFunctionCall]:
         """
         For a handed over list of function names, this method retrieves all function calls in the meta_model.
         :param ast_node: a single meta_model node
-        :type ast_node: ASTNode
         :param function_list: a list of function names
-        :type function_list: list(str)
         :return: a list of all functions in the meta_model
-        :rtype: list(ASTFunctionCall)
         """
         res = list()
         if ast_node is None:
@@ -1951,6 +1943,9 @@ class ASTUtils:
 
     @classmethod
     def resolve_to_variable_symbol_in_blocks(cls, variable_name: str, blocks: List[ASTBlock]):
+        r"""
+        Resolve a variable (by name) to its corresponding ``Symbol`` within the AST blocks in ``blocks``.
+        """
         for block in blocks:
             sym = block.get_scope().resolve_to_symbol(variable_name, SymbolKind.VARIABLE)
             if sym:

--- a/pynestml/utils/ast_utils.py
+++ b/pynestml/utils/ast_utils.py
@@ -39,6 +39,7 @@ from pynestml.meta_model.ast_input_block import ASTInputBlock
 from pynestml.meta_model.ast_input_port import ASTInputPort
 from pynestml.meta_model.ast_kernel import ASTKernel
 from pynestml.meta_model.ast_neuron import ASTNeuron
+from pynestml.meta_model.ast_neuron_or_synapse import ASTNeuronOrSynapse
 from pynestml.meta_model.ast_node import ASTNode
 from pynestml.meta_model.ast_node_factory import ASTNodeFactory
 from pynestml.meta_model.ast_neuron_or_synapse_body import ASTNeuronOrSynapseBody
@@ -420,7 +421,7 @@ class ASTUtils:
         :rtype: ast_neuron
         """
         from pynestml.meta_model.ast_node_factory import ASTNodeFactory
-        if neuron.get_internals_blocks() is None:
+        if not neuron.get_internals_blocks():
             internal = ASTNodeFactory.create_ast_block_with_variables(False, False, True, list(),
                                                                       ASTSourceLocation.get_added_source_position())
             internal.update_scope(neuron.get_scope())
@@ -438,7 +439,7 @@ class ASTUtils:
         """
         # local import since otherwise circular dependency
         from pynestml.meta_model.ast_node_factory import ASTNodeFactory
-        if neuron.get_internals_blocks() is None:
+        if not neuron.get_internals_blocks():
             state = ASTNodeFactory.create_ast_block_with_variables(True, False, False, list(),
                                                                    ASTSourceLocation.get_added_source_position())
             neuron.get_body().get_body_elements().append(state)
@@ -459,42 +460,43 @@ class ASTUtils:
         return False
 
     @classmethod
-    def add_to_state_block(cls, neuron, declaration):
+    def add_to_state_block(cls, model: ASTNeuronOrSynapse, declaration: ASTDeclaration) -> None:
         """
-        Adds the handed over declaration the state block
+        Adds the handed over declaration to an arbitrary state block in the model.
         :param neuron: a single neuron instance
-        :type neuron: ast_neuron
         :param declaration: a single declaration
-        :type declaration: ast_declaration
         """
-        if neuron.get_state_blocks() is None:
-            ASTUtils.create_state_block(neuron)
-        neuron.get_state_blocks().get_declarations().append(declaration)
-        return
+        if not model.get_state_blocks():
+            ASTUtils.create_state_block(model)
+
+        model.get_state_blocks()[0].get_declarations().append(declaration)
 
     @classmethod
-    def get_declaration_by_name(cls, block: ASTBlock, var_name: str) -> Optional[ASTDeclaration]:
+    def get_declaration_by_name(cls, blocks: Union[ASTBlock, List[ASTBlock]], var_name: str) -> Optional[ASTDeclaration]:
         """
         Get a declaration by variable name.
-        :param block: the block to look for the variable in
+        :param blocks: the block or blocks to look for the variable in
         :param var_name: name of the variable to look for (including single quotes indicating differential order)
         """
-        decls = block.get_declarations()
-        for decl in decls:
-            for var in decl.get_variables():
-                if var.get_complete_name() == var_name:
-                    return decl
+        if isinstance(blocks, ASTNode):
+            blocks = [blocks]
+        for block in blocks:
+            for decl in block.get_declarations():
+                for var in decl.get_variables():
+                    if var.get_complete_name() == var_name:
+                        return decl
         return None
 
     @classmethod
-    def all_variables_defined_in_block(cls, block: Optional[ASTBlock]) -> List[ASTVariable]:
-        """return a list of all variable declarations in a block"""
-        if block is None:
-            return []
+    def all_variables_defined_in_block(cls, blocks: Optional[ASTBlock]) -> List[ASTVariable]:
+        """return a list of all variable declarations in a block or blocks"""
+        if isinstance(blocks, ASTNode):
+            blocks = [blocks]
         vars = []
-        for decl in block.get_declarations():
-            for var in decl.get_variables():
-                vars.append(var)
+        for block in blocks:
+            for decl in block.get_declarations():
+                for var in decl.get_variables():
+                    vars.append(var)
         return vars
 
     @classmethod
@@ -552,11 +554,11 @@ class ASTUtils:
 
     @classmethod
     def get_inline_expression_by_name(cls, node, name: str) -> Optional[ASTInlineExpression]:
-        if not node.get_equations_block():
-            return None
-        for inline_expr in node.get_equations_block().get_inline_expressions():
-            if name == inline_expr.variable_name:
-                return inline_expr
+        for equations_block in node.get_equations_blocks():
+            for inline_expr in equations_block.get_inline_expressions():
+                if name == inline_expr.variable_name:
+                    return inline_expr
+
         return None
 
     @classmethod
@@ -658,10 +660,13 @@ class ASTUtils:
         return all_variables
 
     @classmethod
-    def get_all_variables_used_in_convolutions(cls, node: ASTNode, parent_node: ASTNode) -> List[str]:
-        """Make a list of all variable symbol names that are in ``node`` and used in a convolution"""
-        if node is None:
+    def get_all_variables_used_in_convolutions(cls, nodes: Union[ASTEquationsBlock, List[ASTEquationsBlock]], parent_node: ASTNode) -> List[str]:
+        """Make a list of all variable symbol names that are in one of the equation blocks in ``nodes`` and used in a convolution"""
+        if not nodes:
             return []
+
+        if isinstance(nodes, ASTNode):
+            nodes = [nodes]
 
         class ASTAllVariablesUsedInConvolutionVisitor(ASTVisitor):
             _variables = []
@@ -690,9 +695,13 @@ class ASTUtils:
                         var_name = node_.get_variable_name()
                         self._variables.append(var_name)
 
-        visitor = ASTAllVariablesUsedInConvolutionVisitor(node, parent_node)
-        node.accept(visitor)
-        return visitor._variables
+        variables = []
+        for node in nodes:
+            visitor = ASTAllVariablesUsedInConvolutionVisitor(node, parent_node)
+            node.accept(visitor)
+            variables.extend(visitor._variables)
+
+        return variables
 
     @classmethod
     def move_decls(cls, var_name, from_block, to_block, var_name_suffix, block_type: BlockType, mode="move", scope=None) -> List[ASTDeclaration]:
@@ -931,6 +940,8 @@ class ASTUtils:
         :param init_expression: initialization expression
         :return: the neuron extended by the variable
         """
+        assert len(neuron.get_internals_blocks()) <= 1, "Only one internals block supported for now"
+
         from pynestml.utils.model_parser import ModelParser
         from pynestml.visitors.ast_symbol_table_visitor import ASTSymbolTableVisitor
 
@@ -943,8 +954,8 @@ class ASTUtils:
         ast_declaration = ModelParser.parse_declaration(declaration_string)
         if vector_variable is not None:
             ast_declaration.set_size_parameter(vector_variable.get_vector_parameter())
-        neuron.add_to_internal_block(ast_declaration)
-        ast_declaration.update_scope(neuron.get_internals_blocks().get_scope())
+        neuron.add_to_internals_block(ast_declaration)
+        ast_declaration.update_scope(neuron.get_internals_blocks()[0].get_scope())
         symtable_visitor = ASTSymbolTableVisitor()
         symtable_visitor.block_type_stack.push(BlockType.INTERNALS)
         ast_declaration.accept(symtable_visitor)
@@ -967,7 +978,7 @@ class ASTUtils:
     @classmethod
     def add_declaration_to_state_block(cls, neuron: ASTNeuron, variable: str, initial_value: str) -> ASTNeuron:
         """
-        Adds a single declaration to the state block of the neuron. The declared variable is of type real.
+        Adds a single declaration to an arbitrary state block of the neuron. The declared variable is of type real.
         :param neuron: a neuron
         :param variable: state variable to add
         :param initial_value: corresponding initial value
@@ -985,7 +996,6 @@ class ASTUtils:
         if vector_variable is not None:
             ast_declaration.set_size_parameter(vector_variable.get_vector_parameter())
         neuron.add_to_state_block(ast_declaration)
-        ast_declaration.update_scope(neuron.get_state_blocks().get_scope())
 
         symtable_visitor = ASTSymbolTableVisitor()
         symtable_visitor.block_type_stack.push(BlockType.STATE)
@@ -1004,33 +1014,36 @@ class ASTUtils:
         """
         assert type(variable_name) is str
 
-        if neuron.get_state_blocks() is None:
+        if not neuron.get_state_blocks():
             return False
 
-        for decl in neuron.get_state_blocks().get_declarations():
-            for var in decl.get_variables():
-                if var.get_complete_name() == variable_name:
-                    return True
+        for state_block in neuron.get_state_blocks():
+            for decl in state_block.get_declarations():
+                for var in decl.get_variables():
+                    if var.get_complete_name() == variable_name:
+                        return True
 
         return False
 
     @classmethod
     def add_assignment_to_update_block(cls, assignment: ASTAssignment, neuron: ASTNeuron) -> ASTNeuron:
         """
-        Adds a single assignment to the end of the update block of the handed over neuron.
+        Adds a single assignment to the end of the update block of the handed over neuron. At most one update block should be present.
+
         :param assignment: a single assignment
         :param neuron: a single neuron instance
         :return: the modified neuron
         """
+        assert len(neuron.get_update_blocks()) <= 1, "At most one update block should be present"
         small_stmt = ASTNodeFactory.create_ast_small_stmt(assignment=assignment,
                                                           source_position=ASTSourceLocation.get_added_source_position())
         stmt = ASTNodeFactory.create_ast_stmt(small_stmt=small_stmt,
                                               source_position=ASTSourceLocation.get_added_source_position())
         if not neuron.get_update_blocks():
             neuron.create_empty_update_block()
-        neuron.get_update_blocks().get_block().get_stmts().append(stmt)
-        small_stmt.update_scope(neuron.get_update_blocks().get_block().get_scope())
-        stmt.update_scope(neuron.get_update_blocks().get_block().get_scope())
+        neuron.get_update_blocks()[0].get_block().get_stmts().append(stmt)
+        small_stmt.update_scope(neuron.get_update_blocks()[0].get_block().get_scope())
+        stmt.update_scope(neuron.get_update_blocks()[0].get_block().get_scope())
         return neuron
 
     @classmethod
@@ -1041,15 +1054,16 @@ class ASTUtils:
         :param neuron: a single neuron instance
         :return: a modified neuron
         """
+        assert len(neuron.get_update_blocks()) <= 1, "At most one update block should be present"
         small_stmt = ASTNodeFactory.create_ast_small_stmt(declaration=declaration,
                                                           source_position=ASTSourceLocation.get_added_source_position())
         stmt = ASTNodeFactory.create_ast_stmt(small_stmt=small_stmt,
                                               source_position=ASTSourceLocation.get_added_source_position())
         if not neuron.get_update_blocks():
             neuron.create_empty_update_block()
-        neuron.get_update_blocks().get_block().get_stmts().append(stmt)
-        small_stmt.update_scope(neuron.get_update_blocks().get_block().get_scope())
-        stmt.update_scope(neuron.get_update_blocks().get_block().get_scope())
+        neuron.get_update_blocks()[0].get_block().get_stmts().append(stmt)
+        small_stmt.update_scope(neuron.get_update_blocks()[0].get_block().get_scope())
+        stmt.update_scope(neuron.get_update_blocks()[0].get_block().get_scope())
         return neuron
 
     @classmethod
@@ -1091,11 +1105,11 @@ class ASTUtils:
         """
         Checks if the variable is present in an ODE
         """
-        equations_block = neuron.get_equations_blocks()
-        for ode_eq in equations_block.get_ode_equations():
-            var = ode_eq.get_lhs()
-            if var.get_name() == var_base_name:
-                return True
+        for equations_block in neuron.get_equations_blocks():
+            for ode_eq in equations_block.get_ode_equations():
+                var = ode_eq.get_lhs()
+                if var.get_name() == var_base_name:
+                    return True
         return False
 
     @classmethod
@@ -1285,16 +1299,17 @@ class ASTUtils:
         return rhs_is_delta_kernel or rhs_is_multiplied_delta_kernel
 
     @classmethod
-    def get_input_port_by_name(cls, input_block: ASTInputBlock, port_name: str) -> ASTInputPort:
+    def get_input_port_by_name(cls, input_blocks: List[ASTInputBlock], port_name: str) -> ASTInputPort:
         """
         Get the input port given the port name
         :param input_block: block to be searched
         :param port_name: name of the input port
         :return: input port object
         """
-        for input_port in input_block.get_input_ports():
-            if input_port.name == port_name:
-                return input_port
+        for input_block in input_blocks:
+            for input_port in input_block.get_input_ports():
+                if input_port.name == port_name:
+                    return input_port
         return None
 
     @classmethod
@@ -1387,23 +1402,26 @@ class ASTUtils:
             if not var:
                 # all variables checked
                 break
-            decls = cls.get_declarations_from_block(var, node.get_equations_blocks())
 
-            if decls:
-                assert len(decls) == 1
-                decl = decls[0]
-                if (type(decl) in [ASTDeclaration, ASTReturnStmt] and decl.has_expression()) \
-                        or type(decl) is ASTInlineExpression:
-                    vars_used.extend(cls.collect_variable_names_in_expression(decl.get_expression()))
-                elif type(decl) is ASTOdeEquation:
-                    vars_used.extend(cls.collect_variable_names_in_expression(decl.get_rhs()))
-                elif type(decl) is ASTKernel:
-                    for expr in decl.get_expressions():
-                        vars_used.extend(cls.collect_variable_names_in_expression(expr))
-                else:
-                    raise Exception("Unknown type " + str(type(decl)))
-                vars_used = [str(var) for var in vars_used]
-                vars_to_check = vars_to_check.union(set(vars_used))
+            for equations_block in node.get_equations_blocks():
+                decls = cls.get_declarations_from_block(var, equations_block)
+
+                if decls:
+                    assert len(decls) == 1
+                    decl = decls[0]
+                    if (type(decl) in [ASTDeclaration, ASTReturnStmt] and decl.has_expression()) \
+                            or type(decl) is ASTInlineExpression:
+                        vars_used.extend(cls.collect_variable_names_in_expression(decl.get_expression()))
+                    elif type(decl) is ASTOdeEquation:
+                        vars_used.extend(cls.collect_variable_names_in_expression(decl.get_rhs()))
+                    elif type(decl) is ASTKernel:
+                        for expr in decl.get_expressions():
+                            vars_used.extend(cls.collect_variable_names_in_expression(expr))
+                    else:
+                        raise Exception("Unknown type " + str(type(decl)))
+                    vars_used = [str(var) for var in vars_used]
+                    vars_to_check = vars_to_check.union(set(vars_used))
+
             vars_checked.add(var)
 
         return list(set(vars_checked))
@@ -1413,30 +1431,31 @@ class ASTUtils:
         """
         Remove initial values for original declarations (e.g. g_in, g_in', V_m); these might conflict with the initial value expressions returned from ODE-toolbox.
         """
-        assert isinstance(neuron.get_equations_blocks(), ASTEquationsBlock), "only one equation block should be present"
-
-        equations_block = neuron.get_equations_block()
         symbols_to_remove = set()
-        for kernel in equations_block.get_kernels():
-            for kernel_var in kernel.get_variables():
-                kernel_var_order = kernel_var.get_differential_order()
-                for order in range(kernel_var_order):
-                    symbol_name = kernel_var.get_name() + "'" * order
-                    symbols_to_remove.add(symbol_name)
+        for equations_block in neuron.get_equations_blocks():
+            for kernel in equations_block.get_kernels():
+                for kernel_var in kernel.get_variables():
+                    kernel_var_order = kernel_var.get_differential_order()
+                    for order in range(kernel_var_order):
+                        symbol_name = kernel_var.get_name() + "'" * order
+                        symbols_to_remove.add(symbol_name)
 
         decl_to_remove = set()
         for symbol_name in symbols_to_remove:
-            for decl in neuron.get_state_blocks().get_declarations():
-                if len(decl.get_variables()) == 1:
-                    if decl.get_variables()[0].get_name() == symbol_name:
-                        decl_to_remove.add(decl)
-                else:
-                    for var in decl.get_variables():
-                        if var.get_name() == symbol_name:
-                            decl.variables.remove(var)
+            for state_block in neuron.get_state_blocks():
+                for decl in state_block.get_declarations():
+                    if len(decl.get_variables()) == 1:
+                        if decl.get_variables()[0].get_name() == symbol_name:
+                            decl_to_remove.add(decl)
+                    else:
+                        for var in decl.get_variables():
+                            if var.get_name() == symbol_name:
+                                decl.variables.remove(var)
 
         for decl in decl_to_remove:
-            neuron.get_state_blocks().get_declarations().remove(decl)
+            for state_block in neuron.get_state_blocks():
+                if decl in state_block.get_declarations():
+                    state_block.get_declarations().remove(decl)
 
     @classmethod
     def update_initial_values_for_odes(cls, neuron: ASTNeuron, solver_dicts: List[dict]) -> None:
@@ -1445,28 +1464,29 @@ class ASTUtils:
         before ODE-toolbox processing, with the formatted variable names and initial values returned by ODE-toolbox.
         """
         from pynestml.utils.model_parser import ModelParser
-        assert isinstance(neuron.get_equations_blocks(), ASTEquationsBlock), "only one equation block should be present"
+        assert len(neuron.get_equations_blocks()) == 1, "Only one equation block should be present"
 
-        if neuron.get_state_blocks() is None:
+        if not neuron.get_state_blocks():
             return
 
-        for iv_decl in neuron.get_state_blocks().get_declarations():
-            for var in iv_decl.get_variables():
-                var_name = var.get_complete_name()
-                if cls.is_ode_variable(var.get_name(), neuron):
-                    assert cls.variable_in_solver(cls.to_ode_toolbox_processed_name(var_name), solver_dicts)
+        for state_block in neuron.get_state_blocks():
+            for iv_decl in state_block.get_declarations():
+                for var in iv_decl.get_variables():
+                    var_name = var.get_complete_name()
+                    if cls.is_ode_variable(var.get_name(), neuron):
+                        assert cls.variable_in_solver(cls.to_ode_toolbox_processed_name(var_name), solver_dicts)
 
-                    # replace the left-hand side variable name by the ode-toolbox format
-                    var.set_name(cls.to_ode_toolbox_processed_name(var.get_complete_name()))
-                    var.set_differential_order(0)
+                        # replace the left-hand side variable name by the ode-toolbox format
+                        var.set_name(cls.to_ode_toolbox_processed_name(var.get_complete_name()))
+                        var.set_differential_order(0)
 
-                    # replace the defining expression by the ode-toolbox result
-                    iv_expr = cls.get_initial_value_from_ode_toolbox_result(
-                        cls.to_ode_toolbox_processed_name(var_name), solver_dicts)
-                    assert iv_expr is not None
-                    iv_expr = ModelParser.parse_expression(iv_expr)
-                    iv_expr.update_scope(neuron.get_state_blocks().get_scope())
-                    iv_decl.set_expression(iv_expr)
+                        # replace the defining expression by the ode-toolbox result
+                        iv_expr = cls.get_initial_value_from_ode_toolbox_result(
+                            cls.to_ode_toolbox_processed_name(var_name), solver_dicts)
+                        assert iv_expr is not None
+                        iv_expr = ModelParser.parse_expression(iv_expr)
+                        iv_expr.update_scope(state_block.get_scope())
+                        iv_decl.set_expression(iv_expr)
 
     @classmethod
     def create_initial_values_for_kernels(cls, neuron: ASTNeuron, solver_dicts: List[dict], kernels: List[ASTKernel]) -> None:
@@ -1493,7 +1513,7 @@ class ASTUtils:
                         cls.add_declaration_to_state_block(neuron, var_name, expr)
 
     @classmethod
-    def transform_ode_and_kernels_to_json(cls, neuron: ASTNeuron, parameters_block: ASTBlockWithVariables,
+    def transform_ode_and_kernels_to_json(cls, neuron: ASTNeuron, parameters_blocks: Sequence[ASTBlockWithVariables],
                                           kernel_buffers: Mapping[ASTKernel, ASTInputPort], printer: Printer) -> dict:
         """
         Converts AST node to a JSON representation suitable for passing to ode-toolbox.
@@ -1515,24 +1535,24 @@ class ASTUtils:
         odetoolbox_indict = {}
 
         odetoolbox_indict["dynamics"] = []
-        equations_block = neuron.get_equations_block()
-        for equation in equations_block.get_ode_equations():
-            # n.b. includes single quotation marks to indicate differential order
-            lhs = cls.to_ode_toolbox_name(equation.get_lhs().get_complete_name())
-            rhs = printer.print_expression(equation.get_rhs())
-            entry = {"expression": lhs + " = " + rhs}
-            symbol_name = equation.get_lhs().get_name()
-            symbol = equations_block.get_scope().resolve_to_symbol(symbol_name, SymbolKind.VARIABLE)
+        for equations_block in neuron.get_equations_blocks():
+            for equation in equations_block.get_ode_equations():
+                # n.b. includes single quotation marks to indicate differential order
+                lhs = cls.to_ode_toolbox_name(equation.get_lhs().get_complete_name())
+                rhs = printer.print_expression(equation.get_rhs())
+                entry = {"expression": lhs + " = " + rhs}
+                symbol_name = equation.get_lhs().get_name()
+                symbol = equations_block.get_scope().resolve_to_symbol(symbol_name, SymbolKind.VARIABLE)
 
-            entry["initial_values"] = {}
-            symbol_order = equation.get_lhs().get_differential_order()
-            for order in range(symbol_order):
-                iv_symbol_name = symbol_name + "'" * order
-                initial_value_expr = neuron.get_initial_value(iv_symbol_name)
-                if initial_value_expr:
-                    expr = printer.print_expression(initial_value_expr)
-                    entry["initial_values"][cls.to_ode_toolbox_name(iv_symbol_name)] = expr
-            odetoolbox_indict["dynamics"].append(entry)
+                entry["initial_values"] = {}
+                symbol_order = equation.get_lhs().get_differential_order()
+                for order in range(symbol_order):
+                    iv_symbol_name = symbol_name + "'" * order
+                    initial_value_expr = neuron.get_initial_value(iv_symbol_name)
+                    if initial_value_expr:
+                        expr = printer.print_expression(initial_value_expr)
+                        entry["initial_values"][cls.to_ode_toolbox_name(iv_symbol_name)] = expr
+                odetoolbox_indict["dynamics"].append(entry)
 
         # write a copy for each (kernel, spike buffer) combination
         for kernel, spike_input_port in kernel_buffers:
@@ -1566,7 +1586,7 @@ class ASTUtils:
                 odetoolbox_indict["dynamics"].append(entry)
 
         odetoolbox_indict["parameters"] = {}
-        if parameters_block is not None:
+        for parameters_block in parameters_blocks:
             for decl in parameters_block.get_declarations():
                 for var in decl.variables:
                     odetoolbox_indict["parameters"][var.get_complete_name(
@@ -1575,18 +1595,17 @@ class ASTUtils:
         return odetoolbox_indict
 
     @classmethod
-    def remove_ode_definitions_from_equations_block(cls, neuron: ASTNeuron) -> None:
+    def remove_ode_definitions_from_equations_block(cls, model: ASTNeuronOrSynapse) -> None:
         """
-        Removes all ODEs in this block.
+        Removes all ODE definitions from all equations blocks in the model.
         """
-        equations_block = neuron.get_equations_block()
+        for equations_block in model.get_equations_blocks():
+            decl_to_remove = set()
+            for decl in equations_block.get_ode_equations():
+                decl_to_remove.add(decl)
 
-        decl_to_remove = set()
-        for decl in equations_block.get_ode_equations():
-            decl_to_remove.add(decl)
-
-        for decl in decl_to_remove:
-            equations_block.get_declarations().remove(decl)
+            for decl in decl_to_remove:
+                equations_block.get_declarations().remove(decl)
 
     @classmethod
     def make_inline_expressions_self_contained(cls, inline_expressions: List[ASTInlineExpression]) -> List[ASTInlineExpression]:
@@ -1682,18 +1701,17 @@ class ASTUtils:
 
     @classmethod
     def remove_kernel_definitions_from_equations_block(cls, neuron: ASTNeuron) -> ASTDeclaration:
+        r"""
+        Removes all kernels in equations blocks.
         """
-        Removes all kernels in this block.
-        """
-        equations_block = neuron.get_equations_block()
+        for equations_block in neuron.get_equations_blocks():
+            decl_to_remove = set()
+            for decl in equations_block.get_declarations():
+                if type(decl) is ASTKernel:
+                    decl_to_remove.add(decl)
 
-        decl_to_remove = set()
-        for decl in equations_block.get_declarations():
-            if type(decl) is ASTKernel:
-                decl_to_remove.add(decl)
-
-        for decl in decl_to_remove:
-            equations_block.get_declarations().remove(decl)
+            for decl in decl_to_remove:
+                equations_block.get_declarations().remove(decl)
 
         return decl_to_remove
 
@@ -1710,7 +1728,7 @@ class ASTUtils:
         neuron.add_to_internal_block(ModelParser.parse_declaration('__h ms = resolution()'), index=0)
 
     @classmethod
-    def generate_kernel_buffers_(cls, neuron: ASTNeuron, equations_block: ASTEquationsBlock) -> Mapping[ASTKernel, ASTInputPort]:
+    def generate_kernel_buffers_(cls, neuron: ASTNeuron, equations_block: Union[ASTEquationsBlock, List[ASTEquationsBlock]]) -> Mapping[ASTKernel, ASTInputPort]:
         """
         For every occurrence of a convolution of the form `convolve(var, spike_buf)`: add the element `(kernel, spike_buf)` to the set, with `kernel` being the kernel that contains variable `var`.
         """
@@ -1760,13 +1778,14 @@ class ASTUtils:
                     var.set_name(replace_with_var_name + '__d' * var.get_differential_order())
                     var.set_differential_order(0)
 
-        for decl in neuron.get_equations_block().get_declarations():
-            if isinstance(decl, ASTInlineExpression) \
-               and isinstance(decl.get_expression(), ASTSimpleExpression) \
-               and '__X__' in str(decl.get_expression()):
-                replace_with_var_name = decl.get_expression().get_variable().get_name()
-                neuron.accept(ASTHigherOrderVisitor(lambda x: replace_var(
-                    x, decl.get_variable_name(), replace_with_var_name)))
+        for equation_block in neuron.get_equations_blocks():
+            for decl in equation_block.get_declarations():
+                if isinstance(decl, ASTInlineExpression) \
+                   and isinstance(decl.get_expression(), ASTSimpleExpression) \
+                   and '__X__' in str(decl.get_expression()):
+                    replace_with_var_name = decl.get_expression().get_variable().get_name()
+                    neuron.accept(ASTHigherOrderVisitor(lambda x: replace_var(
+                        x, decl.get_variable_name(), replace_with_var_name)))
 
     @classmethod
     def replace_variable_names_in_expressions(cls, neuron: ASTNeuron, solver_dicts: List[dict]) -> None:
@@ -1878,13 +1897,20 @@ class ASTUtils:
         return None
 
     @classmethod
-    def get_convolve_function_calls(cls, ast):
+    def get_convolve_function_calls(cls, nodes: Union[ASTNode, List[ASTNode]]):
         """
         Returns all sum function calls in the handed over meta_model node or one of its children.
         :param ast: a single meta_model node.
         :type ast: ASTNode
         """
-        return cls.get_function_calls(ast, PredefinedFunctions.CONVOLVE)
+        if isinstance(nodes, ASTNode):
+            nodes = [nodes]
+
+        function_calls = []
+        for node in nodes:
+            function_calls.extend(cls.get_function_calls(node, PredefinedFunctions.CONVOLVE))
+
+        return function_calls
 
     @classmethod
     def contains_convolve_function_call(cls, ast):
@@ -1900,7 +1926,7 @@ class ASTUtils:
     @classmethod
     def get_function_calls(cls, ast_node, function_list):
         """
-        For a handed over list of function names, this method retrieves all functions in the meta_model.
+        For a handed over list of function names, this method retrieves all function calls in the meta_model.
         :param ast_node: a single meta_model node
         :type ast_node: ASTNode
         :param function_list: a list of function names
@@ -1917,3 +1943,11 @@ class ASTUtils:
         vis = ASTHigherOrderVisitor(visit_funcs=fun)
         ast_node.accept(vis)
         return res
+
+    @classmethod
+    def resolve_to_variable_symbol_in_blocks(cls, variable_name: str, blocks: List[ASTBlock]):
+        for block in blocks:
+            sym = block.get_scope().resolve_to_symbol(variable_name, SymbolKind.VARIABLE)
+            if sym:
+                return sym
+        return None

--- a/pynestml/utils/ast_utils.py
+++ b/pynestml/utils/ast_utils.py
@@ -431,7 +431,7 @@ class ASTUtils:
     @classmethod
     def create_state_block(cls, neuron):
         """
-        Creates a single internal block in the handed over neuron.
+        Creates a single internals block in the handed over neuron.
         :param neuron: a single neuron
         :type neuron: ast_neuron
         :return: the modified neuron
@@ -443,6 +443,23 @@ class ASTUtils:
             state = ASTNodeFactory.create_ast_block_with_variables(True, False, False, list(),
                                                                    ASTSourceLocation.get_added_source_position())
             neuron.get_body().get_body_elements().append(state)
+        return neuron
+
+    @classmethod
+    def create_equations_block(cls, neuron):
+        """
+        Creates a single equations block in the handed over neuron.
+        :param neuron: a single neuron
+        :type neuron: ast_neuron
+        :return: the modified neuron
+        :rtype: ast_neuron
+        """
+        # local import since otherwise circular dependency
+        from pynestml.meta_model.ast_node_factory import ASTNodeFactory
+        if not neuron.get_equations_blocks():
+            block = ASTNodeFactory.create_ast_equations_block(list(),
+                                                              ASTSourceLocation.get_added_source_position())
+            neuron.get_body().get_body_elements().append(block)
         return neuron
 
     @classmethod
@@ -729,7 +746,7 @@ class ASTUtils:
     def equations_from_block_to_block(cls, state_var, from_block, to_block, var_name_suffix, mode) -> List[ASTDeclaration]:
         assert mode in ["move", "copy"]
 
-        if not to_block or not from_block:
+        if not from_block:
             return []
 
         decls = ASTUtils.get_declarations_from_block(state_var, from_block)

--- a/pynestml/utils/error_listener.py
+++ b/pynestml/utils/error_listener.py
@@ -19,10 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-"""
-This class contains several method used to parse handed over models and returns them as one or more AST trees.
-"""
-from antlr4.error.ErrorListener import ConsoleErrorListener, ErrorListener
+
+from antlr4.error.ErrorListener import ErrorListener
 
 
 class NestMLErrorListener(ErrorListener):

--- a/pynestml/utils/error_strings.py
+++ b/pynestml/utils/error_strings.py
@@ -18,7 +18,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
-from pynestml.utils.ast_source_location import ASTSourceLocation
 
 
 class ErrorStrings:

--- a/pynestml/utils/messages.py
+++ b/pynestml/utils/messages.py
@@ -338,7 +338,6 @@ class Messages:
         """
         assert (input_port_name is not None and isinstance(input_port_name, str)), \
             '(PyNestML.Utils.Message) Not a string provided (%s)!' % type(input_port_name)
-        from pynestml.symbols.predefined_types import PredefinedTypes
         message = 'No type declared for spiking input port \'%s\'!' % input_port_name
         return MessageCode.SPIKE_INPUT_PORT_TYPE_NOT_DEFINED, message
 

--- a/pynestml/utils/type_caster.py
+++ b/pynestml/utils/type_caster.py
@@ -21,7 +21,6 @@
 
 from pynestml.symbols.unit_type_symbol import UnitTypeSymbol
 from pynestml.utils.logger import Logger, LoggingLevel
-from pynestml.utils.logging_helper import LoggingHelper
 from pynestml.utils.messages import Messages
 
 

--- a/pynestml/visitors/ast_function_call_visitor.py
+++ b/pynestml/visitors/ast_function_call_visitor.py
@@ -18,17 +18,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
-"""
-simpleExpression : functionCall
-"""
-from pynestml.meta_model.ast_expression import ASTExpression
-from pynestml.meta_model.ast_node_factory import ASTNodeFactory
+
 from pynestml.meta_model.ast_simple_expression import ASTSimpleExpression
 from pynestml.symbols.error_type_symbol import ErrorTypeSymbol
 from pynestml.symbols.template_type_symbol import TemplateTypeSymbol
 from pynestml.symbols.predefined_functions import PredefinedFunctions
 from pynestml.symbols.symbol import SymbolKind
-from pynestml.symbols.variable_symbol import BlockType
 from pynestml.symbols.void_type_symbol import VoidTypeSymbol
 from pynestml.utils.ast_utils import ASTUtils
 from pynestml.utils.logger import LoggingLevel, Logger

--- a/pynestml/visitors/ast_random_number_generator_visitor.py
+++ b/pynestml/visitors/ast_random_number_generator_visitor.py
@@ -21,10 +21,8 @@
 
 from pynestml.meta_model.ast_simple_expression import ASTSimpleExpression
 from pynestml.symbols.error_type_symbol import ErrorTypeSymbol
-from pynestml.symbols.template_type_symbol import TemplateTypeSymbol
 from pynestml.symbols.predefined_functions import PredefinedFunctions
 from pynestml.symbols.symbol import SymbolKind
-from pynestml.symbols.void_type_symbol import VoidTypeSymbol
 from pynestml.utils.logger import LoggingLevel, Logger
 from pynestml.utils.messages import Messages
 from pynestml.visitors.ast_visitor import ASTVisitor

--- a/pynestml/visitors/ast_symbol_table_visitor.py
+++ b/pynestml/visitors/ast_symbol_table_visitor.py
@@ -22,10 +22,8 @@
 from pynestml.cocos.co_cos_manager import CoCosManager
 from pynestml.meta_model.ast_namespace_decorator import ASTNamespaceDecorator
 from pynestml.meta_model.ast_declaration import ASTDeclaration
-from pynestml.meta_model.ast_node_factory import ASTNodeFactory
 from pynestml.meta_model.ast_stmt import ASTStmt
 from pynestml.meta_model.ast_variable import ASTVariable
-from pynestml.utils.ast_source_location import ASTSourceLocation
 from pynestml.symbol_table.scope import Scope, ScopeType
 from pynestml.symbols.function_symbol import FunctionSymbol
 from pynestml.symbols.predefined_functions import PredefinedFunctions
@@ -84,8 +82,7 @@ class ASTSymbolTableVisitor(ASTVisitor):
         CoCosManager.post_symbol_table_builder_checks(node, after_ast_rewrite=self.after_ast_rewrite_)
 
         # update the equations
-        if node.get_equations_blocks() is not None and len(node.get_equations_blocks().get_declarations()) > 0:
-            equation_block = node.get_equations_blocks()
+        for equation_block in node.get_equations_blocks():
             ASTUtils.assign_ode_to_variables(equation_block)
 
         Logger.set_current_node(None)

--- a/pynestml/visitors/comment_collector_visitor.py
+++ b/pynestml/visitors/comment_collector_visitor.py
@@ -306,7 +306,6 @@ def get_post_comments(ctx, tokens, strip_delim: bool = True) -> List[str]:
                 next_line_start_index = tokens.index(possibleToken)
                 break
             prev_token_was_comment = True
-    first_line = False
     for possibleCommentToken in tokens[next_line_start_index:]:
         if possibleCommentToken.channel == 2:
             # if it is a comment on the comment channel -> get it

--- a/tests/unit_system_test.py
+++ b/tests/unit_system_test.py
@@ -54,13 +54,14 @@ printer = NestPrinter(reference_converter=reference_converter,
 
 
 def get_first_statement_in_update_block(model):
-    if model.get_neuron_list()[0].get_update_blocks():
-        return model.get_neuron_list()[0].get_update_blocks().get_block().get_stmts()[0]
+    if model.get_neuron_list()[0].get_update_blocks()[0]:
+        return model.get_neuron_list()[0].get_update_blocks()[0].get_block().get_stmts()[0]
     return None
 
 
 def get_first_declaration_in_state_block(model):
-    return model.get_neuron_list()[0].get_state_blocks().get_declarations()[0]
+    assert len(model.get_neuron_list()[0].get_state_blocks()) == 1
+    return model.get_neuron_list()[0].get_state_blocks()[0].get_declarations()[0]
 
 
 def get_first_declared_function(model):


### PR DESCRIPTION
This is a purely internal refactoring.

Make ``get_equations_blocks()``, ``get_parameters_blocks()`` and other block-getter function on the ``ASTNeuronOrSynapse`` return lists in a consistent manner. Also de-duplicate some code and fix imports.

Motivation for preferring the list option rather than single elements, is because this leaves the way open in the future, where NESTML could have an "import" or "include" mechanism, to make models more modular. Then, two different blocks of the same type (e.g. ``state``, ``parameters``) from two different .nestml files might end up in the same model.