### PR TITLE
Add non-double state variables to StateVecVars

### DIFF
--- a/pynestml/codegeneration/resources_nest/point_neuron/directives_cpp/StateVariablesEnum.jinja2
+++ b/pynestml/codegeneration/resources_nest/point_neuron/directives_cpp/StateVariablesEnum.jinja2
@@ -8,14 +8,12 @@ enum StateVecVars {
 {%- set ns = namespace(count=0) %}
 {%- for variable in neuron.get_state_symbols() %}
 {%-     set varDomain = declarations.get_domain_from_type(variable.get_type_symbol()) %}
-{%-     if varDomain == "double" and variable.is_recordable %}
     {{ printer_no_origin.print(utils.get_state_variable_by_name(astnode, variable.get_symbol_name())).upper() }} = {{ ns.count }},
-{%-         if variable.has_vector_parameter() %}
-{%-             set size = utils.get_numeric_vector_size(variable) %}
-{%-             set ns.count = ns.count + size %}
-{%-         else %}
-{%-             set ns.count = ns.count + 1 %}
-{%-         endif %}
+{%-     if variable.has_vector_parameter() %}
+{%-         set size = utils.get_numeric_vector_size(variable) %}
+{%-         set ns.count = ns.count + size %}
+{%-     else %}
+{%-         set ns.count = ns.count + 1 %}
 {%-     endif %}
 {%- endfor %}
 };


### PR DESCRIPTION
Fixes #1423.

Todo: add tests where there is an integer as a state variable (for model that both does and does not contain vectors).