### PR TITLE
Refactor ``ASTNode.get_parent()`` to improve runtime performance

### DIFF
--- a/pynestml/cocos/co_co_all_variables_defined.py
+++ b/pynestml/cocos/co_co_all_variables_defined.py
@@ -101,7 +101,7 @@ class CoCoAllVariablesDefined(CoCo):
                 # check if it is part of an invariant
                 # if it is the case, there is no "recursive" declaration
                 # so check if the parent is a declaration and the expression the invariant
-                expr_par = node.get_parent(expr)
+                expr_par = expr.get_parent()
                 if isinstance(expr_par, ASTDeclaration) and expr_par.get_invariant() == expr:
                     # in this case its ok if it is recursive or defined later on
                     continue

--- a/pynestml/cocos/co_co_no_kernels_except_in_convolve.py
+++ b/pynestml/cocos/co_co_no_kernels_except_in_convolve.py
@@ -93,11 +93,11 @@ class KernelUsageVisitor(ASTVisitor):
             if not symbol.is_kernel():
                 continue
             if node.get_complete_name() == kernelName:
-                parent = self.__neuron_node.get_parent(node)
+                parent = node.get_parent()
                 if parent is not None:
                     if isinstance(parent, ASTKernel):
                         continue
-                    grandparent = self.__neuron_node.get_parent(parent)
+                    grandparent = parent.get_parent()
                     if grandparent is not None and isinstance(grandparent, ASTFunctionCall):
                         grandparent_func_name = grandparent.get_name()
                         if grandparent_func_name == 'convolve':

--- a/pynestml/cocos/co_co_resolution_func_legally_used.py
+++ b/pynestml/cocos/co_co_resolution_func_legally_used.py
@@ -62,7 +62,7 @@ class CoCoResolutionFuncLegallyUsedVisitor(ASTVisitor):
         if function_name == PredefinedFunctions.TIME_RESOLUTION:
             _node = node
             while _node:
-                _node = self.neuron.get_parent(_node)
+                _node = _node.get_parent()
 
                 if isinstance(_node, ASTEquationsBlock) \
                         or isinstance(_node, ASTFunction):

--- a/pynestml/cocos/co_co_simple_delta_function.py
+++ b/pynestml/cocos/co_co_simple_delta_function.py
@@ -44,7 +44,7 @@ class CoCoSimpleDeltaFunction(CoCo):
         def check_simple_delta(_expr=None):
             if _expr.is_function_call() and _expr.get_function_call().get_name() == "delta":
                 deltafunc = _expr.get_function_call()
-                parent = model.get_parent(_expr)
+                parent = _expr.get_parent()
 
                 # check the argument
                 if not (len(deltafunc.get_args()) == 1

--- a/pynestml/cocos/co_co_vector_declaration_right_size.py
+++ b/pynestml/cocos/co_co_vector_declaration_right_size.py
@@ -50,7 +50,7 @@ class VectorDeclarationVisitor(ASTVisitor):
     def visit_variable(self, node: ASTVariable):
         vector_parameter = node.get_vector_parameter()
         if vector_parameter is not None:
-            if isinstance(self._neuron.get_parent(node), ASTDeclaration):
+            if isinstance(node.get_parent(), ASTDeclaration):
                 # node is being declared: size should be >= 1
                 min_index = 1
 

--- a/pynestml/meta_model/ast_arithmetic_operator.py
+++ b/pynestml/meta_model/ast_arithmetic_operator.py
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
 from pynestml.meta_model.ast_node import ASTNode
 
 
@@ -71,23 +72,20 @@ class ASTArithmeticOperator(ASTNode):
 
         return dup
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        return None
+        return []
 
-    def equals(self, other):
-        # type: (ASTNode) -> bool
-        """
+    def equals(self, other: ASTNode) -> bool:
+        r"""
         The equality method.
         """
         if not isinstance(other, ASTArithmeticOperator):
             return False
+
         return (self.is_times_op == other.is_times_op and self.is_div_op == other.is_div_op
                 and self.is_modulo_op == other.is_modulo_op and self.is_plus_op == other.is_plus_op
                 and self.is_minus_op == other.is_minus_op and self.is_pow_op == other.is_pow_op)

--- a/pynestml/meta_model/ast_bit_operator.py
+++ b/pynestml/meta_model/ast_bit_operator.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pynestml.meta_model.ast_node import ASTNode
 
 
@@ -82,23 +84,16 @@ class ASTBitOperator(ASTNode):
 
         return dup
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        return None
+        return []
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTBitOperator):
             return False

--- a/pynestml/meta_model/ast_block.py
+++ b/pynestml/meta_model/ast_block.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pynestml.meta_model.ast_node import ASTNode
 
 
@@ -95,28 +97,16 @@ class ASTBlock(ASTNode):
         """
         self.stmts.remove(stmt)
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        for stmt in self.get_stmts():
-            if stmt is ast:
-                return self
-            if stmt.get_parent(ast) is not None:
-                return stmt.get_parent(ast)
-        return None
+        return self.get_stmts()
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTBlock):
             return False

--- a/pynestml/meta_model/ast_block_with_variables.py
+++ b/pynestml/meta_model/ast_block_with_variables.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pynestml.meta_model.ast_node import ASTNode
 
 
@@ -112,28 +114,16 @@ class ASTBlockWithVariables(ASTNode):
         del self.declarations
         self.declarations = list()
 
-    def get_parent(self, ast=None):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        for stmt in self.get_declarations():
-            if stmt is ast:
-                return self
-            if stmt.get_parent(ast) is not None:
-                return stmt.get_parent(ast)
-        return None
+        return self.get_declarations()
 
-    def equals(self, other=None):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False
-        :rtype: bool
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTBlockWithVariables):
             return False

--- a/pynestml/meta_model/ast_comparison_operator.py
+++ b/pynestml/meta_model/ast_comparison_operator.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pynestml.meta_model.ast_node import ASTNode
 
 
@@ -94,26 +96,20 @@ class ASTComparisonOperator(ASTNode):
 
         return dup
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        return None
+        return []
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTComparisonOperator):
             return False
+
         return (self.is_lt == other.is_lt and self.is_le == other.is_le
                 and self.is_eq == other.is_eq and self.is_ne == other.is_ne
                 and self.is_ne2 == other.is_ne2 and self.is_ge == other.is_ge and self.is_gt == other.is_gt)

--- a/pynestml/meta_model/ast_compound_stmt.py
+++ b/pynestml/meta_model/ast_compound_stmt.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pynestml.meta_model.ast_for_stmt import ASTForStmt
 from pynestml.meta_model.ast_if_stmt import ASTIfStmt
 from pynestml.meta_model.ast_node import ASTNode
@@ -141,48 +143,39 @@ class ASTCompoundStmt(ASTNode):
         """
         return self.for_stmt
 
-    def get_parent(self, ast):
-        """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
         if self.is_if_stmt():
-            if self.get_if_stmt() is ast:
-                return self
-            if self.get_if_stmt().get_parent(ast) is not None:
-                return self.get_if_stmt().get_parent(ast)
-        if self.is_while_stmt():
-            if self.get_while_stmt() is ast:
-                return self
-            if self.get_while_stmt().get_parent(ast) is not None:
-                return self.get_while_stmt().get_parent(ast)
-        if self.is_for_stmt():
-            if self.is_for_stmt() is ast:
-                return self
-            if self.get_for_stmt().get_parent(ast) is not None:
-                return self.get_for_stmt().get_parent(ast)
-        return None
+            return [self.get_if_stmt()]
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+        if self.is_while_stmt():
+            return [self.get_while_stmt()]
+
+        if self.is_for_stmt():
+            return [self.get_for_stmt()]
+
+        return []
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTCompoundStmt):
             return False
+
         if self.get_for_stmt() is not None and other.get_for_stmt() is not None and \
                 not self.get_for_stmt().equals(other.get_for_stmt()):
             return False
+
         if self.get_while_stmt() is not None and other.get_while_stmt() is not None and \
                 not self.get_while_stmt().equals(other.get_while_stmt()):
             return False
+
         if self.get_if_stmt() is not None and other.get_if_stmt() is not None and \
                 not self.get_if_stmt().equals(other.get_if_stmt()):
             return False
+
         return True

--- a/pynestml/meta_model/ast_data_type.py
+++ b/pynestml/meta_model/ast_data_type.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from typing import List, Optional
 
 from pynestml.meta_model.ast_node import ASTNode
 from pynestml.meta_model.ast_unit_type import ASTUnitType
@@ -141,38 +141,33 @@ class ASTDataType(ASTNode):
             '(PyNestML.AST.DataType) No or wrong type of type symbol provided (%s)!' % (type(type_symbol))
         self.type_symbol = type_symbol
 
-    def get_parent(self, ast):
-        """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
         if self.is_unit_type():
-            if self.get_unit_type() is ast:
-                return self
-            if self.get_unit_type().get_parent(ast) is not None:
-                return self.get_unit_type().get_parent(ast)
-        return None
+            return [self.get_unit_type()]
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+        return []
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTDataType):
             return False
+
         if not (self.is_integer == other.is_integer and self.is_real == other.is_real
                 and self.is_string == other.is_string and self.is_boolean == other.is_boolean
                 and self.is_void == other.is_void):
             return False
+
         # only one of them uses a unit, thus false
         if self.is_unit_type() + other.is_unit_type() == 1:
             return False
+
         if self.is_unit_type() and other.is_unit_type() and not self.get_unit_type().equals(other.get_unit_type()):
             return False
+
         return True

--- a/pynestml/meta_model/ast_declaration.py
+++ b/pynestml/meta_model/ast_declaration.py
@@ -154,7 +154,7 @@ class ASTDeclaration(ASTNode):
         Returns whether the declaration has a size parameter or not.
         :return: True if has size parameter, else False.
         """
