### PR TITLE
Fix ternary operator handling

### DIFF
--- a/pynestml/codegeneration/printers/cpp_expression_printer.py
+++ b/pynestml/codegeneration/printers/cpp_expression_printer.py
@@ -64,6 +64,9 @@ class CppExpressionPrinter(ExpressionPrinter):
         if node.is_ternary_operator():
             return self._print_ternary_operator_expression(node)
 
+        if node.is_expression():
+            return self.print_expression(node.get_expression())
+
         raise RuntimeError("Tried to print unknown expression: \"%s\"" % str(node))
 
     def _print_unary_op_expression(self, node: ASTExpressionNode) -> str:

--- a/pynestml/codegeneration/printers/python_expression_printer.py
+++ b/pynestml/codegeneration/printers/python_expression_printer.py
@@ -60,6 +60,9 @@ class PythonExpressionPrinter(ExpressionPrinter):
         if node.is_ternary_operator():
             return self._print_ternary_operator_expression(node)
 
+        if node.is_expression():
+            return self.print_expression(node.get_expression())
+
         raise RuntimeError("Tried to print unknown expression: \"%s\"" % str(node))
 
     def _print_unary_op_expression(self, node: ASTExpressionNode) -> str:

--- a/pynestml/utils/model_parser.py
+++ b/pynestml/utils/model_parser.py
@@ -102,8 +102,8 @@ class ModelParser:
         lexer.addErrorListener(ConsoleErrorListener())
         lexerErrorListener = NestMLErrorListener()
         lexer.addErrorListener(lexerErrorListener)
-        # lexer._errHandler = BailErrorStrategy()  # N.B. uncomment this line and the next to halt immediately on lexer errors
-        # lexer._errHandler.reset(lexer)
+        lexer._errHandler = BailErrorStrategy()  # halt immediately on lexer errors
+        lexer._errHandler.reset(lexer)
         lexer.inputStream = input_file
         # create a token stream
         stream = CommonTokenStream(lexer)

--- a/pynestml/visitors/ast_symbol_table_visitor.py
+++ b/pynestml/visitors/ast_symbol_table_visitor.py
@@ -456,8 +456,10 @@ class ASTSymbolTableVisitor(ASTVisitor):
         :type node: ast_expression
         """
         from pynestml.meta_model.ast_simple_expression import ASTSimpleExpression
+
         if isinstance(node, ASTSimpleExpression):
             return self.visit_simple_expression(node)
+
         if node.is_logical_not:
             node.get_expression().update_scope(node.get_scope())
         elif node.is_encapsulated:
@@ -469,10 +471,12 @@ class ASTSymbolTableVisitor(ASTVisitor):
             node.get_lhs().update_scope(node.get_scope())
             node.get_binary_operator().update_scope(node.get_scope())
             node.get_rhs().update_scope(node.get_scope())
-        if node.is_ternary_operator():
+        elif node.is_ternary_operator():
             node.get_condition().update_scope(node.get_scope())
             node.get_if_true().update_scope(node.get_scope())
             node.get_if_not().update_scope(node.get_scope())
+        elif node.is_expression():
+            node.get_expression().update_scope(node.get_scope())
 
     def visit_simple_expression(self, node):
         """


### PR DESCRIPTION
The sympy Piecewise() function was not being converted into C++ (cond ? if_true : if_false) syntax properly. This PR fixes the problem (which showed up in the Hill-Tononi model) as well as changing the lexer/parser error strategy to "bail", so this error cannot pass unnoticed in the future.