### PR TITLE
Remove redundant debug flag

### DIFF
--- a/pynestml/codegeneration/resources_nest/point_neuron/common/NeuronClass.jinja2
+++ b/pynestml/codegeneration/resources_nest/point_neuron/common/NeuronClass.jinja2
@@ -69,8 +69,6 @@ along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "{{ neuronName }}.h"
 
-// uncomment the next line to enable printing of detailed debug information
-// #define DEBUG
 
 {%- if state_vars_that_need_continuous_buffering | length > 0 %}
 {%-     if continuous_state_buffering_method == "continuous_time_buffer" %}


### PR DESCRIPTION
The ``DEBUG`` C++ preprocessor flag is already defined in {{ neuronName }}.h, which is #included from {{ neuronName }}.cpp. This PR removes the redundant flag from the latter cpp file.