### PR TITLE
Fix bug with `integrate_odes()` for numeric solver

### DIFF
--- a/pynestml/codegeneration/resources_nest/point_neuron/directives_cpp/GSLDifferentiationFunction.jinja2
+++ b/pynestml/codegeneration/resources_nest/point_neuron/directives_cpp/GSLDifferentiationFunction.jinja2
@@ -51,14 +51,17 @@ extern "C" inline int {{neuronName}}_dynamics{% if ast.get_args() | length > 0 %
   }
 {%- endif %}
 
-
+{%      set numeric_state_variables_to_be_integrated = numeric_state_variables + purely_numeric_state_variables_moved %}
+{%-     if ast.get_args() | length > 0 %}
+{%-         set numeric_state_variables_to_be_integrated = utils.filter_variables_list(numeric_state_variables_to_be_integrated, ast.get_args()) %}
+{%-     endif %}
 {%- for variable_name in numeric_state_variables + numeric_state_variables_moved %}
 {%-   set update_expr = numeric_update_expressions[variable_name] %}
 {%-   set variable_symbol = variable_symbols[variable_name] %}
 {%- if use_gap_junctions %}
-  f[State_::{{ variable_symbol.get_symbol_name() }}] = {% if ast.get_args() | length > 0 %}{% if variable_name in utils.integrate_odes_args_strs_from_function_call(ast) + utils.all_convolution_variable_names(astnode) %}{{ gsl_printer.print(update_expr)|replace("node.B_." + gap_junction_port + "_grid_sum_", "(node.B_." + gap_junction_port + "_grid_sum_ + __I_gap)") }}{% else %}0{% endif %}{% else %}{{ gsl_printer.print(update_expr) }}{% endif %};
+  f[State_::{{ variable_symbol.get_symbol_name() }}] = {% if ast.get_args() | length > 0 %}{% if variable_name in numeric_state_variables_to_be_integrated + utils.all_convolution_variable_names(astnode) %}{{ gsl_printer.print(update_expr)|replace("node.B_." + gap_junction_port + "_grid_sum_", "(node.B_." + gap_junction_port + "_grid_sum_ + __I_gap)") }}{% else %}0{% endif %}{% else %}{{ gsl_printer.print(update_expr) }}{% endif %};
 {%- else %}
-  f[State_::{{ variable_symbol.get_symbol_name() }}] = {% if ast.get_args() | length > 0 %}{% if variable_name in utils.integrate_odes_args_strs_from_function_call(ast) + utils.all_convolution_variable_names(astnode) %}{{ gsl_printer.print(update_expr) }}{% else %}0{% endif %}{% else %}{{ gsl_printer.print(update_expr) }}{% endif %};
+  f[State_::{{ variable_symbol.get_symbol_name() }}] = {% if ast.get_args() | length > 0 %}{% if variable_name in numeric_state_variables_to_be_integrated + utils.all_convolution_variable_names(astnode) %}{{ gsl_printer.print(update_expr) }}{% else %}0{% endif %}{% else %}{{ gsl_printer.print(update_expr) }}{% endif %};
 {%- endif %}
 {%- endfor %}
 

