### PR TITLE
Code generator performance optimisation

### DIFF
--- a/pynestml/codegeneration/nest_builder.py
+++ b/pynestml/codegeneration/nest_builder.py
@@ -94,10 +94,7 @@ class NESTBuilder(Builder):
                 Logger.log_message(None, -1, "An error occurred while importing the `nest` module in Python. Please check your NEST installation-related environment variables and paths, or specify ``nest_path`` manually in the code generator options.", None, LoggingLevel.ERROR)
                 sys.exit(1)
 
-            nest_version = NESTTools.detect_nest_version()
-            nest_version_dict = NESTTools.get_version_dict_from_version_string(nest_version)
-            if nest_version.startswith("main") \
-                    or (nest_version_dict and (nest_version_dict["major"] == 3 and nest_version_dict["minor"] >= 10) or nest_version_dict["major"] > 3):
+            if "build_info" in dir(nest):
                 nest_path = nest.build_info["prefix"]
             else:
                 nest_path = nest.ll_api.sli_func("statusdict/prefix ::")

--- a/pynestml/meta_model/ast_model.py
+++ b/pynestml/meta_model/ast_model.py
@@ -454,7 +454,7 @@ class ASTModel(ASTNode):
         update_block = ASTNodeFactory.create_ast_update_block(block, ASTSourceLocation.get_predefined_source_position())
         self.get_body().get_body_elements().append(update_block)
 
-    def add_to_internals_block(self, declaration: ASTDeclaration, index: int = -1) -> None:
+    def add_to_internals_block(self, declaration: ASTDeclaration, index: int = -1, run_symboltable_visitor: bool = True) -> None:
         """
         Adds the handed over declaration the internals block
         :param declaration: a single declaration
@@ -476,11 +476,11 @@ class ASTModel(ASTNode):
 
         self.get_internals_blocks()[0].get_declarations().insert(index, declaration)
         declaration.update_scope(self.get_internals_blocks()[0].get_scope())
-        symtable_vistor = ASTSymbolTableVisitor()
-        symtable_vistor.block_type_stack.push(BlockType.INTERNALS)
-        self.accept(ASTParentVisitor())
-        self.accept(symtable_vistor)
-        symtable_vistor.block_type_stack.pop()
+
+        if run_symboltable_visitor:
+            symtable_vistor = ASTSymbolTableVisitor()
+            self.accept(ASTParentVisitor())
+            self.accept(symtable_vistor)
 
     def add_to_state_block(self, declaration: ASTDeclaration) -> None:
         """

--- a/pynestml/utils/ast_utils.py
+++ b/pynestml/utils/ast_utils.py
@@ -1116,11 +1116,12 @@ class ASTUtils:
         :param model: a single model instance
         :param declarations: a map of variable names to declarations
         """
-        for variable in declarations:
-            cls.add_declaration_to_internals(model, variable, declarations[variable])
+        for i, variable in enumerate(declarations):
+            run_symboltable_visitor: bool = i == len(declarations) - 1    # only on the last iteration
+            cls.add_declaration_to_internals(model, variable, declarations[variable], run_symboltable_visitor=run_symboltable_visitor)
 
     @classmethod
-    def add_declaration_to_internals(cls, model: ASTModel, variable_name: str, init_expression: str) -> None:
+    def add_declaration_to_internals(cls, model: ASTModel, variable_name: str, init_expression: str, run_symboltable_visitor: bool = True) -> None:
         """
         Adds the variable as stored in the declaration tuple to the model. The declared variable is of type real.
         :param model: a single model instance
@@ -1139,18 +1140,17 @@ class ASTUtils:
             "[" + vector_variable.get_vector_parameter() + "]"
             if vector_variable is not None and vector_variable.has_vector_parameter() else "") + " = " + init_expression
         ast_declaration = ModelParser.parse_declaration(declaration_string)
+        ast_declaration.update_scope(model.get_internals_blocks()[0].get_scope())
         if vector_variable is not None:
             ast_declaration.set_size_parameter(vector_variable.get_vector_parameter())
-        model.add_to_internals_block(ast_declaration)
+        model.add_to_internals_block(ast_declaration, run_symboltable_visitor=False)
 
-        from pynestml.visitors.ast_parent_visitor import ASTParentVisitor
-        model.accept(ASTParentVisitor())
+        if run_symboltable_visitor:
+            from pynestml.visitors.ast_parent_visitor import ASTParentVisitor
+            model.accept(ASTParentVisitor())
 
-        ast_declaration.update_scope(model.get_internals_blocks()[0].get_scope())
-        symtable_visitor = ASTSymbolTableVisitor()
-        symtable_visitor.block_type_stack.push(BlockType.INTERNALS)
-        ast_declaration.accept(symtable_visitor)
-        symtable_visitor.block_type_stack.pop()
+            symtable_visitor = ASTSymbolTableVisitor()
+            ast_declaration.accept(symtable_visitor)
 
     @classmethod
     def add_declarations_to_state_block(cls, neuron: ASTModel, variables: List, initial_values: List) -> ASTModel:


### PR DESCRIPTION
This shaves off about 4 s (roughly 10% of the total) from NESTML code generation for a single STDP synapse test. It takes the main CI run down from about 75 minutes to 60 minutes.

Just as an overview of where time goes during code generation: the total time spent on the single synapse test is 32 s. Of that, 2.5 s is for parsing, 6 s are for the model transformers (especially ODE-toolbox), 8 s are for the actual code generation, and 13 s are for the C++ build. NEST version detection takes about 1 s and was being done twice while it only needs to be done once.