### PR TITLE
Add pandas dependency to the build workflow

### DIFF
--- a/.github/workflows/nestml-build.yml
+++ b/.github/workflows/nestml-build.yml
@@ -132,6 +132,11 @@ jobs:
         run: |
           pytest -s -o norecursedirs='*' -o log_cli=true -o log_cli_level="DEBUG" tests
 
+      # tmate session
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 720
+
       # Integration tests: prepare (make module containing all NESTML models)
       - name: Setup integration tests
         run: |

--- a/.github/workflows/nestml-build.yml
+++ b/.github/workflows/nestml-build.yml
@@ -75,7 +75,7 @@ jobs:
       # Install Python dependencies
       - name: Python dependencies
         run: |
-          python -m pip install --upgrade pip pytest jupyterlab matplotlib pycodestyle scipy
+          python -m pip install --upgrade pip pytest jupyterlab matplotlib pycodestyle scipy pandas
           python -m pip install -r requirements.txt
 
       # Install Java
@@ -131,11 +131,6 @@ jobs:
       - name: Run unit tests
         run: |
           pytest -s -o norecursedirs='*' -o log_cli=true -o log_cli_level="DEBUG" tests
-
-      # tmate session
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 720
 
       # Integration tests: prepare (make module containing all NESTML models)
       - name: Setup integration tests


### PR DESCRIPTION
The NEST SONATA PR has introduced a `pandas` dependency due to which the `import nest` fails resulting in a CI error. This PR adds `pandas` to the CI workflow.