### PR TITLE
CoCos test should invoke CoCosManager to run CoCos

### DIFF
--- a/tests/test_cocos.py
+++ b/tests/test_cocos.py
@@ -89,7 +89,7 @@ class TestCoCos:
     def test_variable_with_same_name_as_unit(self):
         Logger.set_logging_level(LoggingLevel.NO)
         model = self._parse_and_validate_model(os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), "valid")), "CoCoVariableWithSameNameAsUnit.nestml"))
-        assert len(Logger.get_messages(model, LoggingLevel.WARNING)) == 3
+        assert len(Logger.get_messages(model, LoggingLevel.WARNING)) == 6
 
     def test_invalid_variable_redeclaration(self):
         model = self._parse_and_validate_model(os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), "invalid")), "CoCoVariableRedeclared.nestml"))
@@ -241,7 +241,7 @@ class TestCoCos:
 
     def test_invalid_init_values_have_rhs_and_ode(self):
         model = self._parse_and_validate_model(os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), "invalid")), "CoCoInitValuesWithoutOde.nestml"))
-        assert len(Logger.get_messages(model, LoggingLevel.WARNING)) == 2
+        assert len(Logger.get_messages(model, LoggingLevel.WARNING)) == 4
 
     def test_valid_init_values_have_rhs_and_ode(self):
         model = self._parse_and_validate_model(os.path.join(os.path.realpath(os.path.join(os.path.dirname(__file__), "valid")), "CoCoInitValuesWithoutOde.nestml"))


### PR DESCRIPTION
The CoCos test strangely does not invoke the CoCosManager to run the CoCo tests. This PR fixes that so that the proper number of warning and error messages can be detected.