### PR TITLE
Fix NEST initialisation

### DIFF
--- a/pynestml/codegeneration/resources_nest/point_neuron/common/NeuronClass.jinja2
+++ b/pynestml/codegeneration/resources_nest/point_neuron/common/NeuronClass.jinja2
@@ -353,12 +353,6 @@ void {{neuronName}}::init_state_internal_()
 
   const double __resolution = nest::Time::get_resolution().get_ms();  // do not remove, this is necessary for the resolution() function
 
-{%- if nest_version.startswith("v2") or nest_version.startswith("v3.0") or nest_version.startswith("v3.1") or nest_version.startswith("v3.2") or nest_version.startswith("v3.3") %}
-  calibrate();
-{%- else %}
-  pre_run_hook();
-{%- endif %}
-
 {%- if numeric_solver == "rk45" %}
   // by default, integrate all variables
   // use a default "good enough" value for the absolute error. It can be adjusted via `node.set()`


### PR DESCRIPTION
There is an issue with initialisation of the neuron class: 

The constructor calls ``init_state_internal_()`` which calls ``pre_run_hook()``, which calls ``recompute_internal_variables()``. But the latter depends on the parameters being initialised, which is done only afterwards in ``init_state_internal_()``. Thus, ``recompute_internal_variables()`` might try to initialise internal variables based on uninitialised parameter values. These values are anyway later recomputed when NEST Simulator calls ``pre_run_hook()``, so this PR simply removes the extra unncessary call to ``pre_run_hook()``.