### PR TITLE
Remove unused ``module_name`` parameter from SpiNNaker code generator API

### DIFF
--- a/pynestml/frontend/pynestml_frontend.py
+++ b/pynestml/frontend/pynestml_frontend.py
@@ -329,7 +329,7 @@ def generate_python_standalone_target(input_path: Union[str, Sequence[str]], tar
 
 
 def generate_spinnaker_target(input_path: Union[str, Sequence[str]], target_path: Optional[str] = None, install_path: Optional[str] = None,
-                              logging_level="ERROR", module_name: str = "nestmlmodule", store_log: bool=False,
+                              logging_level="ERROR", store_log: bool=False,
                               suffix: str="", dev: bool=False, codegen_opts: Optional[Mapping[str, Any]]=None):
     r"""Generate and build code for the SpiNNaker target.
 
@@ -343,8 +343,6 @@ def generate_spinnaker_target(input_path: Union[str, Sequence[str]], target_path
         Path to the directory where the generated code will be installed.
     logging_level : str, optional (default: "ERROR")
         Sets which level of information should be displayed duing code generation (among "ERROR", "WARNING", "INFO", or "NO").
-    module_name : str, optional (default: "nestmlmodule")
-        The name of the generated Python module.
     store_log : bool, optional (default: False)
         Whether the log should be saved to file.
     suffix : str, optional (default: "")
@@ -356,7 +354,7 @@ def generate_spinnaker_target(input_path: Union[str, Sequence[str]], target_path
     """
     generate_target(input_path, target_platform="spinnaker", target_path=target_path,
                     install_path=install_path,
-                    logging_level=logging_level, module_name=module_name, store_log=store_log, suffix=suffix, dev=dev,
+                    logging_level=logging_level, module_name="nestmlmodule", store_log=store_log, suffix=suffix, dev=dev,
                     codegen_opts=codegen_opts)
 
 

--- a/pynestml/frontend/pynestml_frontend.py
+++ b/pynestml/frontend/pynestml_frontend.py
@@ -354,7 +354,7 @@ def generate_spinnaker_target(input_path: Union[str, Sequence[str]], target_path
     """
 
     # removed module_name from generate_spinnaker_target() arguments because it is not directly needed for the Jinja templates at the end of the pipeline
-    # but still added to generate_target() to surpress following warning: [5,GLOBAL, INFO]: No module name specified; the generated module will be named "nestmlmodule"
+    # but still added to generate_target() to surpress following log: [5,GLOBAL, INFO]: No module name specified; the generated module will be named "nestmlmodule"
 
     generate_target(input_path, target_platform="spinnaker", target_path=target_path,
                     install_path=install_path,

--- a/pynestml/frontend/pynestml_frontend.py
+++ b/pynestml/frontend/pynestml_frontend.py
@@ -353,7 +353,8 @@ def generate_spinnaker_target(input_path: Union[str, Sequence[str]], target_path
         A dictionary containing additional options for the target code generator.
     """
 
-    #removed module_name from generate_spinnaker_target() arguments because it is not directly needed for the Jinja templates at the end of the pipeline
+    # removed module_name from generate_spinnaker_target() arguments because it is not directly needed for the Jinja templates at the end of the pipeline
+    # but still added to generate_target() to surpress following warning: [5,GLOBAL, INFO]: No module name specified; the generated module will be named "nestmlmodule"
 
     generate_target(input_path, target_platform="spinnaker", target_path=target_path,
                     install_path=install_path,

--- a/pynestml/frontend/pynestml_frontend.py
+++ b/pynestml/frontend/pynestml_frontend.py
@@ -356,7 +356,7 @@ def generate_spinnaker_target(input_path: Union[str, Sequence[str]], target_path
     """
     generate_target(input_path, target_platform="spinnaker", target_path=target_path,
                     install_path=install_path,
-                    logging_level=logging_level, store_log=store_log, suffix=suffix, dev=dev,
+                    logging_level=logging_level, module_name=module_name, store_log=store_log, suffix=suffix, dev=dev,
                     codegen_opts=codegen_opts)
 
 

--- a/pynestml/frontend/pynestml_frontend.py
+++ b/pynestml/frontend/pynestml_frontend.py
@@ -352,6 +352,9 @@ def generate_spinnaker_target(input_path: Union[str, Sequence[str]], target_path
     codegen_opts : Optional[Mapping[str, Any]]
         A dictionary containing additional options for the target code generator.
     """
+
+    #removed module_name from generate_spinnaker_target() arguments because it is not directly needed for the Jinja templates at the end of the pipeline
+
     generate_target(input_path, target_platform="spinnaker", target_path=target_path,
                     install_path=install_path,
                     logging_level=logging_level, module_name="nestmlmodule", store_log=store_log, suffix=suffix, dev=dev,

--- a/tests/spinnaker_tests/test_spinnaker_iaf_psc_exp.py
+++ b/tests/spinnaker_tests/test_spinnaker_iaf_psc_exp.py
@@ -44,13 +44,11 @@ class TestSpiNNakerIafPscExp:
         target_path = "spinnaker-target"
         install_path = "spinnaker-install"
         logging_level = "DEBUG"
-        module_name = "nestmlmodule"
         suffix = "_nestml"
         generate_spinnaker_target(input_path,
                                   target_path=target_path,
                                   install_path=install_path,
                                   logging_level=logging_level,
-                                  module_name=module_name,
                                   suffix=suffix)
         #                          codegen_opts=codegen_opts)
 


### PR DESCRIPTION
Added module_name to generate_target() parameters within generate_spinnaker_target(), due following error when generating spinnaker-target-code:
[5,GLOBAL, INFO]: No module name specified; the generated module will be named "nestmlmodule"