### PR TITLE
Fix for Astropy 7.0.0

### DIFF
--- a/tests/valid/CoCoVariableWithSameNameAsUnit.nestml
+++ b/tests/valid/CoCoVariableWithSameNameAsUnit.nestml
@@ -32,4 +32,4 @@
 #
 model CoCoVariableWithSameNameAsUnit:
     state:
-        eV mV = 1 mV # should not conflict with predefined unit eV but throw a warning
+        m mV = 1 mV # should not conflict with predefined unit m but throw a warning


### PR DESCRIPTION
The eV unit was removed in Astropy 7, change example used for test.

See https://github.com/astropy/astropy/pull/17246.

(For some reason, our CI is still installing Astropy 6.0.1 for "pip install astropy", I'm not sure why it's not defaulting to the newest version. This is why this was not failing yet in CI.)