### PR TITLE
Bump minimum Python version requirement to 3.9 and update CI

### DIFF
--- a/.github/workflows/nestml-build.yml
+++ b/.github/workflows/nestml-build.yml
@@ -29,10 +29,10 @@ jobs:
         uses: actions/checkout@v4
 
       # Setup Python version
-      - name: Setup Python 3.8
+      - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       # Install dependencies
       - name: Install apt dependencies
@@ -60,10 +60,10 @@ jobs:
         uses: actions/checkout@v4
 
       # Setup Python version
-      - name: Setup Python 3.8
+      - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       # Install dependencies
       - name: Install apt dependencies
@@ -99,7 +99,7 @@ jobs:
       # Install NESTML
       - name: Install NESTML
         run: |
-          export PYTHONPATH=${{ env.PYTHONPATH }}:${{ env.NEST_INSTALL }}/lib/python3.8/site-packages
+          export PYTHONPATH=${{ env.PYTHONPATH }}:${{ env.NEST_INSTALL }}/lib/python3.9/site-packages
           #echo PYTHONPATH=`pwd` >> $GITHUB_ENV
           echo "PYTHONPATH=$PYTHONPATH" >> $GITHUB_ENV
           python setup.py install
@@ -131,10 +131,10 @@ jobs:
         uses: actions/checkout@v4
 
       # Setup Python version
-      - name: Setup Python 3.8
+      - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       # Install dependencies
       - name: Install apt dependencies
@@ -169,7 +169,7 @@ jobs:
       # Install NESTML
       - name: Install NESTML
         run: |
-          export PYTHONPATH=${{ env.PYTHONPATH }}:${{ env.NEST_INSTALL }}/lib/python3.8/site-packages
+          export PYTHONPATH=${{ env.PYTHONPATH }}:${{ env.NEST_INSTALL }}/lib/python3.9/site-packages
           #echo PYTHONPATH=`pwd` >> $GITHUB_ENV
           echo "PYTHONPATH=$PYTHONPATH" >> $GITHUB_ENV
           python setup.py install
@@ -195,10 +195,10 @@ jobs:
         uses: actions/checkout@v4
 
       # Setup Python version
-      - name: Setup Python 3.8
+      - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       # Install dependencies
       - name: Install apt dependencies
@@ -252,7 +252,7 @@ jobs:
       # Install NESTML (repeated)
       - name: Install NESTML
         run: |
-          export PYTHONPATH=${{ env.PYTHONPATH }}:${{ env.NEST_INSTALL }}/lib/python3.8/site-packages
+          export PYTHONPATH=${{ env.PYTHONPATH }}:${{ env.NEST_INSTALL }}/lib/python3.9/site-packages
           #echo PYTHONPATH=`pwd` >> $GITHUB_ENV
           echo "PYTHONPATH=$PYTHONPATH" >> $GITHUB_ENV
           python setup.py install
@@ -331,10 +331,10 @@ jobs:
         uses: actions/checkout@v4
 
       # Setup Python version
-      - name: Setup Python 3.8
+      - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       # Install dependencies
       - name: Install apt dependencies
@@ -370,7 +370,7 @@ jobs:
       # Install NESTML (repeated)
       - name: Install NESTML
         run: |
-          export PYTHONPATH=${{ env.PYTHONPATH }}:${{ env.NEST_INSTALL }}/lib/python3.8/site-packages
+          export PYTHONPATH=${{ env.PYTHONPATH }}:${{ env.NEST_INSTALL }}/lib/python3.9/site-packages
           #echo PYTHONPATH=`pwd` >> $GITHUB_ENV
           echo "PYTHONPATH=$PYTHONPATH" >> $GITHUB_ENV
           python setup.py install

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -1,7 +1,7 @@
 Installing NESTML
 =================
 
-Please note that only Python 3.8 (and later versions) are supported. The instructions below assume that ``python`` is aliased to or refers to ``python3``, and ``pip`` to ``pip3``.
+Please note that only Python 3.9 (and later versions) are supported. The instructions below assume that ``python`` is aliased to or refers to ``python3``, and ``pip`` to ``pip3``.
 
 Installing the latest release from PyPI
 ---------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ import os
 import sys
 from setuptools import setup, find_packages
 
-assert sys.version_info.major >= 3 and sys.version_info.minor >= 8, "Python 3.8 or higher is required to run NESTML"
+assert sys.version_info.major >= 3 and sys.version_info.minor >= 9, "Python 3.9 or higher is required to run NESTML"
 
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()


### PR DESCRIPTION
Needed for #1026 due to dependency on a newer matplotlib.

Python 3.9 is the default available on the JSC login node as well as JUSUF.