--- a/tests/nest_tests/resources/aeif_cond_alpha_alt_neuron.nestml
+++ b/tests/nest_tests/resources/aeif_cond_alpha_alt_neuron.nestml
@@ -1,0 +1,122 @@
+"""
+aeif_cond_alpha - Conductance based exponential integrate-and-fire neuron model
+###############################################################################
+
+Description
++++++++++++
+
+aeif_psc_alpha is the adaptive exponential integrate and fire neuron according to Brette and Gerstner (2005), with post-synaptic conductances in the form of a bi-exponential ("alpha") function.
+
+The membrane potential is given by the following differential equation:
+
+.. math::
+
+   C_m \frac{dV_m}{dt} =
+   -g_L(V_m-E_L)+g_L\Delta_T\exp\left(\frac{V_m-V_{th}}{\Delta_T}\right) -
+ g_e(t)(V_m-E_e) \\
+                                                     -g_i(t)(V_m-E_i)-w + I_e
+
+and
+
+.. math::
+
+ \tau_w \frac{dw}{dt} = a(V_m-E_L) - w
+
+Note that the membrane potential can diverge to positive infinity due to the exponential term. To avoid numerical instabilities, instead of :math:`V_m`, the value :math:`\min(V_m,V_{peak})` is used in the dynamical equations.
+
+
+References
+++++++++++
+
+.. [1] Brette R and Gerstner W (2005). Adaptive exponential
+       integrate-and-fire model as an effective description of neuronal
+       activity. Journal of Neurophysiology. 943637-3642
+       DOI: https://doi.org/10.1152/jn.00686.2005
+
+
+See also
+++++++++
+
+iaf_psc_alpha, aeif_psc_exp
+"""
+model aeif_cond_alpha_alt_neuron:
+
+    state:
+        V_m mV = E_L       # Membrane potential
+        w pA = 0 pA        # Spike-adaptation current
+        refr_t ms = 0 ms    # Refractory period timer
+        g_exc nS = 0 nS      # AHP conductance
+        g_exc' nS/ms = 0 nS/ms   # AHP conductance
+        g_inh nS = 0 nS      # AHP conductance
+        g_inh' nS/ms = 0 nS/ms   # AHP conductance
+
+    equations:
+        inline V_bounded mV = min(V_m, V_peak) # prevent exponential divergence
+
+        g_exc'' = -2 * g_exc' / tau_syn_exc - g_exc / tau_syn_exc**2
+        g_inh'' = -2 * g_inh' / tau_syn_inh - g_inh / tau_syn_inh**2
+
+        # Add inlines to simplify the equation definition of V_m
+        inline exp_arg real = (V_bounded - V_th) / Delta_T
+        inline I_spike pA = g_L * Delta_T * exp(exp_arg)
+        # inline I_syn_exc pA = g_exc / nS * pA
+        # inline I_syn_inh pA = g_inh / nS * pA
+
+        V_m' = (-g_L * (V_bounded - E_L) + I_spike - g_exc * (V_bounded - E_exc) - g_inh * (V_bounded - E_exc) - w + I_e + I_stim) / C_m
+        w' = (a * (V_bounded - E_L) - w) / tau_w
+
+        refr_t' = -1e3 * ms/s    # refractoriness is implemented as an ODE, representing a timer counting back down to zero. XXX: TODO: This should simply read ``refr_t' = -1 / s`` (see https://github.com/nest/nestml/issues/984)
+
+    parameters:
+        # membrane parameters
+        C_m pF = 281.0 pF         # Membrane Capacitance
+        refr_T ms = 2 ms         # Duration of refractory period
+        V_reset mV = -60.0 mV     # Reset Potential
+        g_L nS = 30.0 nS          # Leak Conductance
+        E_L mV = -70.6 mV         # Leak reversal Potential (aka resting potential)
+
+        # spike adaptation parameters
+        a nS = 4 nS               # Subthreshold adaptation
+        b pA = 80.5 pA            # Spike-triggered adaptation
+        Delta_T mV = 2.0 mV       # Slope factor
+        tau_w ms = 144.0 ms       # Adaptation time constant
+        V_th mV = -50.4 mV        # Threshold Potential
+        V_peak mV = 0 mV          # Spike detection threshold
+
+        # synaptic parameters
+        tau_syn_exc ms = 0.2 ms    # Synaptic Time Constant Excitatory Synapse
+        tau_syn_inh ms = 2.0 ms    # Synaptic Time Constant for Inhibitory Synapse
+        E_exc mV = 0 mV            # Excitatory reversal Potential
+        E_inh mV = -85.0 mV        # Inhibitory reversal Potential
+
+        # constant external input current
+        I_e pA = 0 pA
+
+    input:
+        exc_spikes <- excitatory spike
+        inh_spikes <- inhibitory spike
+        I_stim pA <- continuous
+
+    output:
+        spike
+
+    update:
+        if refr_t > 0 ms:
+            # neuron is absolute refractory, do not evolve V_m
+            integrate_odes(g_exc, g_inh, w, refr_t)
+        else:
+            # neuron not refractory
+            integrate_odes(g_exc, g_inh, V_m, w)
+
+    onReceive(exc_spikes):
+        g_exc' += exc_spikes * (e / tau_syn_exc) * nS * s
+
+    onReceive(inh_spikes):
+        g_inh' += inh_spikes * (e / tau_syn_inh) * nS * s
+
+    onCondition(refr_t <= 0 ms and V_m >= V_th):
+        # threshold crossing
+        refr_t = refr_T    # start of the refractory period
+        V_m = V_reset
+        w += b
+        emit_spike()

--- a/tests/nest_tests/resources/aeif_cond_alpha_alt_neuron.nestml
+++ b/tests/nest_tests/resources/aeif_cond_alpha_alt_neuron.nestml
@@ -59,10 +59,8 @@ model aeif_cond_alpha_alt_neuron:
         # Add inlines to simplify the equation definition of V_m
         inline exp_arg real = (V_bounded - V_th) / Delta_T
         inline I_spike pA = g_L * Delta_T * exp(exp_arg)
-        # inline I_syn_exc pA = g_exc / nS * pA
-        # inline I_syn_inh pA = g_inh / nS * pA
 
-        V_m' = (-g_L * (V_bounded - E_L) + I_spike - g_exc * (V_bounded - E_exc) - g_inh * (V_bounded - E_exc) - w + I_e + I_stim) / C_m
+        V_m' = (-g_L * (V_bounded - E_L) + I_spike - g_exc * (V_bounded - E_exc) - g_inh * (V_bounded - E_inh) - w + I_e + I_stim) / C_m
         w' = (a * (V_bounded - E_L) - w) / tau_w
 
         refr_t' = -1e3 * ms/s    # refractoriness is implemented as an ODE, representing a timer counting back down to zero. XXX: TODO: This should simply read ``refr_t' = -1 / s`` (see https://github.com/nest/nestml/issues/984)

--- a/tests/nest_tests/test_integrate_odes.py
+++ b/tests/nest_tests/test_integrate_odes.py
@@ -287,7 +287,7 @@ class TestIntegrateODEs:
         Tests for higher-order ODEs of the form F(x'',x',x)=0, integrate_odes(x) integrates the full dynamics of x with a numeric solver.
         """
         resolution = 0.1
-        simtime = 100.
+        simtime = 800.
         params_nestml = {"V_peak": 0.0, "a": 4.0, "b": 80.5, "E_L": -70.6,
                          "g_L": 300.0, 'E_exc': 20.0, 'E_inh': -85.0,
                          'tau_syn_exc': 40.0, 'tau_syn_inh': 20.0}
@@ -312,11 +312,12 @@ class TestIntegrateODEs:
                 nest.SetStatus(n, params_nest)
 
             spike = nest.Create("spike_generator")
-            spike_times = [10.0, 50.0]
+            spike_times = [10.0, 400.0]
             nest.SetStatus(spike, {"spike_times": spike_times})
-            nest.Connect(spike, n, syn_spec={"weight": 1., "delay": 1.0})
+            nest.Connect(spike, n, syn_spec={"weight": 0.1, "delay": 1.0})
+            nest.Connect(spike, n, syn_spec={"weight": -0.2, "delay": 100.})
 
-            mm = nest.Create("multimeter", params={"interval": resolution, "record_from": ["V_m"]})
+            mm = nest.Create("multimeter", params={"record_from": ["V_m"]})
             nest.Connect(mm, n)
 
             nest.Simulate(simtime)

--- a/tests/nest_tests/test_integrate_odes.py
+++ b/tests/nest_tests/test_integrate_odes.py
@@ -336,4 +336,4 @@ class TestIntegrateODEs:
 
             fig.savefig("/tmp/test_integrate_odes_numeric_higher_order.png")
 
-        np.testing.assert_allclose(v_m_nestml[-1], v_m_nest[-1])
+        np.testing.assert_allclose(v_m_nestml, v_m_nest)


### PR DESCRIPTION
This PR solves a bug for neuron models with higher-order differential equations and a numeric solver where not all the state variables of the higher-order ODEs were solved by the GSL solver.