### PR TITLE
Fix matplotlib inline figures in notebooks

### DIFF
--- a/doc/tutorials/active_dendrite/nestml_active_dendrite_tutorial.ipynb
+++ b/doc/tutorials/active_dendrite/nestml_active_dendrite_tutorial.ipynb
@@ -309,7 +309,8 @@
     "            for _loc in [\"top\", \"right\", \"bottom\", \"left\"]:\n",
     "                _ax.spines[_loc].set_visible(False) # hide axis outline\n",
     "        for o in fig.findobj(): o.set_clip_on(False)  # disable clipping\n",
-    "        fig.show()\n",
+    "        plt.show()\n",
+    "        plt.close(fig)\n",
     "\n",
     "        return n_post_spikes"
    ]

--- a/doc/tutorials/inhomogeneous_poisson/inhomogeneous_poisson.ipynb
+++ b/doc/tutorials/inhomogeneous_poisson/inhomogeneous_poisson.ipynb
@@ -188,7 +188,8 @@
     "ax.set_xlim([0, num_steps * step_duration])\n",
     "ax.set_xlabel(\"Time [ms]\")\n",
     "ax.set_ylabel(\"Rate [s${}^{-1}$]\")\n",
-    "fig.show()"
+    "plt.show()\n",
+    "plt.close(fig)\n"
    ]
   },
   {
@@ -252,6 +253,7 @@
     "    ax12.set_ylabel(\"Rate [s${}^{-1}$]\")\n",
     "    ax12.set_xlabel(r\"Time [ms]\")\n",
     "    plt.show()\n",
+    "    plt.close(fig)\n",
     "\n",
     "    return activity[\"times\"], activity[\"senders\"]"
    ]

--- a/doc/tutorials/izhikevich/nestml_izhikevich_tutorial.ipynb
+++ b/doc/tutorials/izhikevich/nestml_izhikevich_tutorial.ipynb
@@ -224,7 +224,8 @@
     "ax[0].set_ylabel(\"v [mV]\")\n",
     "ax[1].set_ylabel(\"u\")\n",
     "ax[-1].set_xlabel(\"Time [ms]\")\n",
-    "fig.show()"
+    "plt.show()\n",
+    "plt.close(fig)\n"
    ]
   },
   {

--- a/doc/tutorials/ornstein_uhlenbeck_noise/nestml_ou_noise_tutorial.ipynb
+++ b/doc/tutorials/ornstein_uhlenbeck_noise/nestml_ou_noise_tutorial.ipynb
@@ -209,6 +209,8 @@
     "        ax.set_ylabel(\"U\")\n",
     "        ax.set_xlim(0., t_sim)\n",
     "        ax.grid()\n",
+    "        plt.show()\n",
+    "        plt.close(fig)\n",
     "    \n",
     "    return timevec, U"
    ]
@@ -482,7 +484,9 @@
     "ax.plot(lags, U_autocorr)\n",
     "ax.set_xlabel(\"Lag [ms]\")\n",
     "ax.set_ylabel(\"Autocorr[U]\")\n",
-    "ax.grid()"
+    "ax.grid()\n",
+    "plt.show()\n",
+    "plt.close(fig)\n"
    ]
   },
   {
@@ -652,6 +656,8 @@
     "        ax.set_xlabel(\"Time [ms]\")\n",
     "        ax.set_ylabel(\"V_m [mV]\")\n",
     "        ax.grid()\n",
+    "        plt.show()\n",
+    "        plt.close(fig)\n",
     "\n",
     "    return ts"
    ]
@@ -772,7 +778,9 @@
     "ax.set_ylim(ylim)\n",
     "ax.set_xlabel(\"ISI [ms]\")\n",
     "ax.set_ylabel(\"Count\")\n",
-    "ax.grid()"
+    "ax.grid()\n",
+    "plt.show()\n",
+    "plt.close(fig)\n"
    ]
   },
   {

--- a/doc/tutorials/spike_frequency_adaptation/nestml_spike_frequency_adaptation_tutorial.ipynb
+++ b/doc/tutorials/spike_frequency_adaptation/nestml_spike_frequency_adaptation_tutorial.ipynb
@@ -230,6 +230,8 @@
     "        ax.set_xlabel(\"Time [ms]\")\n",
     "        ax.set_ylabel(\"V_m [mV]\")\n",
     "        ax.grid()\n",
+    "        plt.show()\n",
+    "        plt.close(fig)\n",
     "\n",
     "    return ts"
    ]
