### PR TITLE
Instruction Update re Basic Ubuntu on WSL

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -91,7 +91,7 @@ Please make sure to have the latest conda version installed and to create a new 
 
    conda create --name wnestml
    conda activate wnestml
-   conda install -c conda-forge nest-simulator ipython cxx-compiler pyqt wxpython boost boost-cpp libboost cmake
+   conda install -c conda-forge nest-simulator ipython cxx-compiler pyqt wxpython boost boost-cpp libboost cmake make
    pip install nestml
 
 Test the path to ``c++``:

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -83,7 +83,9 @@ After installation, correct operation can be tested by:
 Anaconda installation
 ---------------------
 
-In preparation, `create a conda environment with NEST <https://nest-simulator.readthedocs.io/en/stable/installation/index.html>`_, and install some additional dependencies. Note that if you are working with a basic version of Ubuntu or another Linux distribution (ex. a basic download for use in the Windows Linux Subsystem), you also need to include the ``make`` package in the install command. The ``cmake`` package will not function without this package installed (it is by default on full versions of Linux distributions). 
+In preparation, `create a conda environment with NEST <https://nest-simulator.readthedocs.io/en/stable/installation/index.html>`_, and install some additional dependencies.
+
+Please make sure to have the latest conda version installed and to create a new environment with the command below, i.e. installing all packages together at the start versus installing one by one.
 
 .. code-block:: bash
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -83,13 +83,13 @@ After installation, correct operation can be tested by:
 Anaconda installation
 ---------------------
 
-In preparation, `create a conda environment with NEST <https://nest-simulator.readthedocs.io/en/stable/installation/index.html>`_, and install some additional dependencies:
+In preparation, `create a conda environment with NEST <https://nest-simulator.readthedocs.io/en/stable/installation/index.html>`_, and install some additional dependencies. Note that if you are working with a basic version of Ubuntu or another Linux distribution (ex. a basic download for use in the Windows Linux Subsystem), you also need to include the ``make`` package in the install command. The ``cmake`` package will not function without this package installed (it is by default on full versions of Linux distributions). 
 
 .. code-block:: bash
 
    conda create --name wnestml
    conda activate wnestml
-   conda install -c conda-forge nest-simulator ipython cxx-compiler pyqt wxpython boost boost-cpp libboost
+   conda install -c conda-forge nest-simulator ipython cxx-compiler pyqt wxpython boost boost-cpp libboost cmake
    pip install nestml
 
 Test the path to ``c++``:


### PR DESCRIPTION
Added the cmake package to the conda install command. The cmake package is not installed by default and will result in errors if missing (confirmed on MacOS and Linux). 

Also added information relevant to installing on Windows Linux Subsystem installations of Linux.