-        return self.size_parameter
+        return self.size_parameter is not None
 
     def get_size_parameter(self) -> Optional[Union[ASTSimpleExpression, ASTExpression]]:
         """

--- a/pynestml/meta_model/ast_elif_clause.py
+++ b/pynestml/meta_model/ast_elif_clause.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pynestml.meta_model.ast_node import ASTNode
 
 
@@ -88,32 +90,25 @@ class ASTElifClause(ASTNode):
         """
         return self.block
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        if self.get_condition() is ast:
-            return self
-        if self.get_condition().get_parent(ast) is not None:
-            return self.get_condition().get_parent(ast)
-        if self.get_block() is ast:
-            return self
-        if self.get_block().get_parent(ast) is not None:
-            return self.get_block().get_parent(ast)
-        return None
+        children = []
+        if self.get_condition():
+            children.append(self.get_condition())
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+        if self.get_block():
+            children.append(self.get_block())
+
+        return children
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTElifClause):
             return False
+
         return self.get_condition().equals(other.get_condition()) and self.get_block().equals(other.get_block())

--- a/pynestml/meta_model/ast_else_clause.py
+++ b/pynestml/meta_model/ast_else_clause.py
@@ -18,6 +18,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import List
+
 from pynestml.meta_model.ast_node import ASTNode
 
 
@@ -71,28 +74,21 @@ class ASTElseClause(ASTNode):
         """
         return self.block
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        if self.get_block() is ast:
-            return self
-        if self.get_block().get_parent(ast) is not None:
-            return self.get_block().get_parent(ast)
-        return None
+        if self.get_block():
+            return [self.get_block()]
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+        return []
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTElseClause):
             return False
+
         return self.get_block().equals(other.get_block())

--- a/pynestml/meta_model/ast_equations_block.py
+++ b/pynestml/meta_model/ast_equations_block.py
@@ -19,12 +19,12 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Any, Sequence
-from pynestml.meta_model.ast_kernel import ASTKernel
+from typing import Any, List, Sequence
 
+from pynestml.meta_model.ast_inline_expression import ASTInlineExpression
+from pynestml.meta_model.ast_kernel import ASTKernel
 from pynestml.meta_model.ast_node import ASTNode
 from pynestml.meta_model.ast_ode_equation import ASTOdeEquation
-from pynestml.meta_model.ast_inline_expression import ASTInlineExpression
 
 
 class ASTEquationsBlock(ASTNode):
@@ -80,21 +80,6 @@ class ASTEquationsBlock(ASTNode):
         """
         return self.declarations
 
-    def get_parent(self, ast):
-        """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        for decl in self.get_declarations():
-            if decl is ast:
-                return self
-            if decl.get_parent(ast) is not None:
-                return decl.get_parent(ast)
-        return None
-
     def get_ode_equations(self) -> Sequence[ASTOdeEquation]:
         """
         Returns a list of all ode equations in this block.
@@ -135,11 +120,16 @@ class ASTEquationsBlock(ASTNode):
         del self.declarations
         self.declarations = list()
 
-    def equals(self, other: Any) -> bool:
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        The equals method.
-        :param other: a different object.
-        :return: True if equal, otherwise False.
+        return self.get_declarations()
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTEquationsBlock):
             return False

--- a/pynestml/meta_model/ast_expression.py
+++ b/pynestml/meta_model/ast_expression.py
@@ -325,7 +325,7 @@ class ASTExpression(ASTExpressionNode):
             return [self.get_expression()]
 
         if self.is_unary_operator():
-            return [self.get_unary_operator()]
+            return [self.get_unary_operator(), self.get_rhs()]
 
         if self.is_compound_expression():
             children = []

--- a/pynestml/meta_model/ast_expression.py
+++ b/pynestml/meta_model/ast_expression.py
@@ -18,14 +18,17 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
 from __future__ import annotations
-from typing import Union
+
+from typing import List, Union
 
 from pynestml.meta_model.ast_expression_node import ASTExpressionNode
 from pynestml.meta_model.ast_logical_operator import ASTLogicalOperator
 from pynestml.meta_model.ast_arithmetic_operator import ASTArithmeticOperator
 from pynestml.meta_model.ast_bit_operator import ASTBitOperator
 from pynestml.meta_model.ast_comparison_operator import ASTComparisonOperator
+from pynestml.meta_model.ast_node import ASTNode
 from pynestml.meta_model.ast_unary_operator import ASTUnaryOperator
 
 
@@ -313,59 +316,48 @@ class ASTExpression(ASTExpressionNode):
             ret.extend(self.get_if_not().get_function_calls())
         return ret
 
-    def get_parent(self, ast=None):
-        """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
         if self.is_expression():
-            if self.get_expression() is ast:
-                return self
-            if self.get_expression().get_parent(ast) is not None:
-                return self.get_expression().get_parent(ast)
-        if self.is_unary_operator():
-            if self.get_unary_operator() is ast:
-                return self
-            if self.get_unary_operator().get_parent(ast) is not None:
-                return self.get_unary_operator().get_parent(ast)
-        if self.is_compound_expression():
-            if self.get_lhs() is ast:
-                return self
-            if self.get_lhs().get_parent(ast) is not None:
-                return self.get_lhs().get_parent(ast)
-            if self.get_binary_operator() is ast:
-                return self
-            if self.get_binary_operator().get_parent(ast) is not None:
-                return self.get_binary_operator().get_parent(ast)
-            if self.get_rhs() is ast:
-                return self
-            if self.get_rhs().get_parent(ast) is not None:
-                return self.get_rhs().get_parent(ast)
-        if self.is_ternary_operator():
-            if self.get_condition() is ast:
-                return self
-            if self.get_condition().get_parent(ast) is not None:
-                return self.get_condition().get_parent(ast)
-            if self.get_if_true() is ast:
-                return self
-            if self.get_if_true().get_parent(ast) is not None:
-                return self.get_if_true().get_parent(ast)
-            if self.get_if_not() is ast:
-                return self
-            if self.get_if_not().get_parent(ast) is not None:
-                return self.get_if_not().get_parent(ast)
-        return None
+            return [self.get_expression()]
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+        if self.is_unary_operator():
+            return [self.get_unary_operator()]
+
+        if self.is_compound_expression():
+            children = []
+            if self.get_lhs():
+                children.append(self.get_lhs())
+
+            if self.get_binary_operator():
+                children.append(self.get_binary_operator())
+
+            if self.get_rhs():
+                children.append(self.get_rhs())
+
+            return children
+
+        if self.is_ternary_operator():
+            children = []
+            if self.get_condition():
+                children.append(self.get_condition())
+
+            if self.get_if_true():
+                children.append(self.get_if_true())
+
+            if self.get_if_not():
+                children.append(self.get_if_not())
+
+            return children
+
+        return []
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTExpression):
             return False

--- a/pynestml/meta_model/ast_expression_node.py
+++ b/pynestml/meta_model/ast_expression_node.py
@@ -18,6 +18,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import List
+
 from abc import ABCMeta
 from copy import copy
 
@@ -47,8 +50,15 @@ class ASTExpressionNode(ASTNode):
     def type(self, _value):
         self.__type = _value
 
-    def get_parent(self, ast):
-        pass
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
+        """
+        assert False
 
-    def equals(self, other):
-        pass
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
+        """
+        assert False

--- a/pynestml/meta_model/ast_for_stmt.py
+++ b/pynestml/meta_model/ast_for_stmt.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pynestml.meta_model.ast_node import ASTNode
 
 
@@ -137,35 +139,26 @@ class ASTForStmt(ASTNode):
         """
         return self.block
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        if self.get_start_from() is ast:
-            return self
-        if self.get_start_from().get_parent(ast) is not None:
-            return self.get_start_from().get_parent(ast)
-        if self.get_end_at() is ast:
-            return self
-        if self.get_end_at().get_parent(ast) is not None:
-            return self.get_end_at().get_parent(ast)
-        if self.get_block() is ast:
-            return self
-        if self.get_block().get_parent(ast) is not None:
-            return self.get_block().get_parent(ast)
-        return None
+        children = []
+        if self.get_start_from():
+            children.append(self.get_start_from())
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+        if self.get_end_at():
+            children.append(self.get_end_at())
+
+        if self.get_block():
+            children.append(self.get_block())
+
+        return children
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTForStmt):
             return False