@@ -655,7 +657,9 @@
     "        _ax.set_ylabel(\"Firing rate [Hz]\")\n",
     "\n",
     "    ax[0].set_xlabel(\"$I_{inj}$ [pA]\")\n",
-    "    plt.tight_layout()\n"
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "    plt.close(fig)\n"
    ]
   },
   {
@@ -932,7 +936,9 @@
     "ax.set_ylim(ylim)\n",
     "ax.set_xlabel(\"ISI [ms]\")\n",
     "ax.set_ylabel(\"Count\")\n",
-    "ax.grid()\n"
+    "ax.grid()\n",
+    "plt.show()\n",
+    "plt.close(fig)\n"
    ]
   },
   {
@@ -1062,7 +1068,9 @@
     "ax.set_xlabel(\"Firing rate [1/s]\")\n",
     "ax.set_ylabel(\"CV\")\n",
     "ax.legend()\n",
-    "ax.grid()"
+    "ax.grid()\n",
+    "plt.show()\n",
+    "plt.close(fig)\n"
    ]
   },
   {
@@ -1111,6 +1119,8 @@
     "        ax.plot(bin_centers, count, marker=\"o\")\n",
     "        ax.set_xlabel(\"$\\\\Delta$t [ms]\")\n",
     "        ax.grid()\n",
+    "        plt.show()\n",
+    "        plt.close(fig)\n",
     "\n",
     "    return bin_edges, count"
    ]

--- a/doc/tutorials/stdp_dopa_synapse/stdp_dopa_synapse.ipynb
+++ b/doc/tutorials/stdp_dopa_synapse/stdp_dopa_synapse.ipynb
@@ -461,7 +461,9 @@
     "\n",
     "ax.set_xlabel(\"Time of dopa spike [ms]\")\n",
     "ax.set_ylabel(\"Weight at $t = \\infty$\")\n",
