### PR TITLE
Change neuron partner preprocessor #DEFINE to typedef

### DIFF
--- a/pynestml/codegeneration/printers/nest_variable_printer.py
+++ b/pynestml/codegeneration/printers/nest_variable_printer.py
@@ -61,9 +61,9 @@ class NESTVariablePrinter(CppVariablePrinter):
             _name = str(variable)
             if variable.get_alternate_name():
                 # the disadvantage of this approach is that the time the value is to be obtained is not explicitly specified, so we will actually get the value at the end of the min_delay timestep
-                return "((POST_NEURON_TYPE*)(__target))->get_" + variable.get_alternate_name() + "()"
+                return "((post_neuron_t*)(__target))->get_" + variable.get_alternate_name() + "()"
 
-            return "((POST_NEURON_TYPE*)(__target))->get_" + _name + "(_tr_t)"
+            return "((post_neuron_t*)(__target))->get_" + _name + "(_tr_t)"
 
         if variable.get_name() == PredefinedVariables.E_CONSTANT:
             return "numerics::e"

--- a/pynestml/codegeneration/resources_nest/point_neuron/common/SynapseHeader.h.jinja2
+++ b/pynestml/codegeneration/resources_nest/point_neuron/common/SynapseHeader.h.jinja2
@@ -78,8 +78,6 @@ along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 {{ synapse.print_comment() }}
 **/
 
-#define POST_NEURON_TYPE {{ paired_neuron }}
-
 //#define DEBUG
 
 namespace nest
@@ -219,6 +217,10 @@ public:
 template < typename targetidentifierT >
 class {{synapseName}} : public Connection< targetidentifierT >
 {
+{%- if paired_neuron | length > 0 %}
+  typedef {{ paired_neuron }} post_neuron_t;
+
+{% endif %}
 {%- if vt_ports is defined and vt_ports|length > 0  %}
 public:
   void trigger_update_weight( thread t,


### PR DESCRIPTION
This allows each synapse to have exactly one paired neuron. Previously, preprocessor ``#DEFINE``s could conflict with one another across different generated synapse model files.