--- a/pynestml/meta_model/ast_function.py
+++ b/pynestml/meta_model/ast_function.py
@@ -164,52 +164,46 @@ class ASTFunction(ASTNode):
         """
         self.type_symbol = type_symbol
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        for param in self.get_parameters():
-            if param is ast:
-                return self
-            if param.get_parent(ast) is not None:
-                return param.get_parent(ast)
-        if self.has_return_type():
-            if self.get_return_type() is ast:
-                return self
-            if self.get_return_type().get_parent(ast) is not None:
-                return self.get_return_type().get_parent(ast)
-        if self.get_block() is ast:
-            return self
-        if self.get_block().get_parent(ast) is not None:
-            return self.get_block().get_parent(ast)
-        return None
+        children = []
+        children.extend(self.get_parameters())
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+        if self.has_return_type():
+            children.append(self.get_return_type())
+
+        if self.get_block():
+            children.append(self.get_block())
+
+        return children
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTFunction):
             return False
+
         if self.get_name() != other.get_name():
             return False
+
         if len(self.get_parameters()) != len(other.get_parameters()):
             return False
+
         my_parameters = self.get_parameters()
         your_parameters = other.get_parameters()
         for i in range(0, len(my_parameters)):
             if not my_parameters[i].equals(your_parameters[i]):
                 return False
+
         if self.has_return_type() + other.has_return_type() == 1:
             return False
+
         if (self.has_return_type() and other.has_return_type()
                 and not self.get_return_type().equals(other.get_return_type())):
             return False
+
         return self.get_block().equals(other.get_block())

--- a/pynestml/meta_model/ast_function_call.py
+++ b/pynestml/meta_model/ast_function_call.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pynestml.meta_model.ast_node import ASTNode
 
 
@@ -97,28 +99,16 @@ class ASTFunctionCall(ASTNode):
         """
         return self.args
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        for param in self.get_args():
-            if param is ast:
-                return self
-            if param.get_parent(ast) is not None:
-                return param.get_parent(ast)
-        return None
+        return self.get_args()
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTFunctionCall):
             return False

--- a/pynestml/meta_model/ast_if_clause.py
+++ b/pynestml/meta_model/ast_if_clause.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pynestml.meta_model.ast_node import ASTNode
 
 
@@ -88,31 +90,24 @@ class ASTIfClause(ASTNode):
         """
         return self.block
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: ASTNode
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: Optional[ASTNode]
-        """
-        if self.get_condition() is ast:
-            return self
-        if self.get_condition().get_parent(ast) is not None:
-            return self.get_condition().get_parent(ast)
-        if self.get_block() is ast:
-            return self
-        if self.get_block().get_parent(ast) is not None:
-            return self.get_block().get_parent(ast)
-        return None
+        children = []
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equals, otherwise False.
-        :rtype: bool
+        if self.get_condition():
+            children.append(self.get_condition())
+
+        if self.get_block():
+            children.append(self.get_block())
+
+        return children
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTIfClause):
             return False

--- a/pynestml/meta_model/ast_if_stmt.py
+++ b/pynestml/meta_model/ast_if_stmt.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pynestml.meta_model.ast_node import ASTNode
 
 
@@ -127,37 +129,25 @@ class ASTIfStmt(ASTNode):
         """
         return self.else_clause
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: ASTNode
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: Optional[ASTNode]
-        """
-        if self.get_if_clause() is ast:
-            return self
-        if self.get_if_clause().get_parent(ast) is not None:
-            return self.get_if_clause().get_parent(ast)
-        for elifClause in self.get_elif_clauses():
-            if elifClause is ast:
-                return self
-            if elifClause.get_parent(ast) is not None:
-                return elifClause.get_parent(ast)
-        if self.has_else_clause():
-            if self.get_else_clause() is ast:
-                return self
-            if self.get_else_clause().get_parent(ast) is not None:
-                return self.get_else_clause().get_parent(ast)
-        return None
+        children = []
+        if self.get_if_clause():
+            children.append(self.get_if_clause())
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equals, otherwise False.
-        :rtype: bool
+        children.extend(self.get_elif_clauses())
+
+        if self.has_else_clause():
+            children.append(self.get_else_clause())
+
+        return children
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTIfStmt):
             return False

--- a/pynestml/meta_model/ast_inline_expression.py
+++ b/pynestml/meta_model/ast_inline_expression.py
@@ -19,8 +19,10 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-from pynestml.meta_model.ast_node import ASTNode
+from typing import List
+
 from pynestml.meta_model.ast_namespace_decorator import ASTNamespaceDecorator
+from pynestml.meta_model.ast_node import ASTNode
 
 
 class ASTInlineExpression(ASTNode):
@@ -128,31 +130,23 @@ class ASTInlineExpression(ASTNode):
         """
         return self.expression
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        if self.get_data_type() is ast:
-            return self
-        if self.get_data_type().get_parent(ast) is not None:
-            return self.get_data_type().get_parent(ast)
-        if self.get_expression() is ast:
-            return self
-        if self.get_expression().get_parent(ast) is not None:
-            return self.get_expression().get_parent(ast)
-        return None
+        children = []
+        if self.get_data_type():
+            children.append(self.get_data_type())
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+        if self.get_expression():
+            children.append(self.get_expression())
+
+        return children
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTInlineExpression):
             return False

--- a/pynestml/meta_model/ast_input_block.py
+++ b/pynestml/meta_model/ast_input_block.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pynestml.meta_model.ast_input_port import ASTInputPort
 from pynestml.meta_model.ast_node import ASTNode
 
@@ -90,36 +92,27 @@ class ASTInputBlock(ASTNode):
         """
         return self.input_definitions
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        for port in self.get_input_ports():
-            if port is ast:
-                return self
-            if port.get_parent(ast) is not None:
-                return port.get_parent(ast)
-        return None
+        return self.get_input_ports()
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other:  object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTInputBlock):
             return False
+
         if len(self.get_input_ports()) != len(other.get_input_ports()):
             return False
+
         my_input_ports = self.get_input_ports()
         your_input_ports = other.get_input_ports()
         for i in range(0, len(my_input_ports)):
             if not my_input_ports[i].equals(your_input_ports[i]):
                 return False
+
         return True

--- a/pynestml/meta_model/ast_input_port.py
+++ b/pynestml/meta_model/ast_input_port.py
@@ -120,7 +120,7 @@ class ASTInputPort(ASTNode):
         Returns whether a size parameter has been defined.
         :return: True if size has been used, otherwise False.
         """
-        return self.size_parameter
+        return self.size_parameter is not None
 
     def get_size_parameter(self) -> Optional[Union[ASTSimpleExpression, ASTExpression]]:
         r"""

--- a/pynestml/meta_model/ast_input_qualifier.py
+++ b/pynestml/meta_model/ast_input_qualifier.py
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
 
 from pynestml.meta_model.ast_node import ASTNode
 
