### PR TITLE
Fix API doc build environment requirements

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,4 +3,14 @@ nbsphinx
 docutils
 sphinx>=4
 sphinx_rtd_theme>=1.0.0
-nestml   # trick to install all NESTML requirements
+
+# the following list is a direct copy from requirements.txt in the root directory (requirements for NESTML itself rather than for doc building)
+numpy >= 1.8.2
+scipy
+sympy >= 1.1.1,!= 1.11, != 1.11.1
+antlr4-python3-runtime == 4.10
+setuptools
+Jinja2 >= 2.10
+typing;python_version<"3.5"
+astropy
+odetoolbox >= 2.4

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,3 +3,4 @@ nbsphinx
 docutils
 sphinx>=4
 sphinx_rtd_theme>=1.0.0
+nestml   # trick to install all NESTML requirements

--- a/pynestml/codegeneration/nest_code_generator.py
+++ b/pynestml/codegeneration/nest_code_generator.py
@@ -81,9 +81,10 @@ def find_spiking_post_port(synapse, namespace):
 
 class NESTCodeGenerator(CodeGenerator):
     r"""
-    Code generator for a NEST Simulator (versions 3.x.x or higher) C++ extension module.
+    Code generator for a NEST Simulator C++ extension module.
 
     Options:
+
     - **neuron_parent_class**: The C++ class from which the generated NESTML neuron class inherits. Examples: ``"ArchivingNode"``, ``"StructuralPlasticityNode"``. Default: ``"ArchivingNode"``.
     - **neuron_parent_class_include**: The C++ header filename to include that contains **neuron_parent_class**. Default: ``"archiving_node.h"``.
     - **neuron_synapse_pairs**: List of pairs of (neuron, synapse) model names.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# note: copy any changes to doc/requirements.txt
 numpy >= 1.8.2
 scipy
 sympy >= 1.1.1,!= 1.11, != 1.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy >= 1.8.2
+scipy
 sympy >= 1.1.1,!= 1.11, != 1.11.1
 antlr4-python3-runtime == 4.10
 setuptools


### PR DESCRIPTION
The ``requirements.txt`` for the docs is apparently no longer including the dependencies in ``requirements.txt`` of NESTML itself (in the package root). As ``requirements.txt`` files do not support importing one into the other, copy-paste the one into the other while adding some cautionary notes about this as comments.