### PR TITLE
Eliminate debug messages from matplotlib in tests

### DIFF
--- a/pynestml/codegeneration/autodoc_builder.py
+++ b/pynestml/codegeneration/autodoc_builder.py
@@ -21,7 +21,6 @@
 
 from typing import Optional, Mapping, Any
 
-import matplotlib.pyplot as plt
 import numpy as np
 import os
 import re
@@ -100,6 +99,7 @@ class AutodocBuilder(Builder):
     def _test_model_current_pulse(self, model_name, I_min=-100E-12, I_max=500E-12, N=6,
                                   model_opts=None, model_initial_state=None):
         r"""Make current pulse curve"""
+        import matplotlib.pyplot as plt
         import nest
 
         t_stop = 125.1    # [ms]
@@ -162,6 +162,7 @@ class AutodocBuilder(Builder):
 
     def _test_model_fI_curve(self, model_name, model_opts=None, model_initial_state=None):
         r"""Make f-I curve"""
+        import matplotlib.pyplot as plt
         import nest
 
         t_stop = 10000.  # [ms]
@@ -217,6 +218,7 @@ class AutodocBuilder(Builder):
 
     def _test_model_psp(self, model_name, max_weight: float = 10., model_opts=None,
                         model_initial_state=None):
+        import matplotlib.pyplot as plt
         import nest
 
         nest.ResetKernel()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,6 @@ import logging
 
 def pytest_configure(config):
     # prevent matplotlib and other packages from printing a lot of debug messages when NESTML is running in DEBUG logging_level
-    logging.getLogger('matplotlib').setLevel(logging.WARNING)
-    logging.getLogger('graphviz').setLevel(logging.WARNING)
-    logging.getLogger('PIL').setLevel(logging.WARNING)
+    logging.getLogger('matplotlib').setLevel(logging.ERROR)
+    logging.getLogger('graphviz').setLevel(logging.ERROR)
+    logging.getLogger('PIL').setLevel(logging.ERROR)

--- a/tests/nest_continuous_benchmarking/test_nest_continuous_benchmarking.py
+++ b/tests/nest_continuous_benchmarking/test_nest_continuous_benchmarking.py
@@ -27,13 +27,13 @@ import nest
 
 from pynestml.frontend.pynestml_frontend import generate_nest_target
 
+# try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import matplotlib
-    matplotlib.use('Agg')
-    import matplotlib.ticker
+    import matplotlib as mpl
+    mpl.use("agg")
     import matplotlib.pyplot as plt
     TEST_PLOTS = True
-except Exception:
+except BaseException:
     TEST_PLOTS = False
 
 sim_mdl = True
@@ -301,7 +301,7 @@ class TestNESTContinuousBenchmarking:
             ax3.set_ylabel("w")
             for _ax in ax:
                 _ax.grid(which="major", axis="both")
-                _ax.xaxis.set_major_locator(matplotlib.ticker.FixedLocator(np.arange(0, np.ceil(sim_time))))
+                _ax.xaxis.set_major_locator(mpl.ticker.FixedLocator(np.arange(0, np.ceil(sim_time))))
                 _ax.set_xlim(0., sim_time)
                 _ax.legend()
             fig.savefig("/tmp/stdp_synapse_test" + fname_snip + ".png", dpi=300)

--- a/tests/nest_tests/fir_filter_test.py
+++ b/tests/nest_tests/fir_filter_test.py
@@ -29,7 +29,6 @@ import unittest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/nest_custom_templates_test.py
+++ b/tests/nest_tests/nest_custom_templates_test.py
@@ -25,7 +25,6 @@ import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/nest_delay_based_variables_test.py
+++ b/tests/nest_tests/nest_delay_based_variables_test.py
@@ -27,7 +27,6 @@ import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/nest_integration_test.py
+++ b/tests/nest_tests/nest_integration_test.py
@@ -27,7 +27,6 @@ import nest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/nest_split_simulation_test.py
+++ b/tests/nest_tests/nest_split_simulation_test.py
@@ -26,7 +26,6 @@ import unittest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/neuron_ou_conductance_noise_test.py
+++ b/tests/nest_tests/neuron_ou_conductance_noise_test.py
@@ -26,7 +26,6 @@ import unittest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/noisy_synapse_test.py
+++ b/tests/nest_tests/noisy_synapse_test.py
@@ -26,7 +26,6 @@ import unittest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/non_linear_dendrite_test.py
+++ b/tests/nest_tests/non_linear_dendrite_test.py
@@ -26,7 +26,6 @@ import unittest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/recordable_variables_test.py
+++ b/tests/nest_tests/recordable_variables_test.py
@@ -25,7 +25,6 @@ import os
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/stdp_neuromod_test.py
+++ b/tests/nest_tests/stdp_neuromod_test.py
@@ -26,7 +26,6 @@ import unittest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt
@@ -332,7 +331,7 @@ class NestSTDPNeuromodTest(unittest.TestCase):
 
             for _ax in ax:
                 _ax.grid(which="major", axis="both")
