### PR TITLE
Remove NEST 2 from Github Actions CI

### DIFF
--- a/.github/workflows/nestml-build.yml
+++ b/.github/workflows/nestml-build.yml
@@ -199,7 +199,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nest_branch: ["v2.20.2", "v3.0", "v3.9", "master"]
+        nest_branch: ["v3.0", "v3.9", "master"]
       fail-fast: false
     steps:
       - name: Checkout repository contents


### PR DESCRIPTION
A corresponding issue already exists; see #1267. While discussions about continued support for NEST 2 are ongoing, I will leave that issue open.