### PR TITLE
Friendlier lexer and parser error messages

### DIFF
--- a/pynestml/grammars/generate_lexer_parser
+++ b/pynestml/grammars/generate_lexer_parser
@@ -22,4 +22,4 @@
 
 # Do not change the position of this file! In order to generate the corresponding code into `pynestml/generated`, this script has to be executed from `pynestml/grammars`.
 
-antlr4 -Dlanguage=Python3 *.g4 -visitor -no-listener -o ../generated
+antlr4 -encoding UTF8 -Dlanguage=Python3 *.g4 -visitor -no-listener -o ../generated

--- a/pynestml/utils/error_listener.py
+++ b/pynestml/utils/error_listener.py
@@ -36,3 +36,7 @@ class NestMLErrorListener(ErrorListener):
 
     def syntaxError(self, recognizer, offendingSymbol, line, column, msg, e):
         self._error_occurred = True
+        self.offendingSymbol = offendingSymbol
+        self.line = line
+        self.column = column
+        self.msg = msg

--- a/pynestml/utils/messages.py
+++ b/pynestml/utils/messages.py
@@ -182,8 +182,8 @@ class Messages:
         return MessageCode.NO_CODE_GENERATED, message
 
     @classmethod
-    def get_lexer_error(cls):
-        message = 'Error occurred during lexing: abort'
+    def get_lexer_error(cls, msg):
+        message = 'Error occurred during lexing: ' + msg
         return MessageCode.LEXER_ERROR, message
 
     @classmethod
@@ -192,8 +192,8 @@ class Messages:
         return MessageCode.LEXER_ERROR, message
 
     @classmethod
-    def get_parser_error(cls):
-        message = 'Error occurred during parsing: abort'
+    def get_parser_error(cls, msg):
+        message = 'Error occurred during parsing: ' + msg
         return MessageCode.PARSER_ERROR, message
 
     @classmethod


### PR DESCRIPTION
Friendlier error messages (via the logger rather than via stdout) in case of lexer/parser errors.

Also friendly error message in case a unicode character was accidentally used in the model.