### PR TITLE
Run unit tests in a separate CI stage

### DIFF
--- a/.github/workflows/nestml-build.yml
+++ b/.github/workflows/nestml-build.yml
@@ -73,15 +73,6 @@ jobs:
 
       - name: Check that generated lexer and parser code is identical
         run: |
-          echo "pynestml/generated/PyNestMLLexer.py"
-          cat pynestml/generated/PyNestMLLexer.py
-          echo "pynestml/generated/PyNestMLLexer.p_"
-          cat pynestml/generated/PyNestMLLexer.p_
-          echo "pynestml/generated/PyNestMLParser.py"
-          cat pynestml/generated/PyNestMLParser.py
-          echo "pynestml/generated/PyNestMLParser.p_"
-          cat pynestml/generated/PyNestMLParser.p_
-          
           cmp -s pynestml/generated/PyNestMLLexer.py pynestml/generated/PyNestMLLexer.p_
           cmp -s pynestml/generated/PyNestMLParser.py pynestml/generated/PyNestMLParser.p_
 


### PR DESCRIPTION
Unit tests are simulator-independent, but are currently running redundantly for each NEST Simulator version. This PR moves the unit tests into their own separate CI stage.