### PR TITLE
Add missing semver into docs requirements

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -20,4 +20,5 @@ setuptools
 Jinja2 >= 2.10
 typing;python_version<"3.5"
 astropy
-odetoolbox >= 2.4
+semver
+odetoolbox >= 2.5.9


### PR DESCRIPTION
Update docs/requirements.txt to match the main requirements.txt. This fixes errors generating the docs due to missing semver package.