### PR TITLE
Remove 'start building symbol table' debug message

### DIFF
--- a/pynestml/utils/messages.py
+++ b/pynestml/utils/messages.py
@@ -35,7 +35,6 @@ class MessageCode(Enum):
     A mapping between codes and the corresponding messages.
     """
     START_PROCESSING_FILE = 0
-    START_SYMBOL_TABLE_BUILDING = 1
     FUNCTION_CALL_TYPE_ERROR = 2
     TYPE_NOT_DERIVABLE = 3
     IMPLICIT_CAST = 4
@@ -221,15 +220,6 @@ class Messages:
         message = 'Implicit magnitude conversion from %s to %s with factor %s ' % (
             lhs.print_symbol(), rhs.print_symbol(), conversion_factor)
         return MessageCode.IMPLICIT_CAST, message
-
-    @classmethod
-    def get_start_building_symbol_table(cls):
-        """
-        Returns a message that the building for a model has been started.
-        :return: a message
-        :rtype: (MessageCode,str)
-        """
-        return MessageCode.START_SYMBOL_TABLE_BUILDING, 'Start building symbol table!'
 
     @classmethod
     def get_function_call_implicit_cast(

--- a/pynestml/visitors/ast_symbol_table_visitor.py
+++ b/pynestml/visitors/ast_symbol_table_visitor.py
@@ -58,9 +58,6 @@ class ASTSymbolTableVisitor(ASTVisitor):
         Used to visit a single model and create the corresponding global as well as local scopes.
         """
         Logger.set_current_node(node)
-        code, message = Messages.get_start_building_symbol_table()
-        Logger.log_message(node=node, code=code, error_position=node.get_source_position(),
-                           message=message, log_level=LoggingLevel.DEBUG)
         scope = Scope(scope_type=ScopeType.GLOBAL,
                       source_position=node.get_source_position())
         node.update_scope(scope)


### PR DESCRIPTION
This message has no added value for debugging or any of the other log levels; hence, this PR removes it.