@@ -72,24 +73,18 @@ class ASTInputQualifier(ASTNode):
 
         return dup
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: ASTNode
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: Optional[ASTNode]
-        """
-        return None
+        return []
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTInputQualifier):
             return False
+
         return self.is_excitatory == other.is_excitatory and self.is_inhibitory == other.is_inhibitory

--- a/pynestml/meta_model/ast_kernel.py
+++ b/pynestml/meta_model/ast_kernel.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pynestml.meta_model.ast_node import ASTNode
 
 
@@ -93,37 +95,19 @@ class ASTKernel(ASTNode):
         """
         return self.expressions
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: ASTNode
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: ASTNode or None
-        """
-        for var in self.get_variables():
-            if var is ast:
-                return self
+        children = []
+        children.extend(self.get_variables())
+        children.extend(self.get_expressions())
+        return children
 
-            if var.get_parent(ast) is not None:
-                return var.get_parent(ast)
-
-        for expr in self.get_expressions():
-            if expr is ast:
-                return self
-
-            if expr.get_parent(ast) is not None:
-                return expr.get_parent(ast)
-
-        return None
-
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTKernel):
             return False

--- a/pynestml/meta_model/ast_logical_operator.py
+++ b/pynestml/meta_model/ast_logical_operator.py
@@ -18,6 +18,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import List
+
 from pynestml.meta_model.ast_node import ASTNode
 
 
@@ -67,24 +70,18 @@ class ASTLogicalOperator(ASTNode):
 
         return dup
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        return None
+        return []
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTLogicalOperator):
             return False
+
         return self.is_logical_and == other.is_logical_and and self.is_logical_or == other.is_logical_or

--- a/pynestml/meta_model/ast_model.py
+++ b/pynestml/meta_model/ast_model.py
@@ -475,7 +475,7 @@ class ASTModel(ASTNode):
         symtable_vistor = ASTSymbolTableVisitor()
         symtable_vistor.block_type_stack.push(BlockType.INTERNALS)
         declaration.accept(symtable_vistor)
-        self.get_internals_blocks().accept(ASTParentVisitor())
+        self.get_internals_blocks()[0].accept(ASTParentVisitor())
         symtable_vistor.block_type_stack.pop()
 
     def add_to_state_block(self, declaration: ASTDeclaration) -> None:
@@ -494,7 +494,7 @@ class ASTModel(ASTNode):
         symtable_vistor = ASTSymbolTableVisitor()
         symtable_vistor.block_type_stack.push(BlockType.STATE)
         declaration.accept(symtable_vistor)
-        self.get_state_blocks().accept(ASTParentVisitor())
+        self.get_state_blocks()[0].accept(ASTParentVisitor())
         symtable_vistor.block_type_stack.pop()
         from pynestml.symbols.symbol import SymbolKind
         assert declaration.get_variables()[0].get_scope().resolve_to_symbol(

--- a/pynestml/meta_model/ast_model.py
+++ b/pynestml/meta_model/ast_model.py
@@ -471,9 +471,11 @@ class ASTModel(ASTNode):
         self.get_internals_blocks()[0].get_declarations().insert(index, declaration)
         declaration.update_scope(self.get_internals_blocks()[0].get_scope())
         from pynestml.visitors.ast_symbol_table_visitor import ASTSymbolTableVisitor
+        from pynestml.visitors.ast_parent_visitor import ASTParentVisitor
         symtable_vistor = ASTSymbolTableVisitor()
         symtable_vistor.block_type_stack.push(BlockType.INTERNALS)
         declaration.accept(symtable_vistor)
+        self.get_internals_blocks().accept(ASTParentVisitor())
         symtable_vistor.block_type_stack.pop()
 
     def add_to_state_block(self, declaration: ASTDeclaration) -> None:
@@ -488,10 +490,11 @@ class ASTModel(ASTNode):
         self.get_state_blocks()[0].get_declarations().append(declaration)
         declaration.update_scope(self.get_state_blocks()[0].get_scope())
         from pynestml.visitors.ast_symbol_table_visitor import ASTSymbolTableVisitor
-
+        from pynestml.visitors.ast_parent_visitor import ASTParentVisitor
         symtable_vistor = ASTSymbolTableVisitor()
         symtable_vistor.block_type_stack.push(BlockType.STATE)
         declaration.accept(symtable_vistor)
+        self.get_state_blocks().accept(ASTParentVisitor())
         symtable_vistor.block_type_stack.pop()
         from pynestml.symbols.symbol import SymbolKind
         assert declaration.get_variables()[0].get_scope().resolve_to_symbol(
@@ -513,16 +516,6 @@ class ASTModel(ASTNode):
             ret += prefix + comment + '\n'
 
         return ret
-
-    def equals(self, other: ASTNode) -> bool:
-        """
-        The equals method.
-        :param other: a different object.
-        :return: True if equal, otherwise False.
-        """
-        if not isinstance(other, ASTModel):
-            return False
-        return self.get_name() == other.get_name() and self.get_body().equals(other.get_body())
 
     def get_initial_value(self, variable_name: str):
         assert type(variable_name) is str
@@ -652,19 +645,6 @@ class ASTModel(ASTNode):
 
         return False
 
-    def get_parent(self, ast) -> Optional[ASTNode]:
-        """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        """
-        if self.get_body() is ast:
-            return self
-        if self.get_body().get_parent(ast) is not None:
-            return self.get_body().get_parent(ast)
-        return None
-
     def set_default_delay(self, var, expr, dtype):
         self._default_delay_variable = var
         self._default_delay_expression = expr
@@ -712,3 +692,18 @@ class ASTModel(ASTNode):
                                                        or symbol.block_type == BlockType.INPUT_BUFFER_CURRENT):
                 ret.append(symbol)
         return ret
+
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
+        """
+        return [self.get_body()]
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
+        """
+        if not isinstance(other, ASTModel):
+            return False
+        return self.get_name() == other.get_name() and self.get_body().equals(other.get_body())

--- a/pynestml/meta_model/ast_model_body.py
+++ b/pynestml/meta_model/ast_model_body.py
@@ -225,21 +225,6 @@ class ASTModelBody(ASTNode):
 
         return ret
 
-    def get_parent(self, ast=None):
-        """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        for stmt in self.get_body_elements():
-            if stmt is ast:
-                return self
-            if stmt.get_parent(ast) is not None:
-                return stmt.get_parent(ast)
-        return None
-
     def get_spike_input_ports(self) -> List[ASTInputPort]:
         """
         Returns a list of all spike input ports defined in the model.
@@ -253,13 +238,16 @@ class ASTModelBody(ASTNode):
                     ret.append(port)
         return ret
 
-    def equals(self, other):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+        return self.get_body_elements()
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTModelBody):
             return False

--- a/pynestml/meta_model/ast_namespace_decorator.py
+++ b/pynestml/meta_model/ast_namespace_decorator.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from typing import List, Optional
 
 from pynestml.meta_model.ast_node import ASTNode
 
@@ -66,23 +66,16 @@ class ASTNamespaceDecorator(ASTNode):
         """
         return self.name
 
-    def get_parent(self, ast: ASTNode) -> Optional[ASTNode]:
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :return: AST if this or one of the child nodes contains the handed over element.
-        """
-        if self.get_name() is ast:
-            return self
-        elif self.get_namespace() is ast:
-            return self
-        return None
+        return [self.get_name(), self.get_namespace()]
 
     def equals(self, other: ASTNode) -> bool:
-        """
-        The equals operation.
-        :param other: a different object.
-        :return: True if equal, otherwise False.
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTNamespaceDecorator):
             return False

--- a/pynestml/meta_model/ast_nestml_compilation_unit.py
+++ b/pynestml/meta_model/ast_nestml_compilation_unit.py
@@ -102,26 +102,16 @@ class ASTNestMLCompilationUnit(ASTNode):
 
         return None
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        for model in self.get_model_list():
-            if model is ast:
-                return self
-            if model.get_parent(ast) is not None:
-                return model.get_parent(ast)
-        return None
+        return self.get_model_list()
 
-    def equals(self, other) -> bool:
-        """
-        The equals method.
-        :param other: a different object
-        :return: True if equal, otherwise False.
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTNestMLCompilationUnit):
             return False

--- a/pynestml/meta_model/ast_node.py
+++ b/pynestml/meta_model/ast_node.py
@@ -19,12 +19,13 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from typing import Optional, List
 
 from abc import ABCMeta, abstractmethod
 
 from pynestml.symbol_table.scope import Scope
-
 from pynestml.utils.ast_source_location import ASTSourceLocation
 
 
@@ -74,25 +75,28 @@ class ASTNode(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def equals(self, other):
+    def equals(self, other: ASTNode) -> bool:
         """
         The equals operation.
-        :param other: a different object.
-        :type other: object
+        :param other: a different AST node.
         :return: True if equal, otherwise False.
-        :rtype: bool
         """
         pass
 
-    # todo: we can do this with a visitor instead of hard coding grammar traversals all over the place
-    @abstractmethod
-    def get_parent(self, ast):
+    def get_parent(self) -> Optional[ASTNode]:
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
+        Get the parent of this node.
+        :return: The parent node
+        """
+        assert "parent_" in dir(self), "Need to ensure ASTParentVisitor has been run on the AST"
+
+        return self.parent_
+
+    @abstractmethod
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
         pass
 

--- a/pynestml/meta_model/ast_node.py
+++ b/pynestml/meta_model/ast_node.py
@@ -88,7 +88,10 @@ class ASTNode(metaclass=ABCMeta):
         Get the parent of this node.
         :return: The parent node
         """
-        assert "parent_" in dir(self), "Need to ensure ASTParentVisitor has been run on the AST"
+        assert "parent_" in dir(self), "No parent known, please ensure ASTParentVisitor has been run on the AST"
+
+        if self.parent_:
+            assert self in self.parent_.get_children(), "Doubly linked tree is inconsistent: please ensure ASTParentVisitor has been run on the AST"
 
         return self.parent_
 

--- a/pynestml/meta_model/ast_node_factory.py
+++ b/pynestml/meta_model/ast_node_factory.py
@@ -151,9 +151,9 @@ class ASTNodeFactory:
                                is_inline_expression: bool=False,
                                variables=None,  # type: list
                                data_type=None,  # type: ASTDataType
-                               size_parameter=None,  # type: str
-                               expression=None,  # type: Union(ASTSimpleExpression,ASTExpression)
-                               invariant=None,  # type: Union(ASTSimpleExpression,ASTExpression)
+                               size_parameter=None,  # type: Optional[Union[ASTSimpleExpression, ASTExpression]]
+                               expression=None,  # type: Optional[Union[ASTSimpleExpression, ASTExpression]]
+                               invariant=None,  # type: Optional[Union[ASTSimpleExpression, ASTExpression]]
                                source_position=None,  # type: ASTSourceLocation
                                decorators=None,  # type: list
                                ) -> ASTDeclaration:

--- a/pynestml/meta_model/ast_ode_equation.py
+++ b/pynestml/meta_model/ast_ode_equation.py
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
 
 from pynestml.meta_model.ast_node import ASTNode
 from pynestml.meta_model.ast_expression import ASTExpression
@@ -107,31 +108,23 @@ class ASTOdeEquation(ASTNode):
         """
         return self.rhs
 
-    def get_parent(self, ast=None):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        if self.get_lhs() is ast:
-            return self
-        if self.get_lhs().get_parent(ast) is not None:
-            return self.get_lhs().get_parent(ast)
-        if self.get_rhs() is ast:
-            return self
-        if self.get_rhs().get_parent(ast) is not None:
-            return self.get_rhs().get_parent(ast)
-        return None
+        children = []
+        if self.get_lhs():
+            children.append(self.get_lhs())
 
-    def equals(self, other=None):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+        if self.get_rhs():
+            children.append(self.get_rhs())
+
+        return children
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTOdeEquation):
             return False

--- a/pynestml/meta_model/ast_on_condition_block.py
+++ b/pynestml/meta_model/ast_on_condition_block.py
@@ -87,7 +87,14 @@ class ASTOnConditionBlock(ASTNode):
         Returns the children of this node, if any.
         :return: List of children of this node.
         """
-        return [self.get_block()]
+        children = []
+        if self.cond_expr:
+            children.append(self.cond_expr)
+
+        if self.get_block():
+            children.append(self.get_block())
+
+        return children
 
     def equals(self, other: ASTNode) -> bool:
         r"""

--- a/pynestml/meta_model/ast_on_condition_block.py
+++ b/pynestml/meta_model/ast_on_condition_block.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, Mapping
+from typing import Any, List, Optional, Mapping
 
 from pynestml.meta_model.ast_block import ASTBlock
 from pynestml.meta_model.ast_expression import ASTExpression