-                _ax.xaxis.set_major_locator(matplotlib.ticker.FixedLocator(np.arange(0, np.ceil(sim_time))))
+                _ax.xaxis.set_major_locator(mpl.ticker.FixedLocator(np.arange(0, np.ceil(sim_time))))
                 _ax.set_xlim(0., sim_time)
                 _ax.legend()
             fig.savefig("/tmp/stdp_dopa_synapse_test" + fname_snip + ".png", dpi=300)

--- a/tests/nest_tests/stdp_nn_pre_centered_test.py
+++ b/tests/nest_tests/stdp_nn_pre_centered_test.py
@@ -26,7 +26,6 @@ import unittest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt
@@ -304,7 +303,7 @@ class NestSTDPNNSynapseTest(unittest.TestCase):
             ax3.set_ylabel("w")
             for _ax in ax:
                 _ax.grid(which="major", axis="both")
-                _ax.xaxis.set_major_locator(matplotlib.ticker.FixedLocator(np.arange(0, np.ceil(sim_time))))
+                _ax.xaxis.set_major_locator(mpl.ticker.FixedLocator(np.arange(0, np.ceil(sim_time))))
                 _ax.set_xlim(0., sim_time)
                 _ax.legend()
             fig.savefig("/tmp/stdp_synapse_test" + fname_snip + ".png", dpi=300)

--- a/tests/nest_tests/stdp_nn_restr_symm_test.py
+++ b/tests/nest_tests/stdp_nn_restr_symm_test.py
@@ -26,7 +26,6 @@ import unittest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt
@@ -304,7 +303,7 @@ class NestSTDPNNRestrSymmSynapseTest(unittest.TestCase):
             ax3.set_ylabel("w")
             for _ax in ax:
                 _ax.grid(which="major", axis="both")
-                _ax.xaxis.set_major_locator(matplotlib.ticker.FixedLocator(np.arange(0, np.ceil(sim_time))))
+                _ax.xaxis.set_major_locator(mpl.ticker.FixedLocator(np.arange(0, np.ceil(sim_time))))
                 _ax.set_xlim(0., sim_time)
                 _ax.legend()
             fig.savefig("/tmp/stdp_nn_restr_symm_synapse_test" + fname_snip + ".png", dpi=300)

--- a/tests/nest_tests/stdp_nn_synapse_test.py
+++ b/tests/nest_tests/stdp_nn_synapse_test.py
@@ -26,7 +26,6 @@ import unittest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt
@@ -302,7 +301,7 @@ class NestSTDPNNSynapseTest(unittest.TestCase):
             ax3.set_ylabel("w")
             for _ax in ax:
                 _ax.grid(which="major", axis="both")
-                _ax.xaxis.set_major_locator(matplotlib.ticker.FixedLocator(np.arange(0, np.ceil(sim_time))))
+                _ax.xaxis.set_major_locator(mpl.ticker.FixedLocator(np.arange(0, np.ceil(sim_time))))
                 _ax.set_xlim(0., sim_time)
                 _ax.legend()
             fig.savefig("/tmp/stdp_synapse_test" + fname_snip + ".png", dpi=300)

--- a/tests/nest_tests/stdp_synapse_test.py
+++ b/tests/nest_tests/stdp_synapse_test.py
@@ -27,7 +27,6 @@ import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt
@@ -352,7 +351,7 @@ class TestNestSTDPSynapse:
             ax3.set_ylabel("w")
             for _ax in ax:
                 _ax.grid(which="major", axis="both")
-                _ax.xaxis.set_major_locator(matplotlib.ticker.FixedLocator(np.arange(0, np.ceil(sim_time))))
+                _ax.xaxis.set_major_locator(mpl.ticker.FixedLocator(np.arange(0, np.ceil(sim_time))))
                 _ax.set_xlim(0., sim_time)
                 _ax.legend()
             fig.savefig("/tmp/stdp_synapse_test" + fname_snip + ".png", dpi=300)

--- a/tests/nest_tests/stdp_triplet_synapse_test.py
+++ b/tests/nest_tests/stdp_triplet_synapse_test.py
@@ -19,14 +19,12 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-import logging
 import numpy as np
 import os
 import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt
