### PR TITLE
Update requirements to add `typing_extensions` instead of `typing`

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,7 +6,6 @@ MarkupSafe==3.0.3
 readthedocs-sphinx-ext==2.2.0
 nbformat==5.10.4
 nbsphinx==0.9.1
-typing_extensions==4.15.0
 sphinx_rtd_theme==2.0.0
 nbclient==0.10.0
 sphinx-design
@@ -18,7 +17,7 @@ sympy
 antlr4-python3-runtime == 4.13.2
 setuptools
 Jinja2 >= 2.10
-typing;python_version<"3.5"
+typing_extensions;python_version<"3.12"
 astropy
 semver
 odetoolbox >= 2.5.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ sympy
 antlr4-python3-runtime == 4.13.2
 setuptools
 Jinja2 >= 2.10
-typing;python_version<"3.5"
+typing_extensions;python_version<"3.12"
 astropy
 semver
 odetoolbox >= 2.5.9


### PR DESCRIPTION
The `typing_extensions` module is not installed by default in Python versions < 3.12, resulting in an import error. This PR adds it to the `requirements.txt` file in place of `typing`, since the latter is included in Python versions >= 3.5, which is not a concern for us, as the minimum required Python version is `3.9`.