### PR TITLE
Fix gap junctions in the case that integrate_odes() is called with no arguments

### DIFF
--- a/pynestml/codegeneration/resources_nest/point_neuron/directives_cpp/GSLDifferentiationFunction.jinja2
+++ b/pynestml/codegeneration/resources_nest/point_neuron/directives_cpp/GSLDifferentiationFunction.jinja2
@@ -62,7 +62,7 @@ extern "C" inline int {{neuronName}}_dynamics{% if ast.get_args() | length > 0 %
 {%-   set update_expr = numeric_update_expressions[variable_name] %}
 {%-   set variable_symbol = variable_symbols[variable_name] %}
 {%- if use_gap_junctions %}
-  f[State_::{{ variable_symbol.get_symbol_name() }}] = {% if ast.get_args() | length > 0 %}{% if variable_name in numeric_state_variables_to_be_integrated + utils.all_convolution_variable_names(astnode) %}{{ gsl_printer.print(update_expr)|replace("node.B_.continuous_inputs_grid_sum_[" + gap_junction_port.upper() + "]", "(node.B_.continuous_inputs_grid_sum_[" + gap_junction_port.upper() + "] + __I_gap)") }}{% else %}0{% endif %}{% else %}{{ gsl_printer.print(update_expr) }}{% endif %};
+  f[State_::{{ variable_symbol.get_symbol_name() }}] = {% if ast.get_args() | length > 0 %}{% if variable_name in numeric_state_variables_to_be_integrated + utils.all_convolution_variable_names(astnode) %}{{ gsl_printer.print(update_expr)|replace("node.B_.continuous_inputs_grid_sum_[" + gap_junction_port.upper() + "]", "(node.B_.continuous_inputs_grid_sum_[" + gap_junction_port.upper() + "] + __I_gap)") }}{% else %}0{% endif %}{% else %}{{ gsl_printer.print(update_expr)|replace("node.B_.continuous_inputs_grid_sum_[" + gap_junction_port.upper() + "]", "(node.B_.continuous_inputs_grid_sum_[" + gap_junction_port.upper() + "] + __I_gap)") }}{% endif %};
 {%- else %}
   f[State_::{{ variable_symbol.get_symbol_name() }}] = {% if ast.get_args() | length > 0 %}{% if variable_name in numeric_state_variables_to_be_integrated + utils.all_convolution_variable_names(astnode) %}{{ gsl_printer.print(update_expr) }}{% else %}0{% endif %}{% else %}{{ gsl_printer.print(update_expr) }}{% endif %};
 {%- endif %}

--- a/tests/nest_tests/resources/aeif_cond_beta_neuron.nestml
+++ b/tests/nest_tests/resources/aeif_cond_beta_neuron.nestml
@@ -1,0 +1,119 @@
+# aeif_cond_beta - Conductance based exponential integrate-and-fire neuron model
+###############################################################################
+#
+# Description
+# +++++++++++
+#
+# A version of the aeif_cond_beta neuron model that contains an ``integrate_odes()`` call without arguments. For testing gap junction code generation.
+#
+#
+# Copyright statement
+# +++++++++++++++++++
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+#
+model aeif_cond_beta_neuron:
+
+    state:
+        V_m mV = E_L       # Membrane potential
+        w pA = 0 pA        # Spike-adaptation current
+        r integer = 0      # Counts number of tick during the refractory period
+
+        # inputs from the inhibitory conductance
+        g_in real = 0
+        g_in$ real = g_I_const * (1 / tau_syn_rise_I - 1 / tau_syn_decay_I)
+
+        # inputs from the excitatory conductance
+        g_ex real = 0
+        g_ex$ real = g_E_const * (1 / tau_syn_rise_E - 1 / tau_syn_decay_E)
+
+    equations:
+        inline V_bounded mV = min(V_m, V_peak) # prevent exponential divergence
+        kernel g_in' = g_in$ - g_in / tau_syn_rise_I,
+               g_in$' = -g_in$ / tau_syn_decay_I
+
+        kernel g_ex' = g_ex$ - g_ex / tau_syn_rise_E,
+               g_ex$' = -g_ex$ / tau_syn_decay_E
+
+        # Add inlines to simplify the equation definition of V_m
+        inline exp_arg real = (V_bounded - V_th) / Delta_T
+        inline I_spike pA = g_L * Delta_T * exp(exp_arg)
+        inline I_syn_exc pA = convolve(g_ex, exc_spikes) * nS * (V_bounded - E_exc)
+        inline I_syn_inh pA = convolve(g_in, inh_spikes) * nS * (V_bounded - E_inh)
+
+        V_m' = (-g_L * (V_bounded - E_L) + I_spike - I_syn_exc - I_syn_inh - w + I_e + I_stim) / C_m
+        w' = (a * (V_bounded - E_L) - w) / tau_w
+
+    parameters:
+        # membrane parameters
+        C_m pF = 281.0 pF         # Membrane Capacitance
+        t_ref ms = 0.0 ms         # Refractory period
+        V_reset mV = -60.0 mV     # Reset Potential
+        g_L nS = 30.0 nS          # Leak Conductance
+        E_L mV = -70.6 mV         # Leak reversal Potential (aka resting potential)
+
+        # spike adaptation parameters
+        a nS = 4 nS               # Subthreshold adaptation
+        b pA = 80.5 pA            # Spike-triggered adaptation
+        Delta_T mV = 2.0 mV       # Slope factor
+        tau_w ms = 144.0 ms       # Adaptation time constant
+        V_th mV = -50.4 mV        # Threshold Potential
+        V_peak mV = 0 mV          # Spike detection threshold
+
+        # synaptic parameters
+        E_exc mV = 0 mV            # Excitatory reversal Potential
+        E_inh mV = -85.0 mV        # Inhibitory reversal Potential
+        tau_syn_rise_I ms = .2 ms    # Synaptic time constant inhibitory synapse
+        tau_syn_decay_I ms = 2 ms    # Synaptic time constant for inhibitory synapse
+        tau_syn_rise_E ms = .2 ms    # Synaptic time constant excitatory synapse
+        tau_syn_decay_E ms = 2 ms    # Synaptic time constant for excitatory synapse
+
+        # constant external input current
+        I_e pA = 0 pA
+
+    internals:
+        # time of peak conductance excursion after spike arrival at t = 0
+        t_peak_E real = tau_syn_decay_E * tau_syn_rise_E * ln(tau_syn_decay_E / tau_syn_rise_E) / (tau_syn_decay_E - tau_syn_rise_E)
+        t_peak_I real = tau_syn_decay_I * tau_syn_rise_I * ln(tau_syn_decay_I / tau_syn_rise_I) / (tau_syn_decay_I - tau_syn_rise_I)
+
+        # normalisation constants to ensure arriving spike yields peak conductance of 1 nS
+        g_E_const real = 1 / (exp(-t_peak_E / tau_syn_decay_E) - exp(-t_peak_E / tau_syn_rise_E))
+        g_I_const real = 1 / (exp(-t_peak_I / tau_syn_decay_I) - exp(-t_peak_I / tau_syn_rise_I))
+
+        # refractory time in steps
+        RefractoryCounts integer = steps(t_ref)
+
+    input:
+        inh_spikes <- inhibitory spike
+        exc_spikes <- excitatory spike
+        I_stim pA <- continuous
+
+    output:
+        spike
+
+    update:
+        integrate_odes()
+
+        if r > 0: # refractory
+            r -= 1 # decrement refractory ticks count
+            V_m = V_reset # clamp potential
+        elif V_m >= V_peak: # threshold crossing detection
+            r = RefractoryCounts
+            V_m = V_reset # clamp potential
+            w += b
+            emit_spike()

--- a/tests/nest_tests/test_gap_junction.py
+++ b/tests/nest_tests/test_gap_junction.py
@@ -43,20 +43,22 @@ except Exception:
 @pytest.mark.skipif(NESTTools.detect_nest_version().startswith("v2"),
                     reason="This test does not support NEST 2")
 class TestGapJunction:
-    r"""Test code generation and perform simulations and numerical checks for gap junction support in linear and non-linear neuron models"""
+    r"""Test code generation and perform simulations and numerical checks for gap junction support in linear and non-linear neuron models. aeif_cond_beta_neuron is included to test for a case where integrate_odes() is called with no arguments."""
 
-    @pytest.mark.parametrize("neuron_model", ["iaf_psc_exp_neuron", "aeif_cond_exp_neuron"])
-    def test_gap_junction_effect_on_membrane_potential(self, neuron_model: str):
-        self.generate_code(neuron_model)
+    @pytest.mark.parametrize("neuron_model_path, neuron_model", [("models/neurons", "iaf_psc_exp_neuron"),
+                                                                 ("models/neurons", "aeif_cond_exp_neuron"),
+                                                                 ("tests/nest_tests/resources", "aeif_cond_beta_neuron")])
+    def test_gap_junction_effect_on_membrane_potential(self, neuron_model_path: str, neuron_model: str):
+        self.generate_code(neuron_model_path, neuron_model)
         for wfr_interpolation_order in [0, 1, 3]:
             self._test_gap_junction_effect_on_membrane_potential(neuron_model, wfr_interpolation_order)
 
-    def generate_code(self, neuron_model: str):
+    def generate_code(self, neuron_model_path: str, neuron_model: str):
         codegen_opts = {"gap_junctions": {"enable": True,
                                           "gap_current_port": "I_stim",
                                           "membrane_potential_variable": "V_m"}}
 
-        files = [os.path.join("models", "neurons", neuron_model + ".nestml")]
+        files = [os.path.join(*os.path.split(neuron_model_path), neuron_model + ".nestml")]
         input_path = [os.path.realpath(os.path.join(os.path.dirname(__file__), os.path.join(os.pardir, os.pardir, s))) for s in files]
         generate_nest_target(input_path=input_path,
                              logging_level="WARNING",


### PR DESCRIPTION
Replaces #1261.

Fixes #1259.