### PR TITLE
Restore compatibility with Python 3.8

### DIFF
--- a/.github/workflows/nestml-build.yml
+++ b/.github/workflows/nestml-build.yml
@@ -25,10 +25,10 @@ jobs:
         uses: actions/checkout@v3
 
       # Setup Python version
-      - name: Setup Python 3.9
+      - name: Setup Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.8
 
       # Install dependencies
       - name: Install apt dependencies
@@ -60,10 +60,10 @@ jobs:
         uses: actions/checkout@v3
 
       # Setup Python version
-      - name: Setup Python 3.9
+      - name: Setup Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.8
 
       # Install dependencies
       - name: Install apt dependencies
@@ -116,7 +116,7 @@ jobs:
       # Install NESTML (repeated)
       - name: Install NESTML
         run: |
-          export PYTHONPATH=${{ env.PYTHONPATH }}:${{ env.NEST_INSTALL }}/lib/python3.9/site-packages
+          export PYTHONPATH=${{ env.PYTHONPATH }}:${{ env.NEST_INSTALL }}/lib/python3.8/site-packages
           #echo PYTHONPATH=`pwd` >> $GITHUB_ENV
           echo "PYTHONPATH=$PYTHONPATH" >> $GITHUB_ENV
           python setup.py install

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -1,7 +1,7 @@
 Installing NESTML
 =================
 
-Please note that only Python 3.9 (and later versions) are supported. The instructions below assume that ``python`` is aliased to or refers to ``python3``, and ``pip`` to ``pip3``.
+Please note that only Python 3.8 (and later versions) are supported. The instructions below assume that ``python`` is aliased to or refers to ``python3``, and ``pip`` to ``pip3``.
 
 Installing the latest release from PyPI
 ---------------------------------------

--- a/pynestml/transformers/synapse_post_neuron_transformer.py
+++ b/pynestml/transformers/synapse_post_neuron_transformer.py
@@ -36,6 +36,7 @@ from pynestml.transformers.transformer import Transformer
 from pynestml.utils.ast_utils import ASTUtils
 from pynestml.utils.logger import Logger
 from pynestml.utils.logger import LoggingLevel
+from pynestml.utils.string_utils import removesuffix
 from pynestml.visitors.ast_symbol_table_visitor import ASTSymbolTableVisitor
 from pynestml.visitors.ast_higher_order_visitor import ASTHigherOrderVisitor
 from pynestml.visitors.ast_visitor import ASTVisitor
@@ -493,8 +494,8 @@ class SynapsePostNeuronTransformer(Transformer):
         new_synapse.paired_neuron = new_neuron
         new_neuron.paired_synapse = new_synapse
 
-        base_neuron_name = neuron.get_name().removesuffix(FrontendConfiguration.suffix)
-        base_synapse_name = synapse.get_name().removesuffix(FrontendConfiguration.suffix)
+        base_neuron_name = removesuffix(neuron.get_name(), FrontendConfiguration.suffix)
+        base_synapse_name = removesuffix(synapse.get_name(), FrontendConfiguration.suffix)
 
         new_synapse.post_port_names = self.get_post_port_names(synapse, base_neuron_name, base_synapse_name)
         new_synapse.spiking_post_port_names = self.get_spiking_post_port_names(synapse, base_neuron_name, base_synapse_name)

--- a/pynestml/utils/ast_utils.py
+++ b/pynestml/utils/ast_utils.py
@@ -58,6 +58,7 @@ from pynestml.symbols.variable_symbol import VariableSymbol, VariableType
 from pynestml.utils.ast_source_location import ASTSourceLocation
 from pynestml.utils.logger import LoggingLevel, Logger
 from pynestml.utils.messages import Messages
+from pynestml.utils.string_utils import removesuffix
 from pynestml.visitors.ast_higher_order_visitor import ASTHigherOrderVisitor
 from pynestml.visitors.ast_visitor import ASTVisitor
 
@@ -719,7 +720,7 @@ class ASTUtils:
 
         decls = ASTUtils.get_declarations_from_block(var_name, from_block)
         if var_name.endswith(var_name_suffix):
