### PR TITLE
Forbid sympy >= 1.11 due to upstream bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # note: copy any changes to doc/requirements.txt
 numpy >= 1.8.2
 scipy
-sympy >= 1.1.1,!= 1.11, != 1.11.1
+sympy >= 1.1.1, <1.11
 antlr4-python3-runtime == 4.10
 setuptools
 Jinja2 >= 2.10


### PR DESCRIPTION
Failure of CI due to new upstream release of sympy 1.12.

See #806.