@@ -82,25 +82,16 @@ class ASTOnConditionBlock(ASTNode):
         """
         return self.cond_expr
 
-    def get_parent(self, ast: ASTNode) -> Optional[ASTNode]:
+    def get_children(self) -> List[ASTNode]:
         r"""
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :return: AST if this or one of the child nodes contains the handed over element.
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        if self.get_block() is ast:
-            return self
+        return [self.get_block()]
 
-        if self.get_block().get_parent(ast) is not None:
-            return self.get_block().get_parent(ast)
-
-        return None
-
-    def equals(self, other: Any) -> bool:
+    def equals(self, other: ASTNode) -> bool:
         r"""
-        The equals method.
-        :param other: a different object.
-        :return: True if equal, otherwise False.
+        The equality method.
         """
         if not isinstance(other, ASTOnConditionBlock):
             return False

--- a/pynestml/meta_model/ast_on_receive_block.py
+++ b/pynestml/meta_model/ast_on_receive_block.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, Mapping
+from typing import Any, List, Optional, Mapping
 
 from pynestml.meta_model.ast_block import ASTBlock
 from pynestml.meta_model.ast_node import ASTNode
@@ -87,26 +87,18 @@ class ASTOnReceiveBlock(ASTNode):
         """
         return self.port_name
 
-    def get_parent(self, ast: ASTNode) -> Optional[ASTNode]:
+    def get_children(self) -> List[ASTNode]:
         r"""
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :return: AST if this or one of the child nodes contains the handed over element.
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        if self.get_block() is ast:
-            return self
+        return [self.get_block()]
 
-        if self.get_block().get_parent(ast) is not None:
-            return self.get_block().get_parent(ast)
-
-        return None
-
-    def equals(self, other: Any) -> bool:
+    def equals(self, other: ASTNode) -> bool:
         r"""
-        The equals method.
-        :param other: a different object.
-        :return: True if equal, otherwise False.
+        The equality method.
         """
         if not isinstance(other, ASTOnReceiveBlock):
             return False
+
         return self.get_block().equals(other.get_block()) and self.port_name == other.port_name

--- a/pynestml/meta_model/ast_output_block.py
+++ b/pynestml/meta_model/ast_output_block.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pynestml.meta_model.ast_node import ASTNode
 from pynestml.utils.port_signal_type import PortSignalType
 
@@ -82,23 +84,18 @@ class ASTOutputBlock(ASTNode):
         """
         return self.type is PortSignalType.CONTINUOUS
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        return None
+        return []
 
-    def equals(self, other) -> bool:
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equals, otherwise False.
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTOutputBlock):
             return False
+
         return self.is_spike() == other.is_spike() and self.is_continuous() == other.is_continuous()

--- a/pynestml/meta_model/ast_parameter.py
+++ b/pynestml/meta_model/ast_parameter.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pynestml.meta_model.ast_data_type import ASTDataType
 from pynestml.meta_model.ast_node import ASTNode
 
@@ -81,28 +83,18 @@ class ASTParameter(ASTNode):
         """
         return self.data_type
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        if self.get_data_type() is ast:
-            return self
-        if self.get_data_type().get_parent(ast) is not None:
-            return self.get_data_type().get_parent(ast)
-        return None
+        return [self.get_data_type()]
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTParameter):
             return False
+
         return self.get_name() == other.get_name() and self.get_data_type().equals(other.get_data_type())

--- a/pynestml/meta_model/ast_return_stmt.py
+++ b/pynestml/meta_model/ast_return_stmt.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pynestml.meta_model.ast_node import ASTNode
 
 
@@ -83,29 +85,21 @@ class ASTReturnStmt(ASTNode):
         """
         return self.expression
 
-    def get_parent(self, ast):
-        """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
         if self.has_expression():
-            if self.get_expression() is ast:
-                return self
-            if self.get_expression().get_parent(ast) is not None:
-                return self.get_expression().get_parent(ast)
-        return None
+            return [self.get_expression()]
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+        return []
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTReturnStmt):
             return False
+
         return self.get_expression().equals(other.get_expression())

--- a/pynestml/meta_model/ast_simple_expression.py
+++ b/pynestml/meta_model/ast_simple_expression.py
@@ -19,10 +19,11 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 from pynestml.meta_model.ast_expression_node import ASTExpressionNode
 from pynestml.meta_model.ast_function_call import ASTFunctionCall
+from pynestml.meta_model.ast_node import ASTNode
 from pynestml.meta_model.ast_variable import ASTVariable
 from pynestml.utils.cloning_helpers import clone_numeric_literal
 
@@ -272,31 +273,22 @@ class ASTSimpleExpression(ASTExpressionNode):
         """
         return self.string
 
-    def get_parent(self, ast):
-        """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
         if self.is_function_call():
-            if self.get_function_call() is ast:
-                return self
-            if self.get_function_call().get_parent(ast) is not None:
-                return self.get_function_call().get_parent(ast)
-        if self.variable is not None:
-            if self.variable is ast:
-                return self
-            if self.variable.get_parent(ast) is not None:
-                return self.variable.get_parent(ast)
-        return None
+            return [self.get_function_call()]
 
-    def set_variable(self, variable):
-        """
-        Updates the variable of this node.
-        :param variable: a single variable
-        :type variable: ASTVariable
+        if self.variable:
+            return [self.variable]
+
+        return []
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         assert (variable is None or isinstance(variable, ASTVariable)), \
             '(PyNestML.AST.SimpleExpression) No or wrong type of variable provided (%s)!' % type(variable)

--- a/pynestml/meta_model/ast_simple_expression.py
+++ b/pynestml/meta_model/ast_simple_expression.py
@@ -286,9 +286,11 @@ class ASTSimpleExpression(ASTExpressionNode):
 
         return []
 
-    def equals(self, other: ASTNode) -> bool:
-        r"""
-        The equality method.
+    def set_variable(self, variable):
+        """
+        Updates the variable of this node.
+        :param variable: a single variable
+        :type variable: ASTVariable
         """
         assert (variable is None or isinstance(variable, ASTVariable)), \
             '(PyNestML.AST.SimpleExpression) No or wrong type of variable provided (%s)!' % type(variable)
@@ -304,33 +306,39 @@ class ASTSimpleExpression(ASTExpressionNode):
             '(PyNestML.AST.SimpleExpression) No or wrong type of function call provided (%s)!' % type(function_call)
         self.function_call = function_call
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return:True if equal, otherwise False.
-        :rtype: bool
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTSimpleExpression):
             return False
+
         if self.is_function_call() + other.is_function_call() == 1:
             return False
+
         if self.is_function_call() and other.is_function_call() and not self.get_function_call().equals(
                 other.get_function_call()):
             return False
+
         if self.get_numeric_literal() != other.get_numeric_literal():
             return False
+
         if self.is_boolean_false != other.is_boolean_false or self.is_boolean_true != other.is_boolean_true:
             return False
+
         if self.is_variable() + other.is_variable() == 1:
             return False
+
         if self.is_variable() and other.is_variable() and not self.get_variable().equals(other.get_variable()):
             return False
+
         if self.is_inf_literal != other.is_inf_literal:
             return False
+
         if self.is_string() + other.is_string() == 1:
             return False
+
         if self.get_string() != other.get_string():
             return False
+
         return True

--- a/pynestml/meta_model/ast_small_stmt.py
+++ b/pynestml/meta_model/ast_small_stmt.py
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
 
 from pynestml.meta_model.ast_node import ASTNode
 
@@ -156,43 +157,28 @@ class ASTSmallStmt(ASTNode):
         """
         return self.return_stmt
 
-    def get_parent(self, ast):
-        """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
         if self.is_assignment():
-            if self.get_assignment() is ast:
-                return self
-            if self.get_assignment().get_parent(ast) is not None:
-                return self.get_assignment().get_parent(ast)
-        if self.is_function_call():
-            if self.get_function_call() is ast:
-                return self
-            if self.get_function_call().get_parent(ast) is not None:
-                return self.get_function_call().get_parent(ast)
-        if self.is_declaration():
-            if self.get_declaration() is ast:
-                return self
-            if self.get_declaration().get_parent(ast) is not None:
-                return self.get_declaration().get_parent(ast)
-        if self.is_return_stmt():
-            if self.get_return_stmt() is ast:
-                return self
-            if self.get_return_stmt().get_parent(ast) is not None:
-                return self.get_return_stmt().get_parent(ast)
-        return None
+            return [self.get_assignment()]
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object
-        :type other: object
-        :return: True if equals, otherwise False.
-        :rtype: bool
+        if self.is_function_call():
+            return [self.get_function_call()]
+
+        if self.is_declaration():
+            return [self.get_declaration()]
+
+        if self.is_return_stmt():
+            return [self.get_return_stmt()]
+
+        return []
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTSmallStmt):
             return False

--- a/pynestml/meta_model/ast_stmt.py
+++ b/pynestml/meta_model/ast_stmt.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from typing import List, Optional
 
 from pynestml.meta_model.ast_node import ASTNode
 
@@ -74,27 +74,29 @@ class ASTStmt(ASTNode):
 
         return dup
 
-    def get_parent(self, ast: ASTNode=None) -> Optional[ASTNode]:
-        """
-        Returns the parent node of a handed over AST object.
-        """
-        if self.small_stmt is ast:
-            return self
-        if self.small_stmt is not None and self.small_stmt.get_parent(ast) is not None:
-            return self.small_stmt.get_parent(ast)
-        if self.compound_stmt is ast:
-            return self
-        if self.compound_stmt is not None and self.compound_stmt.get_parent(ast) is not None:
-            return self.compound_stmt.get_parent(ast)
-        return None
-
     def is_small_stmt(self):
         return self.small_stmt is not None
 
     def is_compound_stmt(self):
         return self.compound_stmt is not None
 
