### PR TITLE
Fix and add test for saturating-type equations in synapse models

### DIFF
--- a/pynestml/codegeneration/code_generator.py
+++ b/pynestml/codegeneration/code_generator.py
@@ -169,8 +169,6 @@ class CodeGenerator(WithOptions):
         from pynestml.frontend.frontend_configuration import FrontendConfiguration
 
         for synapse in synapses:
-            if Logger.logging_level == LoggingLevel.INFO:
-                print("Generating code for the synapse {}.".format(synapse.get_name()))
             self.generate_synapse_code(synapse)
             code, message = Messages.get_code_generated(synapse.get_name(), FrontendConfiguration.get_target_path())
             Logger.log_message(synapse, code, message, synapse.get_source_position(), LoggingLevel.INFO)

--- a/pynestml/transformers/synapse_post_neuron_transformer.py
+++ b/pynestml/transformers/synapse_post_neuron_transformer.py
@@ -556,9 +556,8 @@ class SynapsePostNeuronTransformer(Transformer):
             None, -1, "Adding suffix to variables in spike updates", None, LoggingLevel.INFO)
 
         for stmt in new_neuron.extra_on_emit_spike_stmts_from_synapse:
-            if stmt.small_stmt.is_assignment():
-                new_name: str = stmt.small_stmt.get_assignment().get_variable().get_name() + var_name_suffix
-                stmt.small_stmt.get_assignment().get_variable().set_name(new_name)
+            ASTUtils.add_suffix_to_variable_names(stmt, var_name_suffix, altscope=synapse.get_scope())
+            ASTUtils.set_new_scope(stmt, new_neuron.get_scope())
 
         #
         #    replace occurrences of the variables in expressions in the original synapse with calls to the corresponding neuron getters

--- a/tests/nest_tests/resources/minimal_neuron.nestml
+++ b/tests/nest_tests/resources/minimal_neuron.nestml
@@ -1,29 +1,28 @@
 # minimal_neuron.nestml
 # #####################
-# 
+#
 # This is a very minimal neuron model for testing, containing as few blocks as possible.
-# 
-# 
+#
+#
 # Copyright statement
 # +++++++++++++++++++
-# 
+#
 # This file is part of NEST.
-# 
+#
 # Copyright (C) 2004 The NEST Initiative
-# 
+#
 # NEST is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-# 
+#
 # NEST is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
-
 #
 model minimal_neuron:
     output:

--- a/tests/nest_tests/resources/stdp_saturating_synapse.nestml
+++ b/tests/nest_tests/resources/stdp_saturating_synapse.nestml
@@ -1,37 +1,13 @@
-# stdp_synapse - Synapse model for spike-timing dependent plasticity
-# ##################################################################
+# stdp_saturating_synapse - Synapse model for spike-timing dependent plasticity
+# #############################################################################
 #
 #
 # Description
 # +++++++++++
 #
-# stdp_synapse is a synapse with spike-timing dependent plasticity (as defined in [1]_). Here the weight dependence exponent can be set separately for potentiation and depression. Examples:
+# For testing neuron/synapse co-generation.
 #
-# =================== ==== =============================
-# Multiplicative STDP [2]_ mu_plus = mu_minus = 1
-# Additive STDP       [3]_ mu_plus = mu_minus = 0
-# Guetig STDP         [1]_ mu_plus, mu_minus in [0, 1]
-# Van Rossum STDP     [4]_ mu_plus = 0 mu_minus = 1
-# =================== ==== =============================
-#
-#
-# References
-# ++++++++++
-#
-# .. [1] Guetig et al. (2003) Learning Input Correlations through Nonlinear
-# Temporally Asymmetric Hebbian Plasticity. Journal of Neuroscience
-#
-# .. [2] Rubin, J., Lee, D. and Sompolinsky, H. (2001). Equilibrium
-# properties of temporally asymmetric Hebbian plasticity, PRL
-# 86,364-367
-#
-# .. [3] Song, S., Miller, K. D. and Abbott, L. F. (2000). Competitive
-# Hebbian learning through spike-timing-dependent synaptic
-# plasticity,Nature Neuroscience 3:9,919--926
-#
-# .. [4] van Rossum, M. C. W., Bi, G-Q and Turrigiano, G. G. (2000).
-# Stable Hebbian learning from spike timing-dependent
-# plasticity, Journal of Neuroscience, 20:23,8812--8821
+# Just like ``stdp_synapse``, except that the ``pre_trace`` and ``post_trace`` increment are dependent on themselves and another parameter.
 #
 #
 # Copyright statement
@@ -54,7 +30,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 #
-model stdp_synapse:
+model stdp_saturating_synapse:
     state:
         w real = 1    # Synaptic weight
         pre_trace real = 0.
@@ -70,6 +46,8 @@ model stdp_synapse:
         mu_minus real = 1
         Wmax real = 100.
         Wmin real = 0.
+        foobar real = 42.
+        xyzzy real = 42.
 
     equations:
         pre_trace' = -pre_trace / tau_tr_pre
@@ -83,14 +61,14 @@ model stdp_synapse:
         spike(weight real, delay ms)
 
     onReceive(post_spikes):
-        post_trace += 1
+        post_trace += foobar - .1 * post_trace
 
         # potentiate synapse
         w_ real = Wmax * ( w / Wmax  + (lambda * ( 1. - ( w / Wmax ) )**mu_plus * pre_trace ))
         w = min(Wmax, w_)
 
     onReceive(pre_spikes):