-            decls.extend(ASTUtils.get_declarations_from_block(var_name.removesuffix(var_name_suffix), from_block))
+            decls.extend(ASTUtils.get_declarations_from_block(removesuffix(var_name, var_name_suffix), from_block))
 
         if decls:
             Logger.log_message(None, -1, "Moving definition of " + var_name + " from synapse to neuron",

--- a/pynestml/utils/string_utils.py
+++ b/pynestml/utils/string_utils.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# string_utils.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+
+def removeprefix(s: str, prefix: str) -> str:
+    if prefix and s.startswith(prefix):
+        return s[len(prefix):]
+
+    return s
+
+
+def removesuffix(s: str, suffix: str) -> str:
+    if suffix and s.endswith(suffix):
+        return s[:-len(suffix)]
+
+    return s

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ import os
 import sys
 from setuptools import setup, find_packages
 
-assert sys.version_info.major >= 3 and sys.version_info.minor >= 9, "Python 3.9 or higher is required to run NESTML"
+assert sys.version_info.major >= 3 and sys.version_info.minor >= 8, "Python 3.8 or higher is required to run NESTML"
 
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()

--- a/tests/nest_tests/nest_integration_test.py
+++ b/tests/nest_tests/nest_integration_test.py
@@ -29,6 +29,7 @@ import nest
 
 from pynestml.codegeneration.nest_tools import NESTTools
 from pynestml.frontend.pynestml_frontend import generate_nest_target
+from pynestml.utils.string_utils import removeprefix, removesuffix
 
 try:
     import matplotlib
@@ -192,7 +193,7 @@ class NestIntegrationTest(unittest.TestCase):
         untested_models = copy.deepcopy(allmodels)
         for model in models:
             model_fname = model[1]
-            assert model_fname.removesuffix(".nestml") in allmodels
+            assert removesuffix(model_fname, ".nestml") in allmodels
             if model_fname in untested_models:
                 untested_models.remove(model_fname)
         print("untested_models = " + str(untested_models))
@@ -202,7 +203,7 @@ class NestIntegrationTest(unittest.TestCase):
         for model in models:
             model_name = model[0]
             model_fname = model[1]
-            model_fname_stripped = model_fname.removesuffix(".nestml")
+            model_fname_stripped = removesuffix(model_fname, ".nestml")
 
             if model_fname_stripped in untested_models:
                 untested_models.remove(model_fname_stripped)
@@ -213,8 +214,8 @@ class NestIntegrationTest(unittest.TestCase):
 
             model_doc_title = get_model_doc_title(os.path.join("models", "synapses", model_fname))
             if model_doc_title.startswith(model_name):
-                model_doc_title = model_doc_title.removeprefix(model_name)
-                model_doc_title = model_doc_title.removeprefix(" - ")
+                model_doc_title = removeprefix(model_doc_title, model_name)
+                model_doc_title = removeprefix(model_doc_title, " - ")
             s += "\n" + model_doc_title + "\n"
 
             s += "\n"
@@ -232,8 +233,8 @@ class NestIntegrationTest(unittest.TestCase):
 
             model_doc_title = get_model_doc_title(os.path.join("models", "synapses", model_fname))
             if model_doc_title.startswith(model_name):
-                model_doc_title = model_doc_title.removeprefix(model_name)
-                model_doc_title = model_doc_title.removeprefix(" - ")
+                model_doc_title = removeprefix(model_doc_title, model_name)
+                model_doc_title = removeprefix(model_doc_title, " - ")
             s += "\n" + model_doc_title + "\n"
 
             s += "\n"
@@ -291,8 +292,8 @@ class NestIntegrationTest(unittest.TestCase):
 
             model_doc_title = get_model_doc_title(os.path.join("models", "neurons", model_fname))
             if model_doc_title.startswith(model_name):
-                model_doc_title = model_doc_title.removeprefix(model_name)
-                model_doc_title = model_doc_title.removeprefix(" - ")
+                model_doc_title = removeprefix(model_doc_title, model_name)
+                model_doc_title = removeprefix(model_doc_title, " - ")
             s += "\n" + model_doc_title + "\n"
 
             s += "\n"
@@ -337,8 +338,8 @@ class NestIntegrationTest(unittest.TestCase):
 
             model_doc_title = get_model_doc_title(os.path.join("models", "neurons", model_fname))
             if model_doc_title.startswith(model_name):
-                model_doc_title = model_doc_title.removeprefix(model_name)
-                model_doc_title = model_doc_title.removeprefix(" - ")
+                model_doc_title = removeprefix(model_doc_title, model_name)
+                model_doc_title = removeprefix(model_doc_title, " - ")
             s += "\n" + model_doc_title + "\n"
 
             s += "\n"


### PR DESCRIPTION
A simple change allows NESTML to run in environments that do not have support yet for Python 3.9.