### PR TITLE
Relax sympy version requirement

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -14,7 +14,7 @@ sphinx-design
 # the following list is a direct copy from requirements.txt in the root directory (requirements for NESTML itself rather than for doc building)
 numpy >= 1.8.2
 scipy
-sympy >= 1.1.1,!= 1.11, != 1.11.1
+sympy
 antlr4-python3-runtime == 4.13.2
 setuptools
 Jinja2 >= 2.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # note: copy any changes to doc/requirements.txt
 numpy >= 1.8.2
 scipy
-sympy >= 1.1.1, <1.11
+sympy
 antlr4-python3-runtime == 4.13.2
 setuptools
 Jinja2 >= 2.10


### PR DESCRIPTION
Fixes #1063.

Thanks to https://github.com/nest/ode-toolbox/pull/70, we are no longer dependent on specific versions of sympy.