@@ -333,7 +331,7 @@ def plot_comparison(syn_opts, times_spikes_pre, times_spikes_post, times_spikes_
     for _ax in ax:
         _ax.grid(True)
         _ax.set_xlim(0., sim_time)
-        _ax.xaxis.set_major_locator(matplotlib.ticker.FixedLocator(np.arange(0, np.ceil(sim_time))))
+        _ax.xaxis.set_major_locator(mpl.ticker.FixedLocator(np.arange(0, np.ceil(sim_time))))
         if not _ax == ax[-1]:
             _ax.set_xticklabels([])
 

--- a/tests/nest_tests/stdp_window_test.py
+++ b/tests/nest_tests/stdp_window_test.py
@@ -25,7 +25,6 @@ import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/terub_stn_test.py
+++ b/tests/nest_tests/terub_stn_test.py
@@ -25,7 +25,6 @@ import numpy as np
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_biexponential_synapse_kernel.py
+++ b/tests/nest_tests/test_biexponential_synapse_kernel.py
@@ -25,7 +25,6 @@ import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_co_generation_static_synapse.py
+++ b/tests/nest_tests/test_co_generation_static_synapse.py
@@ -23,7 +23,6 @@ import os
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_delta_kernel.p_
+++ b/tests/nest_tests/test_delta_kernel.p_
@@ -25,7 +25,6 @@ import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_dopa_second_order_synapse.py
+++ b/tests/nest_tests/test_dopa_second_order_synapse.py
@@ -25,7 +25,6 @@ import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_gap_junction.py
+++ b/tests/nest_tests/test_gap_junction.py
@@ -27,7 +27,6 @@ import scipy.signal
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_gap_junction_get_set_weight.py
+++ b/tests/nest_tests/test_gap_junction_get_set_weight.py
@@ -25,7 +25,6 @@ import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_homogeneous_parameters_synapse.py
+++ b/tests/nest_tests/test_homogeneous_parameters_synapse.py
@@ -25,7 +25,6 @@ import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_ignore_and_fire.py
+++ b/tests/nest_tests/test_ignore_and_fire.py
@@ -25,7 +25,6 @@ import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_integrate_odes.py
+++ b/tests/nest_tests/test_integrate_odes.py
@@ -27,7 +27,6 @@ import scipy.signal
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_minimal_stdp_neuron.py
+++ b/tests/nest_tests/test_minimal_stdp_neuron.py
@@ -27,7 +27,6 @@ import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_multisynapse.py
+++ b/tests/nest_tests/test_multisynapse.py
@@ -26,7 +26,6 @@ import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_plastic_synapse_weight_sign.py
+++ b/tests/nest_tests/test_plastic_synapse_weight_sign.py
@@ -27,7 +27,6 @@ import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_plasticity_dynamics.py
+++ b/tests/nest_tests/test_plasticity_dynamics.py
@@ -26,7 +26,6 @@ import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_priority_neuron.py
+++ b/tests/nest_tests/test_priority_neuron.py
@@ -25,7 +25,6 @@ import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_priority_synapse.py
+++ b/tests/nest_tests/test_priority_synapse.py
@@ -25,7 +25,6 @@ import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_saturating_stdp.py
+++ b/tests/nest_tests/test_saturating_stdp.py
@@ -24,7 +24,6 @@ import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_simultaneous_continuous_and_spike_based_neuromodulation.py
+++ b/tests/nest_tests/test_simultaneous_continuous_and_spike_based_neuromodulation.py
@@ -25,7 +25,6 @@ import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_synapse_continuous_third_factor_is_postsynaptic_inline_expression.py
+++ b/tests/nest_tests/test_synapse_continuous_third_factor_is_postsynaptic_inline_expression.py
@@ -25,7 +25,6 @@ import pytest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_synapse_numeric_solver.py
+++ b/tests/nest_tests/test_synapse_numeric_solver.py
@@ -26,7 +26,6 @@ from scipy.integrate import solve_ivp
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_time_variable.py
+++ b/tests/nest_tests/test_time_variable.py
@@ -26,7 +26,6 @@ import scipy.signal
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_traub_cond_multisyn.py
+++ b/tests/nest_tests/test_traub_cond_multisyn.py
@@ -23,7 +23,6 @@ import os
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/test_wb_cond_multisyn.py
+++ b/tests/nest_tests/test_wb_cond_multisyn.py
@@ -24,7 +24,6 @@ import os
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/traub_psc_alpha_test.py
+++ b/tests/nest_tests/traub_psc_alpha_test.py
@@ -25,7 +25,6 @@ import unittest
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt

--- a/tests/nest_tests/wb_cond_exp_test.py
+++ b/tests/nest_tests/wb_cond_exp_test.py
@@ -25,7 +25,6 @@ import numpy as np
 
 # try to import matplotlib; set the result in the flag TEST_PLOTS
 try:
-    import logging
     import matplotlib as mpl
     mpl.use("agg")
     import matplotlib.pyplot as plt


### PR DESCRIPTION
Matplotlib produces a huge amount of debug log messages. This PR changes the matplotlib logger level to WARNING internally, and cleans up the imports.