-        pre_trace += 1
+        pre_trace += xyzzy - .1 * pre_trace
 
         # depress synapse
         w_ real = Wmax * ( w / Wmax  - ( alpha * lambda * ( w / Wmax )**mu_minus * post_trace ))

--- a/tests/nest_tests/stdp_window_test.py
+++ b/tests/nest_tests/stdp_window_test.py
@@ -41,9 +41,8 @@ except Exception:
 @pytest.fixture(autouse=True,
                 scope="module")
 def nestml_generate_target():
-    r"""Generate the neuron model code"""
+    r"""Generate the NEST C++ code for neuron and synapse models"""
 
-    # generate the "jit" model (co-generated neuron and synapse), that does not rely on ArchivingNode
     files = [os.path.join("models", "neurons", "iaf_psc_delta_neuron.nestml"),
              os.path.join("models", "neurons", "izhikevich_neuron.nestml"),
              os.path.join("models", "synapses", "stdp_synapse.nestml")]
@@ -121,14 +120,19 @@ def run_stdp_network(pre_spike_time, post_spike_time,
     nest.Connect(pre_neuron, spikedet_pre)
     nest.Connect(post_neuron, spikedet_post)
 
-    # get STDP synapse and weight before protocol
+    syn = nest.GetConnections(source=pre_neuron, synapse_model="stdp_nestml_rec")
+
     if custom_synapse_properties:
-        syn = nest.GetConnections(source=pre_neuron, synapse_model="stdp_nestml_rec")
         nest.SetStatus(syn, custom_synapse_properties)
 
+    # get STDP synapse and weight before protocol
     initial_weight = nest.GetStatus(syn)[0][weight_variable_name]
     np.testing.assert_allclose(initial_weight, 1)
+
+    # run the simulation
     nest.Simulate(sim_time)
+
+    # get STDP synapse and weight after protocol
     updated_weight = nest.GetStatus(syn)[0][weight_variable_name]
 
     actual_t_pre_sp = nest.GetStatus(spikedet_pre)[0]["events"]["times"][0]

--- a/tests/nest_tests/test_saturating_stdp.py
+++ b/tests/nest_tests/test_saturating_stdp.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# test_saturating_stdp.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+import os
+import pytest
+
+import nest
+
+from pynestml.codegeneration.nest_tools import NESTTools
+from pynestml.frontend.pynestml_frontend import generate_nest_target
+
+try:
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.ticker
+    import matplotlib.pyplot as plt
+    TEST_PLOTS = True
+except Exception:
+    TEST_PLOTS = False
+
+
+@pytest.mark.skipif(NESTTools.detect_nest_version().startswith("v2"),
+                    reason="This test does not support NEST 2")
+class TestSaturatingSTDP:
+
+    @pytest.fixture(autouse=True,
+                    scope="module")
+    def generate_model_code(self):
+        r"""Generate the NEST C++ code for neuron and synapse models"""
+
+        files = [os.path.join("models", "neurons", "iaf_psc_delta_neuron.nestml"),
+                 os.path.join("models", "neurons", "izhikevich_neuron.nestml"),
+                 os.path.join("tests", "nest_tests", "resources", "stdp_saturating_synapse.nestml")]
+        input_path = [os.path.realpath(os.path.join(os.path.dirname(__file__), os.path.join(
+            os.pardir, os.pardir, s))) for s in files]
+        generate_nest_target(input_path=input_path,
+                             logging_level="INFO",
+                             suffix="_nestml",
+                             codegen_opts={"neuron_synapse_pairs": [{"neuron": "iaf_psc_delta_neuron",
+                                                                     "synapse": "stdp_saturating_synapse",
+                                                                     "post_ports": ["post_spikes"]},
+                                                                    {"neuron": "izhikevich_neuron",
+                                                                     "synapse": "stdp_saturating_synapse",
+                                                                     "post_ports": ["post_spikes"]}],
+                                           "delay_variable": {"stdp_saturating_synapse": "d"},
+                                           "weight_variable": {"stdp_saturating_synapse": "w"}})
+
+    @pytest.mark.parametrize("neuron_model_name,synapse_model_name", [("iaf_psc_delta_neuron_nestml__with_stdp_saturating_synapse_nestml", "stdp_saturating_synapse_nestml__with_iaf_psc_delta_neuron_nestml"),
+                                                                      ("izhikevich_neuron_nestml__with_stdp_saturating_synapse_nestml", "stdp_saturating_synapse_nestml__with_izhikevich_neuron_nestml")])
+    def test_stdp_saturating_synapse(self, neuron_model_name: str, synapse_model_name: str, fname_snip: str = ""):
+        nest.ResetKernel()
+        nest.Install("nestmlmodule")
+        pre_sg = nest.Create("spike_generator", params={"spike_times": [1., 11., 21.]})
+
+        pre_neuron = nest.Create("parrot_neuron")
+        post_neuron = nest.Create(neuron_model_name)
+
+        nest.Connect(pre_sg, pre_neuron, "one_to_one", syn_spec={"delay": 1.})
+        nest.Connect(pre_neuron, post_neuron, "all_to_all", syn_spec={"synapse_model": synapse_model_name})
+
+        nest.Simulate(50.)


### PR DESCRIPTION
Adds an expression ``post_trace += foobar - .1 * post_trace`` where the right-hand side depends on parameters and variables that are moved from synapse to neuron by the co-generation transformer.