-    "ax.legend()"
+    "ax.legend()\n",
+    "plt.show()\n",
+    "plt.close(fig)\n"
    ]
   },
   {
@@ -540,7 +542,9 @@
     "                ax[j].scatter(pos_dopa_spike_times, np.ones_like(pos_dopa_spike_times) * np.amin(trace_values[recordable][:, i]), marker=\"^\", c=\"green\", s=20)\n",
     "            if neg_dopa_spike_times is not None:\n",
     "                ax[j].scatter(neg_dopa_spike_times, np.ones_like(neg_dopa_spike_times) * np.amin(trace_values[recordable][:, i]), marker=\"^\", c=\"red\", s=20)\n",
-    "        fig.tight_layout(rect=[0, 0.03, 1, 0.95])"
+    "        fig.tight_layout(rect=[0, 0.03, 1, 0.95])\n",
+    "        plt.show()\n",
+    "        plt.close(fig)\n"
    ]
   },
   {
@@ -571,7 +575,8 @@
     "    ax.set_xlabel(\"Time [ms]\")\n",
     "    ax.set_ylabel(\"Neuron ID\")\n",
     "    plt.tight_layout()\n",
-    "    fig.show()"
+    "    plt.show()\n",
+    "    plt.close(fig)\n"
    ]
   },
   {
@@ -2029,7 +2034,9 @@
     "ax[0].set_xticklabels([])\n",
     "ax[-1].set_xlabel(\"Time [ms]\")\n",
     "for _ax in ax:\n",
-    "    _ax.set_xlim(0., total_t_sim)"
+    "    _ax.set_xlim(0., total_t_sim)\n",
+    "plt.show()\n",
+    "plt.close(fig)\n"
    ]
   },
   {
@@ -2065,7 +2072,8 @@
     "ax.set_ylabel(\"$V_m$ [mV]\")\n",
     "ax.set_xlabel(\"Time [ms]\")\n",
     "\n",
-    "None"
+    "plt.show()\n",
+    "plt.close(fig)\n"
    ]
   },
   {
@@ -2106,7 +2114,8 @@
     "ax.set_xlabel(\"Time [ms]\")\n",
     "ax.set_ylabel(\"Dopamine concentration [a.u.]\")\n",
     "\n",
-    "None"
+    "plt.show()\n",
+    "plt.close(fig)\n"
    ]
   },
   {
@@ -2144,7 +2153,8 @@
     "ax.set_ylabel(\"Eligibility trace\")\n",
     "ax.legend()\n",
     "\n",
-    "None"
+    "plt.show()\n",
+    "plt.close(fig)\n"
    ]
   },
   {
@@ -2179,7 +2189,8 @@
     "ax[0].set_xticklabels([])\n",
     "ax[0].set_ylabel(\"Average weight                                                                     \")\n",
     "\n",
-    "None"
+    "plt.show()\n",
+    "plt.close(fig)\n"
    ]
   },
   {
@@ -2237,7 +2248,8 @@
     "ax.set_xlabel(\"Time [ms]\")\n",
     "ax.legend()\n",
     "\n",
-    "None"
+    "plt.show()\n",
+    "plt.close(fig)\n"
    ]
   },
   {

--- a/doc/tutorials/stdp_third_factor_active_dendrite/stdp_third_factor_active_dendrite.ipynb
+++ b/doc/tutorials/stdp_third_factor_active_dendrite/stdp_third_factor_active_dendrite.ipynb
@@ -234,7 +234,8 @@
     "        _ax.grid(True)\n",
     "        _ax.set_xlim(0., sim_time)\n",
     "\n",
-    "    fig.savefig(\"/tmp/stdp_third_factor_synapse_test_ref.png\", dpi=300)"
+    "    plt.show()\n",
+    "    plt.close(fig)\n"
    ]
   },
   {
@@ -732,7 +733,8 @@
     "        _ax.grid(True)\n",
     "        _ax.set_xlim(0., sim_time)\n",
     "\n",
-    "    fig.savefig(\"/tmp/stdp_third_factor_synapse_test_ref_\" + fname_snip + \".png\", dpi=300)\n",
+    "    plt.show()\n",
+    "    plt.close(fig)\n",
     "\n",
     "    if validate:\n",
     "        # check that, at the time of each pre spike (because that's when NEST synapse update their state):\n",

--- a/doc/tutorials/stdp_windows/stdp_windows.ipynb
+++ b/doc/tutorials/stdp_windows/stdp_windows.ipynb
@@ -416,7 +416,9 @@
     "    ylim = ax.get_ylim()\n",
     "    ax.plot((np.amin(dt_vec), np.amax(dt_vec)), (0, 0), linestyle=\"--\", color=\"black\", linewidth=2, alpha=.5)\n",
     "    ax.plot((-delay, -delay), ylim, linestyle=\"--\", color=\"black\", linewidth=2, alpha=.5)\n",
-    "    ax.set_ylim(ylim)"
+    "    ax.set_ylim(ylim)\n",
+    "    plt.show()\n",
+    "    plt.close(fig)\n"
    ]
   },
   {

--- a/doc/tutorials/triplet_stdp_synapse/triplet_stdp_synapse.ipynb
+++ b/doc/tutorials/triplet_stdp_synapse/triplet_stdp_synapse.ipynb
@@ -808,7 +808,9 @@
     "lines = axes.get_lines()\n",
     "legend = plt.legend([lines[i] for i in [0,2]], [\"Nearest spike\", \"All-to-all\"])\n",
     "legend2 = plt.legend([ls1[0], ls2[0]], [r\"${\\Delta}t = 10ms$\", r\"${\\Delta}t = -10ms$\"], loc = 4)\n",
-    "axes.add_artist(legend)"
+    "axes.add_artist(legend)\n",
+    "plt.show()\n",
+    "plt.close(fig)\n"
    ]
   },
   {
@@ -886,7 +888,9 @@
     "l.append(post_spike_times)\n",
     "ax2.eventplot(l, colors=colors1)\n",
     "ax2.legend([\"post\", \"pre\"])\n",
-    "plt.tight_layout()"
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "plt.close(fig)\n"
    ]
   },
   {
@@ -1122,7 +1126,8 @@
     "axes.set_xticklabels(pre_post_pre_delays)\n",
     "axes.set_xlabel(r\"${(\\Delta{t_1}, \\Delta{t_2})} \\: [ms]$\")\n",
     "axes.set_ylabel(r\"${\\Delta}w$\")\n",
-    "plt.show()"
+    "plt.show()\n",
+    "plt.close(fig)\n"
    ]
   },
   {
@@ -1211,7 +1216,8 @@
     "axes.set_xticklabels(post_pre_post_delays)\n",
     "axes.set_xlabel(r\"${(\\Delta{t_1}, \\Delta{t_2})} \\: [ms]$\")\n",
     "axes.set_ylabel(r\"${\\Delta}w$\")\n",
-    "plt.show()"
+    "plt.show()\n",
+    "plt.close(fig)\n"
    ]
   },
   {


### PR DESCRIPTION
``%matplotlib inline`` was no longer showing figures on EBRAINS-lab notebooks. This PR seems to fix the problem.