-    def equals(self, other=None):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
+        """
+        if self.small_stmt:
+            return [self.small_stmt]
+
+        if self.compound_stmt:
+            return [self.compound_stmt]
+
+        return []
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
+        """
         if not isinstance(other, ASTStmt):
             return False
         if self.is_small_stmt() and other.is_small_stmt():

--- a/pynestml/meta_model/ast_unary_operator.py
+++ b/pynestml/meta_model/ast_unary_operator.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pynestml.meta_model.ast_node import ASTNode
 
 
@@ -73,23 +75,16 @@ class ASTUnaryOperator(ASTNode):
 
         return dup
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        return None
+        return []
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTUnaryOperator):
             return False

--- a/pynestml/meta_model/ast_unit_type.py
+++ b/pynestml/meta_model/ast_unit_type.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pynestml.meta_model.ast_node import ASTNode
 from pynestml.utils.cloning_helpers import clone_numeric_literal
 
@@ -177,44 +179,32 @@ class ASTUnitType(ASTNode):
     def set_type_symbol(self, type_symbol):
         self.type_symbol = type_symbol
 
-    def get_parent(self, ast):
-        """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
         if self.is_encapsulated:
-            if self.compound_unit is ast:
-                return self
-            if self.compound_unit.get_parent(ast) is not None:
-                return self.compound_unit.get_parent(ast)
+            return [self.compound_unit]
 
         if self.is_pow:
-            if self.base is ast:
-                return self
-            if self.base.get_parent(ast) is not None:
-                return self.base.get_parent(ast)
-        if self.is_arithmetic_expression():
-            if isinstance(self.get_lhs(), ASTUnitType):
-                if self.get_lhs() is ast:
-                    return self
-                if self.get_lhs().get_parent(ast) is not None:
-                    return self.get_lhs().get_parent(ast)
-            if self.get_rhs() is ast:
-                return self
-            if self.get_rhs().get_parent(ast) is not None:
-                return self.get_rhs().get_parent(ast)
-        return None
+            return [self.base]
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+        if self.is_arithmetic_expression():
+            children = []
+            if self.get_lhs() and isinstance(self.get_lhs(), ASTNode):
+                children.append(self.get_lhs())
+
+            if self.get_rhs() and isinstance(self.get_rhs(), ASTNode):
+                children.append(self.get_rhs())
+
+            return children
+
+        return []
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTUnitType):
             return False

--- a/pynestml/meta_model/ast_update_block.py
+++ b/pynestml/meta_model/ast_update_block.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pynestml.meta_model.ast_block import ASTBlock
 from pynestml.meta_model.ast_node import ASTNode
 
@@ -81,27 +83,16 @@ class ASTUpdateBlock(ASTNode):
         """
         return self.block
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        if self.get_block() is ast:
-            return self
-        if self.get_block().get_parent(ast) is not None:
-            return self.get_block().get_parent(ast)
-        return None
+        return [self.get_block()]
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equal, otherwise False.
-        :rtype: bool
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTUpdateBlock):
             return False

--- a/pynestml/meta_model/ast_variable.py
+++ b/pynestml/meta_model/ast_variable.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from copy import copy
 
@@ -184,14 +184,6 @@ class ASTVariable(ASTNode):
         assert (delay is not None), '(PyNestML.AST.Variable) No delay parameter provided'
         self.delay_parameter = delay
 
-    def get_parent(self, ast: ASTNode) -> Optional[ASTNode]:
-        """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :return: AST if this or one of the child nodes contains the handed over element.
-        """
-        return None
-
     def is_unit_variable(self) -> bool:
         r"""
         Provided on-the-fly information whether this variable represents a unit-variable, e.g., nS.
@@ -203,19 +195,28 @@ class ASTVariable(ASTNode):
             return True
         return False
 
-    def equals(self, other: Any) -> bool:
-        r"""
-        The equals method.
-        :param other: a different object.
-        :return: True if equals, otherwise False.
-        """
-        if not isinstance(other, ASTVariable):
-            return False
-        return self.get_name() == other.get_name() and self.get_differential_order() == other.get_differential_order()
-
     def is_delay_variable(self) -> bool:
         """
         Returns whether it is a delay variable or not
         :return: True if the variable has a delay parameter, False otherwise
         """
         return self.get_delay_parameter() is not None
+
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
+        """
+        if self.has_vector_parameter():
+            return [self.get_vector_parameter()]
+
+        return []
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
+        """
+        if not isinstance(other, ASTVariable):
+            return False
+
+        return self.get_name() == other.get_name() and self.get_differential_order() == other.get_differential_order()

--- a/pynestml/meta_model/ast_while_stmt.py
+++ b/pynestml/meta_model/ast_while_stmt.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 from pynestml.meta_model.ast_block import ASTBlock
 from pynestml.meta_model.ast_expression import ASTExpression
 from pynestml.meta_model.ast_node import ASTNode
@@ -90,31 +92,23 @@ class ASTWhileStmt(ASTNode):
         """
         return self.block
 
-    def get_parent(self, ast):
+    def get_children(self) -> List[ASTNode]:
+        r"""
+        Returns the children of this node, if any.
+        :return: List of children of this node.
         """
-        Indicates whether a this node contains the handed over node.
-        :param ast: an arbitrary meta_model node.
-        :type ast: AST_
-        :return: AST if this or one of the child nodes contains the handed over element.
-        :rtype: AST_ or None
-        """
-        if self.get_condition() is ast:
-            return self
-        if self.get_condition().get_parent(ast) is not None:
-            return self.get_condition().get_parent(ast)
-        if self.get_block() is ast:
-            return self
-        if self.get_block().get_parent(ast) is not None:
-            return self.get_block().get_parent(ast)
-        return None
+        children = []
+        if self.get_condition():
+            children.append(self.get_condition())
 
-    def equals(self, other):
-        """
-        The equals method.
-        :param other: a different object.
-        :type other: object
-        :return: True if equals, otherwise False.
-        :rtype: bool
+        if self.get_block():
+            children.append(self.get_block())
+
+        return children
+
+    def equals(self, other: ASTNode) -> bool:
+        r"""
+        The equality method.
         """
         if not isinstance(other, ASTWhileStmt):
             return False

--- a/pynestml/transformers/synapse_post_neuron_transformer.py
+++ b/pynestml/transformers/synapse_post_neuron_transformer.py
@@ -226,10 +226,12 @@ class SynapsePostNeuronTransformer(Transformer):
         new_neuron = neuron.clone()
         new_synapse = synapse.clone()
 
-        new_neuron.accept(ASTSymbolTableVisitor())
+        new_neuron.parent_ = None    # set root element
         new_neuron.accept(ASTParentVisitor())
-        new_synapse.accept(ASTSymbolTableVisitor())
+        new_synapse.parent_ = None    # set root element
         new_synapse.accept(ASTParentVisitor())
+        new_neuron.accept(ASTSymbolTableVisitor())
+        new_synapse.accept(ASTSymbolTableVisitor())
 
         assert len(new_neuron.get_equations_blocks()) <= 1, "Only one equations block per neuron supported for now."
         assert len(new_synapse.get_equations_blocks()) <= 1, "Only one equations block per synapse supported for now."
@@ -544,12 +546,12 @@ class SynapsePostNeuronTransformer(Transformer):
         #    add modified versions of neuron and synapse to list
         #
 
+        new_neuron.accept(ASTParentVisitor())
+        new_synapse.accept(ASTParentVisitor())
         ast_symbol_table_visitor = ASTSymbolTableVisitor()
         ast_symbol_table_visitor.after_ast_rewrite_ = True
         new_neuron.accept(ast_symbol_table_visitor)
         new_synapse.accept(ast_symbol_table_visitor)
-        new_neuron.accept(ASTParentVisitor())
-        new_synapse.accept(ASTParentVisitor())
 
         ASTUtils.update_blocktype_for_common_parameters(new_synapse)
 

--- a/pynestml/transformers/synapse_post_neuron_transformer.py
+++ b/pynestml/transformers/synapse_post_neuron_transformer.py
@@ -38,6 +38,7 @@ from pynestml.utils.ast_utils import ASTUtils
 from pynestml.utils.logger import Logger
 from pynestml.utils.logger import LoggingLevel
 from pynestml.utils.string_utils import removesuffix
+from pynestml.visitors.ast_parent_visitor import ASTParentVisitor
 from pynestml.visitors.ast_symbol_table_visitor import ASTSymbolTableVisitor
 from pynestml.visitors.ast_higher_order_visitor import ASTHigherOrderVisitor
 from pynestml.visitors.ast_visitor import ASTVisitor
@@ -172,7 +173,7 @@ class SynapsePostNeuronTransformer(Transformer):
                         found_parent_assignment = False
                         node_ = node
                         while not found_parent_assignment:
-                            node_ = self.parent_node.get_parent(node_)
+                            node_ = node_.get_parent()
                             # XXX TODO also needs to accept normal ASTExpression, ASTAssignment?
                             if isinstance(node_, ASTInlineExpression):
                                 found_parent_assignment = True
