### PR TITLE
Fix template namespace bug

### DIFF
--- a/pynestml/codegeneration/nest_code_generator.py
+++ b/pynestml/codegeneration/nest_code_generator.py
@@ -656,7 +656,6 @@ class NESTCodeGenerator(CodeGenerator):
             else:
                 namespace["numeric_state_variables"] = self.numeric_solver[neuron.get_name()]["state_variables"]
 
-            namespace["variable_symbols"] = {}
             for var_name in namespace["numeric_state_variables"]:
                 for equations_block in neuron.get_equations_blocks():
                     sym = equations_block.get_scope().resolve_to_symbol(var_name, SymbolKind.VARIABLE)


### PR DESCRIPTION
In the NEST code generator, the ``variable_symbols`` environment variable could get accidentally overwritten even though it was initialized already at some point prior. This PR fixes the bug.