### PR TITLE
Update installation instructions for NESTML

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -34,13 +34,8 @@ Then update the index and install the necessary packages:
 
    sudo apt update
    sudo apt install nest python3-nestml
-   python3 -m pip install --upgrade odetoolbox pygsl antlr4-python3-runtime==4.10
-
-Before running NEST or NESTML, make sure the correct environment variables are set by running the following command:
-
-.. code-block:: bash
-
-   source /usr/bin/nest_vars.sh
+   wget https://raw.githubusercontent.com/nest/nestml/refs/heads/master/requirements.txt
+   python3 -m pip install -r requirements.txt
 
 
 Installing the latest development version from GitHub


### PR DESCRIPTION
Download ``requirements.txt`` from the GitHub repository to make sure requirements are up-to-date.

Remove the requirement for sourcing ``nest_vars.sh`` as this file is removed in PyNEST-NG (see https://github.com/nest/nest-simulator/issues/3740).