### PR TITLE
Update documentation on conda installation on macOS

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -81,6 +81,8 @@ Edit ``nest-config`` and correct the entry under ``--compiler`` with the output 
 
    nano /home/graber/miniconda3/envs/wnestml/bin/nest-config
 
+macOS users must in addition replace the ``-fopenmp=libomp`` entries with ``-Xclang -fopenmp`` under both ``--cflags`` and ``--libs`` in the ``nest-config``.
+
 Now set the correct paths and start ``ipython``:
 
 .. code-block:: bash


### PR DESCRIPTION
It does not seem like issue https://github.com/nest/nest-simulator/issues/2497 will be resolved by the release of NEST 3.4. This PR adds documentation on a temporary workaround with edits to the `nest-config` on macOS when NEST is installed from conda-forge. 