### PR TITLE
Make sure ipython3 raises exception in case exception occurs in notebook

### DIFF
--- a/.github/workflows/nestml-build.yml
+++ b/.github/workflows/nestml-build.yml
@@ -281,7 +281,7 @@ jobs:
           for fn in $ipynb_fns; do
               echo "Now running Jupyter notebook: ${fn}"
               cd `dirname ${fn}`
-              jupyter nbconvert --to notebook --execute ${fn}
+              jupyter nbconvert --to notebook --execute ${fn} --stdout
               if [ $? -ne 0 ]; then
                   echo "Error running Jupyter notebook: ${fn}"
                   rc=1

--- a/.github/workflows/nestml-build.yml
+++ b/.github/workflows/nestml-build.yml
@@ -281,7 +281,7 @@ jobs:
           for fn in $ipynb_fns; do
               echo "Now running Jupyter notebook: ${fn}"
               cd `dirname ${fn}`
-              ipython3 ${fn}
+              ipython3 --raise-exceptions ${fn}
               if [ $? -ne 0 ]; then
                   echo "Error running Jupyter notebook: ${fn}"
                   rc=1

--- a/.github/workflows/nestml-build.yml
+++ b/.github/workflows/nestml-build.yml
@@ -218,7 +218,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip pytest jupyterlab matplotlib pycodestyle scipy pandas
+          python -m pip install --upgrade pip pytest jupyterlab matplotlib pycodestyle scipy pandas nbconvert
           python -m pip install -r requirements.txt
 
       - name: Install NEST simulator
@@ -281,7 +281,7 @@ jobs:
           for fn in $ipynb_fns; do
               echo "Now running Jupyter notebook: ${fn}"
               cd `dirname ${fn}`
-              ipython3 --raise-exceptions ${fn}
+              jupyter nbconvert --to notebook --execute ${fn}
               if [ $? -ne 0 ]; then
                   echo "Error running Jupyter notebook: ${fn}"
                   rc=1

--- a/pynestml/frontend/pynestml_frontend.py
+++ b/pynestml/frontend/pynestml_frontend.py
@@ -77,6 +77,14 @@ def transformers_from_target_name(target_name: str, options: Optional[Mapping[st
         transformer = IllegalVariableNameTransformer({"forbidden_names": ["alignas", "alignof", "and", "and_eq", "asm", "auto", "bitand", "bitor", "bool", "break", "case", "catch", "char", "char8_t", "char16_t", "char32_t", "class", "compl", "concept", "const", "const_cast", "consteval", "constexpr", "constinit", "continue", "co_await", "co_return", "co_yield", "decltype", "default", "delete", "do", "double", "dynamic_cast", "else", "enum", "explicit", "export", "extern", "false", "float", "for", "friend", "goto", "if", "inline", "int", "long", "mutable", "namespace", "new", "noexcept", "not", "not_eq", "nullptr", "operator", "or", "or_eq", "private", "protected", "public", "register", "reinterpret_cast", "requires", "return", "short", "signed", "sizeof", "static", "static_assert", "static_cast", "struct", "switch", "template", "this", "thread_local", "throw", "true", "try", "typedef", "typeid", "typename", "union", "unsigned", "using", "virtual", "void", "volatile", "wchar_t", "while", "xor", "xor_eq"]})
         transformers.append(transformer)
 
+    if target_name.upper() in ["PYTHON_STANDALONE"]:
+        from pynestml.transformers.illegal_variable_name_transformer import IllegalVariableNameTransformer
+
+        # rewrite all Python keywords
+        # from: ``import keyword; print(keyword.kwlist)``
+        transformer = IllegalVariableNameTransformer({"forbidden_names": ["False", "None", "True", "and", "as", "assert", "async", "await", "break", "class", "continue", "def", "del", "elif", "else", "except", "finally", "for", "from", "global", "if", "import", "in", "is", "lambda", "nonlocal", "not", "or", "pass", "raise", "return", "try", "while", "with", "yield"]})
+        transformers.append(transformer)
+
     if target_name.upper() not in ["NEST_COMPARTMENTAL"]:
         # InlineExpressionExpansionTransformer
         from pynestml.transformers.inline_expression_expansion_transformer import InlineExpressionExpansionTransformer
@@ -84,19 +92,10 @@ def transformers_from_target_name(target_name: str, options: Optional[Mapping[st
         transformers.append(transformer)
 
     if target_name.upper() in ["NEST"]:
-        from pynestml.transformers.synapse_post_neuron_transformer import SynapsePostNeuronTransformer
-
         # co-generate neuron and synapse
+        from pynestml.transformers.synapse_post_neuron_transformer import SynapsePostNeuronTransformer
         transformer = SynapsePostNeuronTransformer()
         options = transformer.set_options(options)
-        transformers.append(transformer)
-
-    if target_name.upper() in ["PYTHON_STANDALONE"]:
-        from pynestml.transformers.illegal_variable_name_transformer import IllegalVariableNameTransformer
-
-        # rewrite all Python keywords
-        # from: ``import keyword; print(keyword.kwlist)``
-        transformer = IllegalVariableNameTransformer({"forbidden_names": ["False", "None", "True", "and", "as", "assert", "async", "await", "break", "class", "continue", "def", "del", "elif", "else", "except", "finally", "for", "from", "global", "if", "import", "in", "is", "lambda", "nonlocal", "not", "or", "pass", "raise", "return", "try", "while", "with", "yield"]})
         transformers.append(transformer)
 
     if target_name.upper() not in ["NEST_COMPARTMENTAL"]:


### PR DESCRIPTION
Running notebooks through ipython can fail to set a nonzero exit code in case an exception occurs, because some exceptions are captured by ipython. ``nbconvert`` always sets a nonzero exit code in case any kind of failure occurs.

I used ``--stdout`` to sanity-check that the notebooks actually run. However, this could be said to be a bit superfluous. What do you think?

TODO: print just stderr.