@@ -226,7 +227,9 @@ class SynapsePostNeuronTransformer(Transformer):
         new_synapse = synapse.clone()
 
         new_neuron.accept(ASTSymbolTableVisitor())
+        new_neuron.accept(ASTParentVisitor())
         new_synapse.accept(ASTSymbolTableVisitor())
+        new_synapse.accept(ASTParentVisitor())
 
         assert len(new_neuron.get_equations_blocks()) <= 1, "Only one equations block per neuron supported for now."
         assert len(new_synapse.get_equations_blocks()) <= 1, "Only one equations block per synapse supported for now."
@@ -545,6 +548,8 @@ class SynapsePostNeuronTransformer(Transformer):
         ast_symbol_table_visitor.after_ast_rewrite_ = True
         new_neuron.accept(ast_symbol_table_visitor)
         new_synapse.accept(ast_symbol_table_visitor)
+        new_neuron.accept(ASTParentVisitor())
+        new_synapse.accept(ASTParentVisitor())
 
         ASTUtils.update_blocktype_for_common_parameters(new_synapse)
 

--- a/pynestml/transformers/synapse_remove_post_port.py
+++ b/pynestml/transformers/synapse_remove_post_port.py
@@ -152,10 +152,13 @@ class SynapseRemovePostPortTransformer(Transformer):
         #    add modified versions of neuron and synapse to list
         #
 
+        new_neuron.parent_ = None    # set root element
+        new_neuron.accept(ASTParentVisitor())
+        new_synapse.parent_ = None    # set root element
+        new_synapse.accept(ASTParentVisitor())
+
         new_neuron.accept(ASTSymbolTableVisitor())
         new_synapse.accept(ASTSymbolTableVisitor())
-        new_neuron.accept(ASTParentVisitor())
-        new_synapse.accept(ASTParentVisitor())
 
         ASTUtils.update_blocktype_for_common_parameters(new_synapse)
 

--- a/pynestml/transformers/synapse_remove_post_port.py
+++ b/pynestml/transformers/synapse_remove_post_port.py
@@ -28,6 +28,7 @@ from pynestml.meta_model.ast_node import ASTNode
 from pynestml.utils.logger import Logger, LoggingLevel
 from pynestml.transformers.transformer import Transformer
 from pynestml.utils.ast_utils import ASTUtils
+from pynestml.visitors.ast_parent_visitor import ASTParentVisitor
 from pynestml.visitors.ast_symbol_table_visitor import ASTSymbolTableVisitor
 from pynestml.frontend.frontend_configuration import FrontendConfiguration
 
@@ -153,6 +154,8 @@ class SynapseRemovePostPortTransformer(Transformer):
 
         new_neuron.accept(ASTSymbolTableVisitor())
         new_synapse.accept(ASTSymbolTableVisitor())
+        new_neuron.accept(ASTParentVisitor())
+        new_synapse.accept(ASTParentVisitor())
 
         ASTUtils.update_blocktype_for_common_parameters(new_synapse)
 

--- a/pynestml/utils/ast_utils.py
+++ b/pynestml/utils/ast_utils.py
@@ -418,6 +418,10 @@ class ASTUtils:
                                                                       ASTSourceLocation.get_added_source_position())
             internal.update_scope(model.get_scope())
             model.get_body().get_body_elements().append(internal)
+
+        from pynestml.visitors.ast_parent_visitor import ASTParentVisitor
+        model.accept(ASTParentVisitor())
+
         return model
 
     @classmethod
@@ -433,6 +437,10 @@ class ASTUtils:
             state = ASTNodeFactory.create_ast_block_with_variables(True, False, False, list(),
                                                                    ASTSourceLocation.get_added_source_position())
             model.get_body().get_body_elements().append(state)
+
+        from pynestml.visitors.ast_parent_visitor import ASTParentVisitor
+        model.accept(ASTParentVisitor())
+
         return model
 
     @classmethod
@@ -637,6 +645,8 @@ class ASTUtils:
                                               source_position=var.get_source_position())
             if alternate_name:
                 ast_ext_var.set_alternate_name(alternate_name)
+
+            ast_ext_var.parent_ = _expr
 
             ast_ext_var.update_alt_scope(new_scope)
             from pynestml.visitors.ast_symbol_table_visitor import ASTSymbolTableVisitor

--- a/pynestml/utils/ast_utils.py
+++ b/pynestml/utils/ast_utils.py
@@ -644,18 +644,18 @@ class ASTUtils:
 
             if isinstance(_expr, ASTSimpleExpression) and _expr.is_variable():
                 Logger.log_message(None, -1, "ASTSimpleExpression replacement made (var = " + str(
-                    ast_ext_var.get_name()) + ") in expression: " + str(node.get_parent(_expr)), None, LoggingLevel.INFO)
+                    ast_ext_var.get_name()) + ") in expression: " + str(_expr.get_parent()), None, LoggingLevel.INFO)
                 _expr.set_variable(ast_ext_var)
                 return
 
             if isinstance(_expr, ASTVariable):
-                if isinstance(node.get_parent(_expr), ASTAssignment):
-                    node.get_parent(_expr).lhs = ast_ext_var
+                if isinstance(_expr.get_parent(), ASTAssignment):
+                    _expr.get_parent().lhs = ast_ext_var
                     Logger.log_message(None, -1, "ASTVariable replacement made in expression: "
-                                       + str(node.get_parent(_expr)), None, LoggingLevel.INFO)
-                elif isinstance(node.get_parent(_expr), ASTSimpleExpression) and node.get_parent(_expr).is_variable():
-                    node.get_parent(_expr).set_variable(ast_ext_var)
-                elif isinstance(node.get_parent(_expr), ASTDeclaration):
+                                       + str(_expr.get_parent()), None, LoggingLevel.INFO)
+                elif isinstance(_expr.get_parent(), ASTSimpleExpression) and _expr.get_parent().is_variable():
+                    _expr.get_parent().set_variable(ast_ext_var)
+                elif isinstance(_expr.get_parent(), ASTDeclaration):
                     # variable could occur on the left-hand side; ignore. Only replace if it occurs on the right-hand side.
                     pass
                 else:
@@ -664,12 +664,14 @@ class ASTUtils:
                     raise Exception()
                 return
 
-            p = node.get_parent(var)
+            p = var.get_parent()
             Logger.log_message(None, -1, "Error: unhandled use of variable "
                                + var_name + " in expression " + str(p), None, LoggingLevel.INFO)
             raise Exception()
 
         node.accept(ASTHigherOrderVisitor(lambda x: replace_var(x)))
+        from pynestml.visitors.ast_parent_visitor import ASTParentVisitor
+        node.accept(ASTParentVisitor())
 
     @classmethod
     def add_suffix_to_decl_lhs(cls, decl, suffix: str):
@@ -742,7 +744,7 @@ class ASTUtils:
                         found_parent_assignment = False
                         node_ = node
                         while not found_parent_assignment:
-                            node_ = self.parent_node.get_parent(node_)
+                            node_ = node_.get_parent()
                             # XXX TODO also needs to accept normal ASTExpression, ASTAssignment?
                             if isinstance(node_, ASTInlineExpression):
                                 found_parent_assignment = True
@@ -789,6 +791,9 @@ class ASTUtils:
                 ast_symbol_table_visitor.block_type_stack.push(block_type)
                 decl.accept(ast_symbol_table_visitor)
                 ast_symbol_table_visitor.block_type_stack.pop()
+
+        from pynestml.visitors.ast_parent_visitor import ASTParentVisitor
+        to_block.accept(ASTParentVisitor())
 
         return decls
 
@@ -1008,11 +1013,16 @@ class ASTUtils:
         if vector_variable is not None:
             ast_declaration.set_size_parameter(vector_variable.get_vector_parameter())
         neuron.add_to_internals_block(ast_declaration)
+
+        from pynestml.visitors.ast_parent_visitor import ASTParentVisitor
+        neuron.accept(ASTParentVisitor())
+
         ast_declaration.update_scope(neuron.get_internals_blocks()[0].get_scope())
         symtable_visitor = ASTSymbolTableVisitor()
         symtable_visitor.block_type_stack.push(BlockType.INTERNALS)
         ast_declaration.accept(symtable_visitor)
         symtable_visitor.block_type_stack.pop()
+
         return neuron
 
     @classmethod
@@ -1049,6 +1059,9 @@ class ASTUtils:
         if vector_variable is not None:
             ast_declaration.set_size_parameter(vector_variable.get_vector_parameter())
         neuron.add_to_state_block(ast_declaration)
+
+        from pynestml.visitors.ast_parent_visitor import ASTParentVisitor
+        neuron.accept(ASTParentVisitor())
 
         symtable_visitor = ASTSymbolTableVisitor()
         symtable_visitor.block_type_stack.push(BlockType.STATE)

--- a/pynestml/utils/chan_info_enricher.py
+++ b/pynestml/utils/chan_info_enricher.py
@@ -19,11 +19,11 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-from pynestml.utils.model_parser import ModelParser
-from pynestml.visitors.ast_symbol_table_visitor import ASTSymbolTableVisitor
 import sympy
 
 from pynestml.utils.mechs_info_enricher import MechsInfoEnricher
+from pynestml.utils.model_parser import ModelParser
+from pynestml.visitors.ast_symbol_table_visitor import ASTSymbolTableVisitor
 
 
 class ChanInfoEnricher(MechsInfoEnricher):

