### PR TITLE
Remove broken link to model

### DIFF
--- a/doc/models_library/output.html
+++ b/doc/models_library/output.html
@@ -424,10 +424,4 @@ role="doc">stdp_triplet_synapse &lt;stdp_triplet_synapse&gt;</code></h3>
 <p>Synapse type with triplet spike-timing dependent plasticity</p>
 <p>Source file: <a
 href="https://www.github.com/nest/nestml/blob/master/models/synapses/stdp_triplet_synapse.nestml">stdp_triplet_synapse.nestml</a></p>
-<h3 id="third_factor_stdp_synapse-third_factor_stdp_synapse"><code
-class="interpreted-text"
-role="doc">third_factor_stdp_synapse &lt;third_factor_stdp_synapse&gt;</code></h3>
-<p>Synapse model for spike-timing dependent plasticity with postsynaptic
-third-factor modulation</p>
-<p>Source file: <a
-href="https://www.github.com/nest/nestml/blob/master/models/synapses/third_factor_stdp_synapse.nestml">third_factor_stdp_synapse.nestml</a></p>
+


### PR DESCRIPTION
#1078 moved this model from the ``models/synapses`` directory to inside the Jupyter notebook. This PR fixes the broken link in the documentation.