--- a/pynestml/utils/logger.py
+++ b/pynestml/utils/logger.py
@@ -29,7 +29,6 @@ from pynestml.meta_model.ast_node import ASTNode
 from pynestml.utils.ast_source_location import ASTSourceLocation
 from pynestml.utils.messages import MessageCode
 from pynestml.meta_model.ast_inline_expression import ASTInlineExpression
-from pynestml.meta_model.ast_input_port import ASTInputPort
 
 
 class LoggingLevel(Enum):

--- a/pynestml/utils/mechs_info_enricher.py
+++ b/pynestml/utils/mechs_info_enricher.py
@@ -19,14 +19,16 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-from pynestml.meta_model.ast_model import ASTModel
-from pynestml.utils.model_parser import ModelParser
-from pynestml.visitors.ast_symbol_table_visitor import ASTSymbolTableVisitor
-from pynestml.symbols.symbol import SymbolKind
-from pynestml.visitors.ast_visitor import ASTVisitor
-from pynestml.symbols.predefined_functions import PredefinedFunctions
 from collections import defaultdict
+
+from pynestml.meta_model.ast_model import ASTModel
+from pynestml.symbols.predefined_functions import PredefinedFunctions
+from pynestml.symbols.symbol import SymbolKind
 from pynestml.utils.ast_utils import ASTUtils
+from pynestml.utils.model_parser import ModelParser
+from pynestml.visitors.ast_parent_visitor import ASTParentVisitor
+from pynestml.visitors.ast_symbol_table_visitor import ASTSymbolTableVisitor
+from pynestml.visitors.ast_visitor import ASTVisitor
 
 
 class MechsInfoEnricher:
@@ -117,6 +119,8 @@ class MechsInfoEnricher:
                                     mechanism_info["time_resolution_var"] = variable
 
                     mechanism_info["ODEs"][ode_var_name]["transformed_solutions"].append(solution_transformed)
+
+        neuron.accept(ASTParentVisitor())
 
         return mechs_info
 

--- a/pynestml/utils/model_parser.py
+++ b/pynestml/utils/model_parser.py
@@ -71,6 +71,7 @@ from pynestml.utils.logger import Logger, LoggingLevel
 from pynestml.utils.messages import Messages
 from pynestml.visitors.ast_builder_visitor import ASTBuilderVisitor
 from pynestml.visitors.ast_higher_order_visitor import ASTHigherOrderVisitor
+from pynestml.visitors.ast_parent_visitor import ASTParentVisitor
 from pynestml.visitors.ast_symbol_table_visitor import ASTSymbolTableVisitor
 
 
@@ -130,6 +131,11 @@ class ModelParser:
         # create a new visitor and return the new AST
         ast_builder_visitor = ASTBuilderVisitor(stream.tokens)
         ast = ast_builder_visitor.visit(compilation_unit)
+
+        # create links back from children in the tree to their parents
+        for model in ast.get_model_list():
+            model.parent_ = None   # root node has no parent
+            model.accept(ASTParentVisitor())
 
         # create and update the corresponding symbol tables
         SymbolTable.initialize_symbol_table(ast.get_source_position())

--- a/pynestml/visitors/ast_parent_visitor.py
+++ b/pynestml/visitors/ast_parent_visitor.py
@@ -55,12 +55,3 @@ class ASTParentVisitor(ASTVisitor):
         children = node.get_children()
         for child in children:
             child.parent_ = node
-        # queue = [node]
-        # while queue:
-        #     node = queue.pop(0)   # pop from the front of the queue -- breadth first search
-
-        #     children = node.get_children()
-        #     for child in children:
-        #         child.parent_ = node
-
-        #     queue.extend(children)

--- a/pynestml/visitors/ast_parent_visitor.py
+++ b/pynestml/visitors/ast_parent_visitor.py
@@ -19,32 +19,13 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-from pynestml.cocos.co_cos_manager import CoCosManager
-from pynestml.meta_model.ast_model import ASTModel
-from pynestml.meta_model.ast_model_body import ASTModelBody
-from pynestml.meta_model.ast_namespace_decorator import ASTNamespaceDecorator
-from pynestml.meta_model.ast_declaration import ASTDeclaration
 from pynestml.meta_model.ast_node import ASTNode
-from pynestml.meta_model.ast_stmt import ASTStmt
-from pynestml.meta_model.ast_variable import ASTVariable
-from pynestml.symbol_table.scope import Scope, ScopeType
-from pynestml.symbols.function_symbol import FunctionSymbol
-from pynestml.symbols.predefined_functions import PredefinedFunctions
-from pynestml.symbols.predefined_types import PredefinedTypes
-from pynestml.symbols.predefined_variables import PredefinedVariables
-from pynestml.symbols.symbol import SymbolKind
-from pynestml.symbols.variable_symbol import VariableSymbol, BlockType, VariableType
-from pynestml.utils.ast_utils import ASTUtils
-from pynestml.utils.logger import Logger, LoggingLevel
-from pynestml.utils.messages import Messages
-from pynestml.utils.stack import Stack
-from pynestml.visitors.ast_data_type_visitor import ASTDataTypeVisitor
 from pynestml.visitors.ast_visitor import ASTVisitor
 
 
 class ASTParentVisitor(ASTVisitor):
     r"""
-    For each node in the AST, assign its ``parent_`` attribute; in other words, make it a doubly-linked tree.
+    For each node in the AST, assign its ``parent_`` attribute; in other words, make the AST a doubly-linked tree.
     """
 
     def __init__(self):

--- a/pynestml/visitors/ast_parent_visitor.py
+++ b/pynestml/visitors/ast_parent_visitor.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# ast_parent_visitor.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+from pynestml.cocos.co_cos_manager import CoCosManager
+from pynestml.meta_model.ast_model import ASTModel
+from pynestml.meta_model.ast_model_body import ASTModelBody
+from pynestml.meta_model.ast_namespace_decorator import ASTNamespaceDecorator
+from pynestml.meta_model.ast_declaration import ASTDeclaration
+from pynestml.meta_model.ast_node import ASTNode
+from pynestml.meta_model.ast_stmt import ASTStmt
+from pynestml.meta_model.ast_variable import ASTVariable
+from pynestml.symbol_table.scope import Scope, ScopeType
+from pynestml.symbols.function_symbol import FunctionSymbol
+from pynestml.symbols.predefined_functions import PredefinedFunctions
+from pynestml.symbols.predefined_types import PredefinedTypes
+from pynestml.symbols.predefined_variables import PredefinedVariables
+from pynestml.symbols.symbol import SymbolKind
+from pynestml.symbols.variable_symbol import VariableSymbol, BlockType, VariableType
+from pynestml.utils.ast_utils import ASTUtils
+from pynestml.utils.logger import Logger, LoggingLevel
+from pynestml.utils.messages import Messages
+from pynestml.utils.stack import Stack
+from pynestml.visitors.ast_data_type_visitor import ASTDataTypeVisitor
+from pynestml.visitors.ast_visitor import ASTVisitor
+
+
+class ASTParentVisitor(ASTVisitor):
+    r"""
+    For each node in the AST, assign its ``parent_`` attribute; in other words, make it a doubly-linked tree.
+    """
+
+    def __init__(self):
+        super(ASTParentVisitor, self).__init__()
+
+    def visit(self, node: ASTNode):
+        r"""Set ``parent_`` property on all children to refer back to this node."""
+        children = node.get_children()
+        for child in children:
+            child.parent_ = node
+        # queue = [node]
+        # while queue:
+        #     node = queue.pop(0)   # pop from the front of the queue -- breadth first search
+
+        #     children = node.get_children()
+        #     for child in children:
+        #         child.parent_ = node
+
+        #     queue.extend(children)

--- a/tests/invalid/CoCoVectorInNonVectorDeclaration.nestml
+++ b/tests/invalid/CoCoVectorInNonVectorDeclaration.nestml
@@ -36,5 +36,6 @@ model CoCoVectorInNonVectorDeclaration:
     state:
         g_ex [ten] mV = 10mV
         g_in mV = 10mV + g_ex
+
     parameters:
         ten integer = 10

--- a/tests/test_symbol_table_builder.py
+++ b/tests/test_symbol_table_builder.py
@@ -36,6 +36,7 @@ from pynestml.symbols.predefined_units import PredefinedUnits
 from pynestml.symbols.predefined_variables import PredefinedVariables
 from pynestml.utils.logger import Logger, LoggingLevel
 from pynestml.visitors.ast_builder_visitor import ASTBuilderVisitor
+from pynestml.visitors.ast_parent_visitor import ASTParentVisitor
 from pynestml.visitors.ast_symbol_table_visitor import ASTSymbolTableVisitor
 
 
@@ -78,6 +79,8 @@ class TestSymbolTableBuilder:
             SymbolTable.initialize_symbol_table(ast.get_source_position())
             symbol_table_visitor = ASTSymbolTableVisitor()
             for model in ast.get_model_list():
+                model.parent_ = None    # set root element
+                model.accept(ASTParentVisitor())
                 model.accept(symbol_table_visitor)
                 SymbolTable.add_model_scope(name=model.get_name(), scope=model.get_scope())
 


### PR DESCRIPTION
Add an ASTParentVisitor which sets an attribute ``parent_`` on each ASTNode on the basis of calls to ``get_children()`` on ASTNodes, making the AST a doubly-linked tree. This is (probably) the fastest and easiest solution, but of course has the disadvantage that information is stored redundantly.

As a test for self-consistency, an assert is added to check that ``self`` is in ``parent_.get_children()`` in each call to ``get_parent()``.

Fixes #1024.